### PR TITLE
fix-ArsonistWin-EndGame.csにArsonistWinを追加

### DIFF
--- a/SuperNewRoles/EndGame/EndGame.cs
+++ b/SuperNewRoles/EndGame/EndGame.cs
@@ -556,6 +556,7 @@ namespace SuperNewRoles.EndGame
             bool FalseChargesWin = gameOverReason == (GameOverReason)CustomGameOverReason.FalseChargesWin;
             bool FoxWin = gameOverReason == (GameOverReason)CustomGameOverReason.FoxWin;
             bool DemonWin = gameOverReason == (GameOverReason)CustomGameOverReason.DemonWin;
+            bool ArsonistWin = gameOverReason == (GameOverReason)CustomGameOverReason.ArsonistWin;
             bool VultureWin = gameOverReason == (GameOverReason)CustomGameOverReason.VultureWin;
             bool BUGEND = gameOverReason == (GameOverReason)CustomGameOverReason.BugEnd;
             if (ModeHandler.isMode(ModeId.SuperHostRoles) && EndData != null)


### PR DESCRIPTION
bool ArsonistWin = gameOverReason == (GameOverReason)CustomGameOverReason.ArsonistWin;