### PR TITLE
C#のバージョン変更

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup>
+   <LangVersion>preview</LangVersion>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
C#のバージョンを8.0からpreviewに変更しました。
これにより補完された文字列ハンドラーなどがエラーを吐かなくなりました。