### PR TITLE
CreateRoleAdvanced.pyの修正

### DIFF
--- a/SNRDevTools/CreateRoleAdvanced.py
+++ b/SNRDevTools/CreateRoleAdvanced.py
@@ -229,6 +229,7 @@ namespace SuperNewRoles.Roles
                 {
                     return CustomRPC.RoleId.ROLENAME;
                 }\n                //ロールチェック""".replace("ROLENAME",MainClass.GetInput("RoleName")))
+
         MainClass.WriteCodes("Roles/RoleHelper.cs", "//ロールアド",
                                 """case (CustomRPC.RoleId.ROLENAME):
                     Roles.RoleClass.ROLENAME.ROLENAMEPlayer.Add(player);
@@ -266,6 +267,7 @@ namespace SuperNewRoles.Roles
                 //くりあぁあんどりろぉどぉ
             }
         }\n        //新ロールクラス""".replace("ROLENAME", MainClass.GetInput("RoleName")).replace("COLORS", MainClass.GetRoleColor()))
+
         # Intro/IntroDate.cs
         if (MainClass.GetBool("Impo")):
             MainClass.WriteCodes("Intro/IntroDate.cs", "//イントロオブジェ","""public static IntroDate ROLENAMEIntro = new IntroDate("ROLENAME", RoleClass.ROLENAME.color, 1, CustomRPC.RoleId.ROLENAME, TeamRoleType.Impostor);

--- a/SNRDevTools/CreateRoleAdvanced.py
+++ b/SNRDevTools/CreateRoleAdvanced.py
@@ -319,9 +319,9 @@ namespace SuperNewRoles.Roles
         if (MainClass.GetBool("A_CanSheriffKill")):
             # Roles/Sheriff.cs
             MainClass.WriteCodes("Roles/Sheriff.cs", "//シェリフキルゥ",
-            """if (Target.isRole(CustomRPC.RoleId.ROLENAME) && RoleClass.Sheriff.IsMadRoleKill) return true;""".replace("ROLENAME", MainClass.GetInput("RoleName")))
+                                 """if (Target.isRole(CustomRPC.RoleId.ROLENAME) && RoleClass.Sheriff.IsMadRoleKill) return true;\n            //シェリフキルぅ""".replace("ROLENAME", MainClass.GetInput("RoleName")))
             MainClass.WriteCodes("Roles/Sheriff.cs", "//リモシェリフキルゥ",
-            """if (Target.isRole(CustomRPC.RoleId.ROLENAME) && RoleClass.Sheriff.IsMadRoleKill) return true;""".replace("ROLENAME", MainClass.GetInput("RoleName")))
+                                 """if (Target.isRole(CustomRPC.RoleId.ROLENAME) && RoleClass.Sheriff.IsMadRoleKill) return true;\n            //リモシェリフキルゥ""".replace("ROLENAME", MainClass.GetInput("RoleName")))
 
         ## キルボタン
         if (MainClass.GetBool("A_CanKill")):

--- a/SNRDevTools/CreateRoleAdvanced.py
+++ b/SNRDevTools/CreateRoleAdvanced.py
@@ -229,7 +229,6 @@ namespace SuperNewRoles.Roles
                 {
                     return CustomRPC.RoleId.ROLENAME;
                 }\n                //ロールチェック""".replace("ROLENAME",MainClass.GetInput("RoleName")))
-                            
         MainClass.WriteCodes("Roles/RoleHelper.cs", "//ロールアド",
                                 """case (CustomRPC.RoleId.ROLENAME):
                     Roles.RoleClass.ROLENAME.ROLENAMEPlayer.Add(player);
@@ -267,7 +266,6 @@ namespace SuperNewRoles.Roles
                 //くりあぁあんどりろぉどぉ
             }
         }\n        //新ロールクラス""".replace("ROLENAME", MainClass.GetInput("RoleName")).replace("COLORS", MainClass.GetRoleColor()))
-        
         # Intro/IntroDate.cs
         if (MainClass.GetBool("Impo")):
             MainClass.WriteCodes("Intro/IntroDate.cs", "//イントロオブジェ","""public static IntroDate ROLENAMEIntro = new IntroDate("ROLENAME", RoleClass.ROLENAME.color, 1, CustomRPC.RoleId.ROLENAME, TeamRoleType.Impostor);
@@ -316,7 +314,7 @@ namespace SuperNewRoles.Roles
             #else:
                 #MainClass.CreateErrorWindow("設定タブの値が空白です")
         ## シェリフキル
-        if (MainClass.GetBool("A_CanSheriffKill") or MainClass.GetBool("Neut")):
+        if (MainClass.GetBool("A_CanSheriffKill")):
             # Roles/Sheriff.cs
             MainClass.WriteCodes("Roles/Sheriff.cs", "//シェリフキルゥ",
             """if (Target.isRole(CustomRPC.RoleId.ROLENAME) && RoleClass.Sheriff.IsMadRoleKill) return true;""".replace("ROLENAME", MainClass.GetInput("RoleName")))
@@ -397,7 +395,7 @@ namespace SuperNewRoles.Roles
                     return RoleClass.ROLENAME.IsImpostorLight;\n                //インポの視界""".replace("ROLENAME", MainClass.GetInput("RoleName")))
 
         # いらないやつ(次実行するときに複数書いてしまうため)の削除　(例:Jackal→//その他Option, NewRole→//その他Optionの場合、二つに書かれてしまうため重複する)
-        MainClass.WriteCodes("Roles/RoleHelper.cs", "//ベント設定可視化", "")
+        #MainClass.WriteCodes("Roles/RoleHelper.cs", "//ベント設定可視化", "")
         MainClass.WriteCodes("Roles/RoleHelper.cs", "//その他Option", "")
         MainClass.WriteCodes("Roles/RoleHelper.cs", "//くりあぁあんどりろぉどぉ", "")
         #MainClass.WriteCodes("Roles/RoleHelper.cs", "", "")

--- a/SuperNewRoles/Intro/IntroDate.cs
+++ b/SuperNewRoles/Intro/IntroDate.cs
@@ -178,6 +178,6 @@ namespace SuperNewRoles.Intro
         public static IntroDate EvilHackerIntro = new IntroDate("EvilHacker", RoleClass.EvilHacker.color, 1, CustomRPC.RoleId.EvilHacker, TeamRoleType.Impostor);
         public static IntroDate HauntedWolfIntro = new IntroDate("HauntedWolf", RoleClass.HauntedWolf.color, 1, CustomRPC.RoleId.HauntedWolf);
         public static IntroDate TunaIntro = new IntroDate("Tuna", RoleClass.Tuna.color, 1, CustomRPC.RoleId.Tuna, TeamRoleType.Neutral);
-            //イントロオブジェ
+        //イントロオブジェ
     }
 }


### PR DESCRIPTION
・//ベント設定可視化が消える問題を修正
・第三陣営で役職を作るとSheriff.csに`if(Target.isRole(CustomRPC.RoleId.役職名) && RoleClass.Sheriff.IsMadRoleKill) return true;`が追加されていた問題を修正
・シェリフにキルされるがオンになっていたら//シェリフキルゥと//リモシェリフキルゥが消えていた問題を修正