### PR TITLE
マグロの死亡するかの判定を初手会議以降に変更

### DIFF
--- a/SuperNewRoles/Roles/RoleClass.cs
+++ b/SuperNewRoles/Roles/RoleClass.cs
@@ -2197,6 +2197,7 @@ namespace SuperNewRoles.Roles
             public static float StoppingTime;
             public static bool IsUseVent;
             public static Dictionary<byte, float> Timers;
+            public static bool IsMeetingEnd;
             public static void ClearAndReload()
             {
                 TunaPlayer = new();
@@ -2205,6 +2206,7 @@ namespace SuperNewRoles.Roles
                 StoppingTime = CustomOption.CustomOptions.TunaStoppingTime.getFloat();
                 if (Mode.ModeHandler.isMode(Mode.ModeId.Default)) Timer = StoppingTime;
                 IsUseVent = CustomOptions.TunaIsUseVent.getBool();
+                IsMeetingEnd = false;
                 if (Mode.ModeHandler.isMode(Mode.ModeId.SuperHostRoles))
                 {
                     Timers = new();

--- a/SuperNewRoles/Roles/Tuna.cs
+++ b/SuperNewRoles/Roles/Tuna.cs
@@ -13,7 +13,7 @@ namespace SuperNewRoles.Roles
             if (RoleClass.IsMeeting) return;
             if (ModeHandler.isMode(ModeId.Default))
             {
-                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) && PlayerControl.LocalPlayer.CanMove && Mode.ModeHandler.isMode(Mode.ModeId.Default)&& RoleClass.Tuna.IsMeetingEnd)
+                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) 　 && Mode.ModeHandler.isMode(Mode.ModeId.Default)&& RoleClass.Tuna.IsMeetingEnd)
                 {
                     if (RoleClass.Tuna.Position[CachedPlayer.LocalPlayer.PlayerControl.PlayerId] == CachedPlayer.LocalPlayer.PlayerControl.transform.position)
                     {

--- a/SuperNewRoles/Roles/Tuna.cs
+++ b/SuperNewRoles/Roles/Tuna.cs
@@ -13,7 +13,7 @@ namespace SuperNewRoles.Roles
             if (RoleClass.IsMeeting) return;
             if (ModeHandler.isMode(ModeId.Default))
             {
-                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) && PlayerControl.LocalPlayer.CanMove && Mode.ModeHandler.isMode(Mode.ModeId.Default))
+                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) && PlayerControl.LocalPlayer.CanMove && Mode.ModeHandler.isMode(Mode.ModeId.Default)&& RoleClass.Tuna.IsMeetingEnd)
                 {
                     if (RoleClass.Tuna.Position[CachedPlayer.LocalPlayer.PlayerControl.PlayerId] == CachedPlayer.LocalPlayer.PlayerControl.transform.position)
                     {
@@ -29,10 +29,12 @@ namespace SuperNewRoles.Roles
                         RoleClass.Tuna.Position[CachedPlayer.LocalPlayer.PlayerControl.PlayerId] = CachedPlayer.LocalPlayer.PlayerControl.transform.position;
                     }
                 }
-            } else
+            }
+            else
             {
-                foreach (PlayerControl p in RoleClass.Tuna.TunaPlayer) {
-                    if (p.isAlive())
+                foreach (PlayerControl p in RoleClass.Tuna.TunaPlayer)
+                {
+                    if (p.isAlive() && RoleClass.Tuna.IsMeetingEnd)
                     {
                         if (RoleClass.Tuna.Position[p.PlayerId] == p.transform.position)
                         {
@@ -45,6 +47,18 @@ namespace SuperNewRoles.Roles
                         RoleClass.Tuna.Position[p.PlayerId] = p.transform.position;
                     }
                 }
+            }
+        }
+    }
+    [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
+    public class MeetingEnd
+    {
+        static void Prefix(MeetingHud __instance)
+        {
+            SuperNewRolesPlugin.Logger.LogInfo("----会議終了----");
+            if (AmongUsClient.Instance.AmHost && !RoleClass.Tuna.IsMeetingEnd)
+            {
+                RoleClass.Tuna.IsMeetingEnd = true;
             }
         }
     }

--- a/SuperNewRoles/Roles/Tuna.cs
+++ b/SuperNewRoles/Roles/Tuna.cs
@@ -13,7 +13,7 @@ namespace SuperNewRoles.Roles
             if (RoleClass.IsMeeting) return;
             if (ModeHandler.isMode(ModeId.Default))
             {
-                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) 　 && Mode.ModeHandler.isMode(Mode.ModeId.Default)&& RoleClass.Tuna.IsMeetingEnd)
+                if (!CachedPlayer.LocalPlayer.PlayerControl.Data.IsDead && CachedPlayer.LocalPlayer.PlayerControl.isRole(CustomRPC.RoleId.Tuna) && Mode.ModeHandler.isMode(Mode.ModeId.Default) && RoleClass.Tuna.IsMeetingEnd)
                 {
                     if (RoleClass.Tuna.Position[CachedPlayer.LocalPlayer.PlayerControl.PlayerId] == CachedPlayer.LocalPlayer.PlayerControl.transform.position)
                     {
@@ -49,10 +49,7 @@ namespace SuperNewRoles.Roles
                 }
             }
         }
-    }
-    [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
-    public class MeetingEnd
-    {
+        [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
         static void Prefix(MeetingHud __instance)
         {
             SuperNewRolesPlugin.Logger.LogInfo("----会議終了----");

--- a/SuperNewRoles/Roles/Tuna.cs
+++ b/SuperNewRoles/Roles/Tuna.cs
@@ -52,11 +52,7 @@ namespace SuperNewRoles.Roles
         [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.OnDestroy))]
         static void Prefix(MeetingHud __instance)
         {
-            SuperNewRolesPlugin.Logger.LogInfo("----会議終了----");
-            if (AmongUsClient.Instance.AmHost && !RoleClass.Tuna.IsMeetingEnd)
-            {
-                RoleClass.Tuna.IsMeetingEnd = true;
-            }
+            RoleClass.Tuna.IsMeetingEnd = true;
         }
     }
 }


### PR DESCRIPTION
会議後かどうかを判定して会議後ならマグロが死ぬように仕様変更しました。
これにより、湧く前に死んでる問題を修正できたと思います
SNRとSHR両方です