### PR TITLE
Fix .gitignore[.editorconfigをgitignoreに追加]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ SuperNewRoles/bin/
 SuperNewRoles/SuperNewRoles.csproj.user
 .vs/
 SuperNewRoles/obj/*
+SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfig

--- a/SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfig
+++ b/SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfig
@@ -1,3 +1,3 @@
 is_global = true
 build_property.RootNamespace = SuperNewRoles
-build_property.ProjectDir = D:\06-Program\AmongUs_Mod_Development\SNR-Origin\SuperNewRoles\SuperNewRoles\
+build_property.ProjectDir = C:\Users\10user\source\repos\SuperNewRoles\SuperNewRoles\

--- a/SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfig
+++ b/SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfig
@@ -1,3 +1,0 @@
-is_global = true
-build_property.RootNamespace = SuperNewRoles
-build_property.ProjectDir = C:\Users\10user\source\repos\SuperNewRoles\SuperNewRoles\


### PR DESCRIPTION
[要約]
SuperNewRoles/obj/Debug/netstandard2.1/SuperNewRoles.GeneratedMSBuildEditorConfig.editorconfigの追跡を停止し、
gitignoreに追加した


[内容]
毎回出て来る.editorconfigの変更がしつこいと思ったので、追跡を停止してgitignoreに追加しました。
あともう一つあったと思うのですが、覚えていない上に出すことができなかった為、諦めて[.editorconfig]のみの追加です。

うまくできているか分からない為、念入りに確認してくださるとありがたいです。