### PR TITLE
Fix/create role.pyのプレイヤーカウントのコード修正及び[//プレイヤーカウント]の復旧

### DIFF
--- a/SNRDevTools/CreateRole.py
+++ b/SNRDevTools/CreateRole.py
@@ -3,33 +3,34 @@ while True:
     intronum = int(input("イントロ数:"))
     team = input("陣営(0:インポ,1:第三陣営,2:クルー):")
     baseurl = r"..\\SuperNewRoles\\"
-    if team=="0":
-        color ="ImpostorRed"
+    if team == "0":
+        color = "ImpostorRed"
     else:
         color = "new Color32(0, 255, 0, byte.MaxValue)"
-    if team=="0":
+    if team == "0":
         ARolename = "Impo"
-    elif team=="1":
+    elif team == "1":
         ARolename = "Neut"
-    elif team=="2":
+    elif team == "2":
         ARolename = "Crew"
-    if team=="1":
-        isneut=True
+    if team == "1":
+        isneut = True
     else:
-        isneut=False
-    if team=="0":
+        isneut = False
+    if team == "0":
         isimpo = True
     else:
         isimpo = False
-    with open(baseurl+"CustomRPC\\CustomRPC.cs",mode="r",encoding="utf-8") as r:
+    with open(baseurl+"CustomRPC\\CustomRPC.cs", mode="r", encoding="utf-8") as r:
         temp = r.read()
-        with open(baseurl+"CustomRPC\\CustomRPC.cs",mode="w",encoding="utf-8") as f:
-            temp = temp.replace("//RoleId",rolename+",\n        //RoleId")
+        with open(baseurl+"CustomRPC\\CustomRPC.cs", mode="w", encoding="utf-8") as f:
+            temp = temp.replace("//RoleId", rolename+",\n        //RoleId")
             f.write(temp)
-    with open(baseurl+"Roles\\RoleClass.cs",mode="r",encoding="utf-8") as r:
+    with open(baseurl+"Roles\\RoleClass.cs", mode="r", encoding="utf-8") as r:
         temp = r.read()
-        with open(baseurl+"Roles\\RoleClass.cs",mode="w",encoding="utf-8") as f:
-            temp = temp.replace("//ロールクリア",rolename+".ClearAndReload();\n            //ロールクリア")
+        with open(baseurl+"Roles\\RoleClass.cs", mode="w", encoding="utf-8") as f:
+            temp = temp.replace("//ロールクリア", rolename +
+                                ".ClearAndReload();\n            //ロールクリア")
             temp = temp.replace("//新ロールクラス",
                                 """public static class ROLE!!
         {
@@ -39,11 +40,11 @@ while True:
             {
                 ROLE!!Player = new List<PlayerControl>();
             }
-        }\n        //新ロールクラス""".replace("ROLE!!",rolename).replace("COLORS",color))
+        }\n        //新ロールクラス""".replace("ROLE!!", rolename).replace("COLORS", color))
             f.write(temp)
-    with open(baseurl+"AllRoleSetClass.cs",mode="r",encoding="utf-8") as r:
+    with open(baseurl+"AllRoleSetClass.cs", mode="r", encoding="utf-8") as r:
         temp = r.read()
-        with open(baseurl+"AllRoleSetClass.cs",mode="w",encoding="utf-8") as f:
+        with open(baseurl+"AllRoleSetClass.cs", mode="w", encoding="utf-8") as f:
             temp = temp.replace("//セットクラス",
                                 """if (!(CustomOption.CustomOptions.ROLEID!!Option.getString().Replace("0%", "") == ""))
             {
@@ -60,44 +61,43 @@ while True:
                         TEAMnotonepar.Add(ThisRoleId);
                     }
                 }
-            }\n        //セットクラス""".replace("ROLEID!!",rolename).replace("TEAM",ARolename))
-            temp = temp.replace("//プレイヤーカウント","""case (RoleId.ROLENAME):
-                    return CustomOption.CustomOptions.ROLENAMEPlayerCount.getFloat();\n                    //プレイヤーカウント""".replace("ROLENAME",rolename))
+            }\n        //セットクラス""".replace("ROLEID!!", rolename).replace("TEAM", ARolename))
+            temp = temp.replace("//プレイヤーカウント", """RoleId.ROLENAME => CustomOptions.ROLENAMEPlayerCount.getFloat(),\n                //プレイヤーカウント""".replace("ROLENAME", rolename))
             f.write(temp)
-    with open(baseurl+"Roles\\RoleHelper.cs",mode="r",encoding="utf-8") as r:
+    with open(baseurl+"Roles\\RoleHelper.cs", mode="r", encoding="utf-8") as r:
         temp = r.read()
-        with open(baseurl+"Roles\\RoleHelper.cs",mode="w",encoding="utf-8") as f:
+        with open(baseurl+"Roles\\RoleHelper.cs", mode="w", encoding="utf-8") as f:
             temp = temp.replace("//ロールチェック",
                                 """else if (Roles.RoleClass.ROLENAME.ROLENAMEPlayer.IsCheckListPlayerControl(player))
             {
                 return CustomRPC.RoleId.ROLENAME;
-            }\n            //ロールチェック""".replace("ROLENAME",rolename))
+            }\n            //ロールチェック""".replace("ROLENAME", rolename))
             temp = temp.replace("//ロールアド",
                                 """case (CustomRPC.RoleId.ROLENAME):
                     Roles.RoleClass.ROLENAME.ROLENAMEPlayer.Add(player);
-                    break;\n                //ロールアド""".replace("ROLENAME",rolename))
+                    break;\n                //ロールアド""".replace("ROLENAME", rolename))
             temp = temp.replace("//ロールリモベ",
                                 """case (CustomRPC.RoleId.ROLENAME):
                     Roles.RoleClass.ROLENAME.ROLENAMEPlayer.RemoveAll(ClearRemove);
-                    break;\n                //ロールリモベ""".replace("ROLENAME",rolename))
+                    break;\n                //ロールリモベ""".replace("ROLENAME", rolename))
             if isneut:
                 temp = temp.replace("//第三か",
-                                """case (RoleId.ROLENAME):
+                                    """case (RoleId.ROLENAME):
                     IsNeutral = true;
-                    break;\n                //第三か""".replace("ROLENAME",rolename))
+                    break;\n                //第三か""".replace("ROLENAME", rolename))
                 temp = temp.replace("//タスククリアか",
-                                """case (RoleId.ROLENAME):
+                                    """case (RoleId.ROLENAME):
                     IsTaskClear = true;
                     break; 
-                //タスククリアか""".replace("ROLENAME",rolename))
+                //タスククリアか""".replace("ROLENAME", rolename))
             f.write(temp)
-    with open(baseurl+"Intro\\IntroDate.cs",mode="r",encoding="utf-8") as r:
+    with open(baseurl+"Intro\\IntroDate.cs", mode="r", encoding="utf-8") as r:
         temp = r.read()
-        with open(baseurl+"Intro\\IntroDate.cs",mode="w",encoding="utf-8") as f:
-            temp = temp.replace("//イントロオブジェ","""public static IntroDate ROLENAMEIntro = new IntroDate("ROLENAME", RoleClass.ROLENAME.color, 1, CustomRPC.RoleId.ROLENAME);
-        //イントロオブジェ""".replace("ROLENAME",rolename))
-            temp = temp.replace("//イントロ検知","""case (CustomRPC.RoleId.ROLENAME):
+        with open(baseurl+"Intro\\IntroDate.cs", mode="w", encoding="utf-8") as f:
+            temp = temp.replace("//イントロオブジェ", """public static IntroDate ROLENAMEIntro = new IntroDate("ROLENAME", RoleClass.ROLENAME.color, 1, CustomRPC.RoleId.ROLENAME);
+        //イントロオブジェ""".replace("ROLENAME", rolename))
+            temp = temp.replace("//イントロ検知", """case (CustomRPC.RoleId.ROLENAME):
                     return ROLENAMEIntro;
-                //イントロ検知""".replace("ROLENAME",rolename))
+                //イントロ検知""".replace("ROLENAME", rolename))
             f.write(temp)
     print("完了！")

--- a/SNRDevTools/CreateRoleAdvanced.py
+++ b/SNRDevTools/CreateRoleAdvanced.py
@@ -223,7 +223,7 @@ namespace SuperNewRoles.Roles
             }\n        //セットクラス""".replace("ROLEID!!",MainClass.GetInput("RoleName")).replace("TEAM",MainClass.GetTeam()))'''
 
 
-        MainClass.WriteCodes("AllRoleSetClass.cs", "//プレイヤーカウント","""RoleId.ROLENAME => CustomOption.CustomOptions.ROLENAMEPlayerCount.getFloat(),\n                    //プレイヤーカウント""".replace("ROLENAME",MainClass.GetInput("RoleName")))
+        MainClass.WriteCodes("AllRoleSetClass.cs", "//プレイヤーカウント","""RoleId.ROLENAME => CustomOption.CustomOptions.ROLENAMEPlayerCount.getFloat(),\n                //プレイヤーカウント""".replace("ROLENAME",MainClass.GetInput("RoleName")))
 
         # Roles/RoleHelper.cs
         if (not MainClass.GetBool("TeamGhost")):

--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -837,6 +837,7 @@ namespace SuperNewRoles
                 RoleId.Mafia => CustomOptions.MafiaPlayerCount.getFloat(),
                 RoleId.BlackCat => CustomOptions.BlackCatPlayerCount.getFloat(),
                 RoleId.Spy => CustomOptions.SpyPlayerCount.getFloat(),
+                //プレイヤーカウント
                 _ => 1,
             };
         }


### PR DESCRIPTION
### [要約]
・create role.pyが自動リファクタ後のコードに対応していなかった点の修正
・[AllRoleSetClass.cs]に「//プレイヤーカウント」が記載されていなかった点の修正
・CreateRoleAdvanced.pyで「//プレイヤーカウント」が記載しなおされる位置がずれていた点の修正

### [修正点]

・create role.pyが自動リファクタ後のコード対応にしていなかった点の修正
クリパイのコードを
```case (RoleId.ROLENAME):                    return CustomOption.CustomOptions.ROLENAMEPlayerCount.getFloat();\n                    //プレイヤーカウント```
から
```RoleId.ROLENAME => CustomOptions.ROLENAMEPlayerCount.getFloat(),\n                //プレイヤーカウント```
に変更しました。

create role.pyにCtrl+Fをかけたら一部スペースが増えました

・[AllRoleSetClass.cs]に「//プレイヤーカウント」が記載されていなかった為、元に戻しました。

・CreateRoleAdvanced.pyで「//プレイヤーカウント」が記載しなおされる位置が、半角スペース4つ分右にずれていた点の修正