### PR TITLE
Fix/廃村時リザルト画面で出ていた「勝利」の消去

### DIFF
--- a/SuperNewRoles/EndGame/EndGame.cs
+++ b/SuperNewRoles/EndGame/EndGame.cs
@@ -174,8 +174,11 @@ namespace SuperNewRoles.EndGame
                     break;
                 case WinCondition.HAISON:
                     text = "HAISON";
-                    textRenderer.color = Color.white;
-                    __instance.BackgroundBar.material.SetColor("_Color", Color.white);
+                    textRenderer.color = Color.clear;
+                    __instance.WinText.text = ModTranslation.getString("HaisonName");
+                    Color32 HaisonColor = new(163, 163, 162, byte.MaxValue);
+                    __instance.WinText.color = HaisonColor;
+                    __instance.BackgroundBar.material.SetColor("_Color", HaisonColor);
                     break;
                 case WinCondition.JesterWin:
                     text = "JesterName";


### PR DESCRIPTION
廃村のリザルト画面で青字の「勝利」を消し、
下の勝利陣営が書かれる場所にあった「廃村」を透明の文字にして見えないようにした。

```textRenderer.color = Color.clear; => 下の文字を透明にして、見かけ上勝利陣営の表記が出ないようにした```

```Color32 HaisonColor = new(163, 163, 162, byte.MaxValue);　=> 廃村時の背景とリザルトの色設定```
```__instance.WinText.color = HaisonColor;```