### PR TITLE
SHRモードでSNRが名前に入ってしまっているときに公開部屋にできないようにする機能を追加

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -368,8 +368,8 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                     FastDestroyableSingleton<HudManager>.Instance.KillButton.SetTarget(null);
                 }
             }
-            else if (PlayerControl.LocalPlayer.isRole(RoleId.Jackal,RoleId.MadMaker,RoleId.Egoist,RoleId.RemoteSheriff,
-                RoleId.Demon,RoleId.Arsonist)
+            else if (PlayerControl.LocalPlayer.isRole(RoleId.Jackal, RoleId.MadMaker, RoleId.Egoist, RoleId.RemoteSheriff,
+                RoleId.Demon, RoleId.Arsonist)
                 )
             {
                 FastDestroyableSingleton<HudManager>.Instance.KillButton.gameObject.SetActive(true);

--- a/SuperNewRoles/Patch/GameStartPatch.cs
+++ b/SuperNewRoles/Patch/GameStartPatch.cs
@@ -1,23 +1,5 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using BepInEx;
-using BepInEx.Configuration;
-using BepInEx.IL2CPP;
 using HarmonyLib;
-using Hazel;
-using Il2CppSystem;
-using Il2CppSystem.Collections.Generic;
-using Il2CppSystem.Linq;
-using UnhollowerBaseLib;
 using UnityEngine;
-using UnityEngine.UI;
 using SuperNewRoles.Mode;
 
 namespace SuperNewRoles.Patch
@@ -45,6 +27,16 @@ namespace SuperNewRoles.Patch
                 return true;
             }
         }
+
+        public static void FixedUpdate(PlayerControl __instance)
+        {
+            if (ModeHandler.isMode(ModeId.SuperHostRoles, false))
+            {
+                //PlayerControl.LocalPlayer.RpcSetName("<size=>次のターゲット:よッキング</size>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+                Mode.SuperHostRoles.FixedUpdate.Update();
+            }
+        }
+
         [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
         public static class LobbyCountDownTimer
         {

--- a/SuperNewRoles/Patch/GameStartPatch.cs
+++ b/SuperNewRoles/Patch/GameStartPatch.cs
@@ -27,16 +27,6 @@ namespace SuperNewRoles.Patch
                 return true;
             }
         }
-
-        public static void FixedUpdate(PlayerControl __instance)
-        {
-            if (ModeHandler.isMode(ModeId.SuperHostRoles, false))
-            {
-                //PlayerControl.LocalPlayer.RpcSetName("<size=>次のターゲット:よッキング</size>\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-                Mode.SuperHostRoles.FixedUpdate.Update();
-            }
-        }
-
         [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
         public static class LobbyCountDownTimer
         {

--- a/SuperNewRoles/Patch/GameStartPatch.cs
+++ b/SuperNewRoles/Patch/GameStartPatch.cs
@@ -18,6 +18,7 @@ using Il2CppSystem.Linq;
 using UnhollowerBaseLib;
 using UnityEngine;
 using UnityEngine.UI;
+using SuperNewRoles.Mode;
 
 namespace SuperNewRoles.Patch
 {
@@ -29,10 +30,16 @@ namespace SuperNewRoles.Patch
             public static bool Prefix()
             {
                 bool NameIncludeMod = SaveManager.PlayerName.ToLower().Contains("mod");
-                bool NameIncludeSNR = SaveManager.PlayerName.ToUpper().Contains("SNR") || SaveManager.PlayerName.ToUpper().Contains("SHR");
+                bool NameIncludeSNR = SaveManager.PlayerName.ToUpper().Contains("SNR");
+                bool NameIncludeSHR = SaveManager.PlayerName.ToUpper().Contains("SHR");
                 if (NameIncludeMod && !NameIncludeSNR)
                 {
                     SuperNewRolesPlugin.Logger.LogWarning("\"mod\"が名前に含まれている状態では公開部屋にすることはできません。");
+                    return false;
+                }
+                else if (ModeHandler.isMode(ModeId.SuperHostRoles, false) && NameIncludeSNR && !NameIncludeSHR || ModeHandler.isMode(ModeId.SuperHostRoles, false) && NameIncludeMod && !NameIncludeSHR)
+                {
+                    SuperNewRolesPlugin.Logger.LogWarning("SHRモードで\"SNR\"が名前に含まれている状態では公開部屋にすることはできません。");
                     return false;
                 }
                 return true;


### PR DESCRIPTION
～追加した条件～
（どちらもSHRモードにて）
・SNRが名前に入っていてSHRが名前に入っていないとき(両方はいっていれば公開部屋にできるようになってます)
・Modが名前に入っていてSHRが名前に入っていないとき(同上)