### PR TITLE
タスク個別設定の翻訳でロングタスクとショートタスクが逆転していた問題を修正

### DIFF
--- a/SNRDevTools/trans_00_en.txt
+++ b/SNRDevTools/trans_00_en.txt
@@ -3,8 +3,8 @@ SuperNewRoles
 Second
 <size=125%><color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color> NewData</size>\nVersion:{0}\n{1}
 Common Tasks
-Long Tasks
 Short Tasks
+Long Tasks
 Salmon
 Bordeaux
 Olive

--- a/SNRDevTools/trans_11_jp.txt
+++ b/SNRDevTools/trans_11_jp.txt
@@ -3,8 +3,8 @@ SuperNewRoles
 秒
 <size=200%><color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color>の最新情報</size>\n<size=150%>バージョン:{0}</size>\n{1}
 通常タスク
-ロングタスク
 ショートタスク
+ロングタスク
 サーモン
 ボルドー
 オリーブ

--- a/SNRDevTools/transdate.txt
+++ b/SNRDevTools/transdate.txt
@@ -4,8 +4,8 @@ StartLogText,\n---------------\nSuperNewRoles\nCreate By ykundesu\nThank You Pla
 second,Second,秒
 announcementUpdate,<size=125%><color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color> NewData</size>\nVersion:{0}\n{1},<size=200%><color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color>の最新情報</size>\n<size=150%>バージョン:{0}</size>\n{1}
 GameCommonTasks,Common Tasks,通常タスク
-GameShortTasks,Long Tasks,ロングタスク
-GameLongTasks,Short Tasks,ショートタスク
+GameShortTasks,Short Tasks,ショートタスク
+GameLongTasks,Long Tasks,ロングタスク
 colorSalmon,Salmon,サーモン
 colorBordeaux,Bordeaux,ボルドー
 colorOlive,Olive,オリーブ

--- a/SNRDevTools/translatedate.json
+++ b/SNRDevTools/translatedate.json
@@ -21,12 +21,12 @@
         "11" : "\u901a\u5e38\u30bf\u30b9\u30af"
         } ,
  "GameShortTasks" : {
-        "0" : "Long Tasks" ,
-        "11" : "\u30ed\u30f3\u30b0\u30bf\u30b9\u30af"
-        } ,
- "GameLongTasks" : {
         "0" : "Short Tasks" ,
         "11" : "\u30b7\u30e7\u30fc\u30c8\u30bf\u30b9\u30af"
+        } ,
+ "GameLongTasks" : {
+        "0" : "Long Tasks" ,
+        "11" : "\u30ed\u30f3\u30b0\u30bf\u30b9\u30af"
         } ,
  "colorSalmon" : {
         "0" : "Salmon" ,
@@ -3259,7 +3259,7 @@
  "KillName" : {
         "0" : "KILL" ,
         "11" : "\u30ad\u30eb"
- },
+        } ,
  "JackalCreateFriendSetting" : {
         "0" : "Can Create JackalFriends" ,
         "11" : "\u30b8\u30e3\u30c3\u30ab\u30eb\u30d5\u30ec\u30f3\u30ba\u3092\u4f5c\u308c\u308b"

--- a/SuperNewRoles/Resources/translatedate.json
+++ b/SuperNewRoles/Resources/translatedate.json
@@ -21,12 +21,12 @@
         "11" : "\u901a\u5e38\u30bf\u30b9\u30af"
         } ,
  "GameShortTasks" : {
-        "0" : "Long Tasks" ,
-        "11" : "\u30ed\u30f3\u30b0\u30bf\u30b9\u30af"
-        } ,
- "GameLongTasks" : {
         "0" : "Short Tasks" ,
         "11" : "\u30b7\u30e7\u30fc\u30c8\u30bf\u30b9\u30af"
+        } ,
+ "GameLongTasks" : {
+        "0" : "Long Tasks" ,
+        "11" : "\u30ed\u30f3\u30b0\u30bf\u30b9\u30af"
         } ,
  "colorSalmon" : {
         "0" : "Salmon" ,
@@ -3259,7 +3259,7 @@
  "KillName" : {
         "0" : "KILL" ,
         "11" : "\u30ad\u30eb"
- },
+        } ,
  "JackalCreateFriendSetting" : {
         "0" : "Can Create JackalFriends" ,
         "11" : "\u30b8\u30e3\u30c3\u30ab\u30eb\u30d5\u30ec\u30f3\u30ba\u3092\u4f5c\u308c\u308b"


### PR DESCRIPTION
[要約]
タスク個別設定の翻訳でロングタスクとショートタスクが逆転していた問題を修正

[変更点]
タスク個別設定の翻訳で、ロングタスクとショートタスクが逆転していた為、
設定でショートタスクを1にしたつもりが、ゲームではロングタスク1が配布されていた問題を修正した。
![image](https://user-images.githubusercontent.com/104145991/178185722-729196b2-8dd8-4b02-be00-efeb976d7565.png)
