### PR TITLE
公開部屋にできないとき通達するチャットを送る機能

### DIFF
--- a/SuperNewRoles/Patch/GameStartPatch.cs
+++ b/SuperNewRoles/Patch/GameStartPatch.cs
@@ -9,7 +9,7 @@ namespace SuperNewRoles.Patch
         [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.MakePublic))]
         class MakePublicPatch
         {
-            public static bool Prefix()
+            public static bool Prefix(GameStartManager __instance)
             {
                 bool NameIncludeMod = SaveManager.PlayerName.ToLower().Contains("mod");
                 bool NameIncludeSNR = SaveManager.PlayerName.ToUpper().Contains("SNR");
@@ -17,11 +17,15 @@ namespace SuperNewRoles.Patch
                 if (NameIncludeMod && !NameIncludeSNR && !NameIncludeSHR)
                 {
                     SuperNewRolesPlugin.Logger.LogWarning("\"mod\"が名前に含まれている状態では公開部屋にすることはできません。");
+                    __instance.MakePublicButton.color = Palette.DisabledClear;
+                    __instance.privatePublicText.color = Palette.DisabledClear;
+                    PlayerControl.LocalPlayer.RpcSendChat(string.Format("Modが名前に含まれている状態では公開部屋にすることはできません。"));
                     return false;
                 }
                 else if (ModeHandler.isMode(ModeId.SuperHostRoles, false) && NameIncludeSNR && !NameIncludeSHR || ModeHandler.isMode(ModeId.SuperHostRoles, false) && NameIncludeMod && !NameIncludeSHR)
                 {
                     SuperNewRolesPlugin.Logger.LogWarning("SHRモードで\"SNR\"が名前に含まれている状態では公開部屋にすることはできません。");
+                    PlayerControl.LocalPlayer.RpcSendChat(string.Format("SHRモードでSNRが名前に含まれている状態では公開部屋にすることはできません。"));
                     return false;
                 }
                 return true;


### PR DESCRIPTION
Modが名前に入っていてSNR、SHRが入っていないときに公開非公開を切り替えるボタンを押すと透明化するようにしました。
公開部屋にできない状態でチャットを送ると公開部屋にできないことを伝えるチャットが送信されるようにしました。