### PR TITLE
サブマージドダウンロードボタンをコメントアウトして隠した。

### DIFF
--- a/SuperNewRoles/Patch/LogoAndStamp.cs
+++ b/SuperNewRoles/Patch/LogoAndStamp.cs
@@ -269,6 +269,8 @@ namespace SuperNewRoles.Patches
                 SuperNewRolesPlugin.Logger.LogInfo("[Submerged]Passage ahhhhhh!:" + Assembly.GetExecutingAssembly().Location.Replace("SuperNewRoles.dll", "Submerged.dll"));
                 //サブマージド追加ボタン
 
+                /*サブマージドのダウンロードボタン隠しSTART 今日の日はさようならまた逢う日まで・・・
+
                 var template = GameObject.Find("ExitGameButton");
                 if (template == null) return;
 
@@ -297,6 +299,8 @@ namespace SuperNewRoles.Patches
                     await DownloadSubmarged();
                     button.SetActive(false);
                 }
+
+                サブマージドのダウンロードボタン隠し End　復活する際はSTARTとENDのコメント行を削除してください*/
             }
 
             private static IEnumerator Download()


### PR DESCRIPTION
サブマージドをダウンロードする人があまりにも多いので、
サブマージドのダウンロードボタンをコメントアウトして隠しました。
ただそれだけです。