### PR TITLE
トイレファンからインポスターとしての能力を奪っていなかった部分の修正

### DIFF
--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -852,7 +852,7 @@ namespace SuperNewRoles
                 RoleId.Smasher => CustomOptions.SmasherPlayerCount.getFloat(),
                 RoleId.SuicideWisher => CustomOptions.SuicideWisherPlayerCount.getFloat(),
                 RoleId.Neet => CustomOptions.NeetPlayerCount.getFloat(),
-                RoleId.ToiletFan => CustomOptions.NeetPlayerCount.getFloat(),
+                RoleId.ToiletFan => CustomOptions.ToiletFanPlayerCount.getFloat(),
                 //プレイヤーカウント
                 _ => 1,
             };

--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -852,6 +852,7 @@ namespace SuperNewRoles
                 RoleId.Smasher => CustomOptions.SmasherPlayerCount.getFloat(),
                 RoleId.SuicideWisher => CustomOptions.SuicideWisherPlayerCount.getFloat(),
                 RoleId.Neet => CustomOptions.NeetPlayerCount.getFloat(),
+                RoleId.ToiletFan => CustomOptions.NeetPlayerCount.getFloat(),
                 //プレイヤーカウント
                 _ => 1,
             };

--- a/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
@@ -40,6 +40,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 case RoleId.Sheriff:
                 case RoleId.truelover:
                 case RoleId.FalseCharges:
+                case RoleId.ToiletFan:
                     break;
                 default:
                     return true;

--- a/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
@@ -73,6 +73,10 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             {
                 p.RpcSetRole(RoleTypes.GuardianAngel);
             }
+            foreach (PlayerControl p in RoleClass.ToiletFan.ToiletFanPlayer)
+            {
+                p.RpcSetRole(RoleTypes.GuardianAngel);
+            }
             if (OnGameEndPatch.EndData == null && (reason == GameOverReason.ImpostorByKill || reason == GameOverReason.ImpostorBySabotage || reason == GameOverReason.ImpostorByVote || reason == GameOverReason.ImpostorDisconnect))
             {
                 foreach (PlayerControl p in RoleClass.Survivor.SurvivorPlayer)

--- a/SuperNewRoles/Mode/SuperHostRoles/MorePatch.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/MorePatch.cs
@@ -23,7 +23,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             if (systemType == SystemTypes.Sabotage && AmongUsClient.Instance.GameMode != GameModes.FreePlay)
             {
                 if ((player.isRole(RoleId.Jackal) && !RoleClass.Jackal.IsUseSabo) || player.isRole(RoleId.Demon, RoleId.Arsonist, RoleId.RemoteSheriff, RoleId.Sheriff,
-                    RoleId.truelover, RoleId.FalseCharges, RoleId.MadMaker)) return false;
+                    RoleId.truelover, RoleId.FalseCharges, RoleId.MadMaker, RoleId.ToiletFan)) return false;
                 if (!RoleClass.Minimalist.UseSabo && player.isRole(RoleId.Minimalist)) return false;
                 if (!RoleClass.Samurai.UseSabo && player.isRole(RoleId.Samurai)) return false;
                 if (!RoleClass.Egoist.UseSabo && player.isRole(RoleId.Egoist)) return false;

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -342,6 +342,12 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                     }
                     break;
                 case RoleId.ToiletFan:
+                    optdata.ImpostorLightMod = optdata.CrewLightMod;
+                    var switchSystemToiletFan = MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>();
+                    if (switchSystemToiletFan != null && switchSystemToiletFan.IsActive)
+                    {
+                        optdata.ImpostorLightMod /= 5;
+                    }
                     optdata.RoleOptions.ShapeshifterCooldown = RoleClass.ToiletFan.ToiletCool;
                     optdata.RoleOptions.ShapeshifterDuration = 1f;
                     break;

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -398,6 +398,7 @@ namespace SuperNewRoles.Patches
                     switch (__instance.getRole())
                     {
                         case RoleId.RemoteSheriff:
+                        case RoleId.ToiletFan:
                             return false;
                         case RoleId.Egoist:
                             if (!RoleClass.Egoist.UseKill) return false;

--- a/SuperNewRoles/Roles/RoleHelper.cs
+++ b/SuperNewRoles/Roles/RoleHelper.cs
@@ -1016,7 +1016,7 @@ namespace SuperNewRoles
             {
                 IsTaskClear = true;
             }
-            if (!IsTaskClear && ModeHandler.isMode(ModeId.SuperHostRoles) && (player.isRole(RoleId.Sheriff) || player.isRole(RoleId.RemoteSheriff)))
+            if (!IsTaskClear && ModeHandler.isMode(ModeId.SuperHostRoles) && (player.isRole(RoleId.Sheriff) || player.isRole(RoleId.RemoteSheriff) || player.isRole(RoleId.ToiletFan)))
             {
                 IsTaskClear = true;
             }


### PR DESCRIPTION
### トイレファンからインポスターとしての能力を奪っていなかった部分の修正

・インポスターの視界になっていた問題を修正
・ベントに入れた問題の修正
・サボタージュができた問題の修正
・キルができた問題の修正

・SHR時タスクがクリアされていなかった問題の修正
・死後守護天使になるようにした

・一人以上に設定できなかった問題の修正


### 補足

・死後守護天使になるようにした
　　　これはシェリフにあった為追加しましたが、必要意義の分からないまま追加した為、問題があったら教えてください。

・一人以上に設定できなかった問題の修正
　　　仕様でしたら教えてください
