### PR TITLE
FastMakerがマッドを作ると同時にキルしてしまう問題の修正

### DIFF
--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -377,16 +377,22 @@ namespace SuperNewRoles.Patches
                             if (!RoleClass.FastMaker.IsCreatedMadMate)//まだ作ってなくて、設定が有効の時
                             {
                                 if (target == null || RoleClass.FastMaker.CreatePlayers.Contains(__instance.PlayerId)) return false;
-                                RoleClass.FastMaker.CreatePlayers.Add(__instance.PlayerId);
-                                target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
-                                target.setRoleRPC(RoleId.MadMate);//マッドにする
-                                Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
-                                RoleClass.FastMaker.IsCreatedMadMate = true;//作ったことにする
+                                 target.RpcProtectPlayer(target, 0);//キルを無効にする為守護をかける
+                                 //守護がかかるのを待つためのLateTask
+                                new LateTask(() =>
+                                    {
+                                        RoleClass.FastMaker.CreatePlayers.Add(__instance.PlayerId);
+                                        target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.setRoleRPC(RoleId.MadMate);//マッドにする
+                                        Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
+                                        RoleClass.FastMaker.IsCreatedMadMate = true;//作ったことにする
+                                        SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSNR]マッドを作ったよ");
+                                    }, 0.5f);
                             }
                             else
                             {
-                                //作ってたら普通のキル
-                                __instance.RpcMurderPlayer(target);
+                                //作ってたら普通のキル(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
+                                SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSNR]作ったので普通のキル");
                             }
                             return false;
                     }
@@ -547,17 +553,22 @@ namespace SuperNewRoles.Patches
                             if (!RoleClass.FastMaker.IsCreatedMadMate)//まだ作ってなくて、設定が有効の時
                             {
                                 if (target == null || RoleClass.FastMaker.CreatePlayers.Contains(__instance.PlayerId)) return false;
-                                RoleClass.FastMaker.CreatePlayers.Add(__instance.PlayerId);
-                                target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
-                                target.setRoleRPC(RoleId.MadMate);//マッドにする
-                                Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
-                                RoleClass.FastMaker.IsCreatedMadMate = true;//作ったことにする
+                                target.RpcProtectPlayer(target, 0);//キルを無効にする為守護をかける
+                                //守護がかかるのを待つためのLateTask
+                                new LateTask(() =>
+                                    {
+                                        RoleClass.FastMaker.CreatePlayers.Add(__instance.PlayerId);
+                                        target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.setRoleRPC(RoleId.MadMate);//マッドにする
+                                        Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
+                                        RoleClass.FastMaker.IsCreatedMadMate = true;//作ったことにする
+                                        SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSHR]マッドを作ったよ");
+                                    }, 0.5f);
                             }
                             else
                             {
-                                //作ってたら普通のキル
-                                SuperNewRolesPlugin.Logger.LogInfo("作ったので普通のキル");
-                                __instance.RpcMurderPlayer(target);
+                                //作ってたら普通のキル(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
+                                SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSHR]作ったので普通のキル");
                             }
                             break;
                         case RoleId.Jackal:

--- a/SuperNewRoles/Roles/Impostor/Minimalist.cs
+++ b/SuperNewRoles/Roles/Impostor/Minimalist.cs
@@ -112,10 +112,18 @@ namespace SuperNewRoles.Roles
                         FastDestroyableSingleton<HudManager>.Instance.ReportButton.buttonLabelText.SetText("");
                     }
                 }
-                else if (role == RoleId.FastMaker && !RoleClass.FastMaker.IsCreatedMadMate)//マッドが作られていないとき
+                else if (role == RoleId.FastMaker)
                 {
-                    //純正キルボタン削除
-                    HudManager.Instance.KillButton.gameObject.SetActive(false);
+                    if (!RoleClass.FastMaker.IsCreatedMadMate)//マッドが作られていないとき
+                    {
+                        //純正キルボタン削除
+                        HudManager.Instance.KillButton.gameObject.SetActive(false);
+                    }
+                    else//マッドが作られた後
+                    {
+                        //純正キルボタン復活
+                        HudManager.Instance.KillButton.gameObject.SetActive(true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### [変更点要約]

[SNR時]
・キルクが0sになっていた問題の修正
・マッドをつくれたかどうかを判断しにくかった為、守護モーションを追加し分かり易くした。

[共通]
・キーコードをQに修正した

[SHR]
・マッドにしたと同時にキルしていた問題の修正
・2回キルモーションと死体が2体上がる問題の修正


### [変更点]
[Button.cs&Minimalist.cs]
・キルクが0sになっていた問題の修正
　　　　・カスタムボタンによりキルを行っていた為、インポスターのキルクール設定と同期せずキルクが0sになっていた。
　　　　　　・マッドを作った後はcustomボタンを消去し、純正キルボタンを復活させることで修正した。


[Button.cs]
・マッドをつくれたかどうかを判断しにくかった為、守護モーションを追加し分かり易くした。
　　・守護モーションが発動するようにしてマッドを作ったことを視覚的に分かり易くした。

・キーコードをQに変更し、通常のキルボタンとして見えるように修正した。


[PlayerControlPatch.cs]
・マッドにしたと同時にキルしていた問題の修正
　　・守護をかけキルを防ぐように修正した。
　　　　・LateTaskにより守護をかけた後にマッドを作る設定が進行するようにした。


・2回キルモーションと死体が2体上がる問題の修正
　　・「//作ってたら普通のキル
　　　　__instance.RpcMurderPlayer(target);」が原因となっていた為修正した。
　　　　　　・通常のキルとRpcMurderPlayerによるキルで二回キルを行っていた。

　　・Discordの方でこの問題を放置してよいか聞いた後に、
　　　2死体上がってしまうと、キルした人がファストメーカーだと確定してしまう為問題がある時が付き、
　　　修正いたしました。

