### PR TITLE
新役職 戦術家

### DIFF
--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -931,6 +931,7 @@ namespace SuperNewRoles
                 RoleId.Dictator => CustomOptions.DictatorPlayerCount.GetFloat(),
                 RoleId.Spelunker => CustomOptions.SpelunkerPlayerCount.GetFloat(),
                 RoleId.SuicidalIdeation => CustomOptions.SuicidalIdeationPlayerCount.GetFloat(),
+                RoleId.Tactician => CustomOptions.TacticianPlayerCount.GetFloat(),
                 //プレイヤーカウント
                 _ => 1,
             };

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2085,7 +2085,12 @@ namespace SuperNewRoles.Buttons
                 {
                     if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsKey(RoleClass.Tactician.target.PlayerId) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(RoleClass.Tactician.target.PlayerId))
                     {
-                        RoleClass.Tactician.AlliancePlayer.Add(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
+                        MessageWriter Writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.CustomRPC.TacticianAllianceSet, SendOption.Reliable, -1);
+                        Writer.Write(CachedPlayer.LocalPlayer.PlayerId);
+                        Writer.Write(true);
+                        AmongUsClient.Instance.FinishRpcImmediately(Writer);
+
+                        RPCProcedure.TacticianAllianceSet(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
                         RoleClass.Tactician.Alliance = true;
                     }
                 },
@@ -2118,7 +2123,12 @@ namespace SuperNewRoles.Buttons
                 {
                     if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsKey(RoleClass.Tactician.target.PlayerId) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(RoleClass.Tactician.target.PlayerId))
                     {
-                        RoleClass.Tactician.FakeAlliancePlayer.Add(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
+                        MessageWriter Writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.CustomRPC.TacticianFakeAllianceSet, SendOption.Reliable, -1);
+                        Writer.Write(CachedPlayer.LocalPlayer.PlayerId);
+                        Writer.Write(true);
+                        AmongUsClient.Instance.FinishRpcImmediately(Writer);
+
+                        RPCProcedure.TacticianFakeAllianceSet(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
                         RoleClass.Tactician.FakeAlliance -= 1;
                     }
                 },

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -68,6 +68,8 @@ namespace SuperNewRoles.Buttons
         public static CustomButton ButtonerButton;
         public static CustomButton RevolutionistButton;
         public static CustomButton SuicidalIdeationButton;
+        public static CustomButton TacticianAllianceButton;
+        public static CustomButton tacticianFakeAllianceButton;
 
         public static TMPro.TMP_Text sheriffNumShotsText;
         public static TMPro.TMP_Text GhostMechanicNumRepairText;
@@ -2075,6 +2077,39 @@ namespace SuperNewRoles.Buttons
             )
             {
                 buttonText = ModTranslation.GetString("SuicidalIdeationButtonName"),
+                showButtonText = true
+            };
+
+            TacticianAllianceButton = new(
+                () =>
+                {
+                    if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician))
+                    {
+                        RoleClass.Tactician.AlliancePlayer.Add(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
+                        RoleClass.Tactician.Alliance = true;
+                    }
+                },
+                (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Tactician && !RoleClass.Tactician.Alliance; },
+                () =>
+                {
+                    RoleClass.Tactician.target = SetTarget();
+                    return RoleClass.Tactician.target != null;
+                },
+                () =>
+                {
+                    TacticianAllianceButton.MaxTimer = 0f;
+                    TacticianAllianceButton.Timer = 0f;
+                },
+                RoleClass.ToiletFan.GetButtonSprite(),
+                new Vector3(-2.7f, -0.06f, 0),
+                __instance,
+                __instance.AbilityButton,
+                KeyCode.Q,
+                8,
+                () => { return false; }
+            )
+            {
+                buttonText = ModTranslation.GetString("TacticianAllianceButtonName"),
                 showButtonText = true
             };
 

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -69,7 +69,7 @@ namespace SuperNewRoles.Buttons
         public static CustomButton RevolutionistButton;
         public static CustomButton SuicidalIdeationButton;
         public static CustomButton TacticianAllianceButton;
-        public static CustomButton tacticianFakeAllianceButton;
+        public static CustomButton TacticianFakeAllianceButton;
 
         public static TMPro.TMP_Text sheriffNumShotsText;
         public static TMPro.TMP_Text GhostMechanicNumRepairText;
@@ -2083,7 +2083,7 @@ namespace SuperNewRoles.Buttons
             TacticianAllianceButton = new(
                 () =>
                 {
-                    if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician))
+                    if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsKey(RoleClass.Tactician.target.PlayerId) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(RoleClass.Tactician.target.PlayerId))
                     {
                         RoleClass.Tactician.AlliancePlayer.Add(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
                         RoleClass.Tactician.Alliance = true;
@@ -2110,6 +2110,39 @@ namespace SuperNewRoles.Buttons
             )
             {
                 buttonText = ModTranslation.GetString("TacticianAllianceButtonName"),
+                showButtonText = true
+            };
+
+            TacticianFakeAllianceButton = new(
+                () =>
+                {
+                    if (!RoleClass.Tactician.target.IsRole(RoleId.Tactician) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsKey(RoleClass.Tactician.target.PlayerId) && !RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(RoleClass.Tactician.target.PlayerId))
+                    {
+                        RoleClass.Tactician.FakeAlliancePlayer.Add(PlayerControl.LocalPlayer.PlayerId, RoleClass.Tactician.target.PlayerId);
+                        RoleClass.Tactician.FakeAlliance -= 1;
+                    }
+                },
+                (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Tactician && RoleClass.Tactician.FakeAlliance != 0; },
+                () =>
+                {
+                    RoleClass.Tactician.target = SetTarget();
+                    return RoleClass.Tactician.target != null;
+                },
+                () =>
+                {
+                    TacticianFakeAllianceButton.MaxTimer = 0f;
+                    TacticianFakeAllianceButton.Timer = 0f;
+                },
+                RoleClass.ToiletFan.GetButtonSprite(),
+                new Vector3(-1.8f, -0.06f, 0),
+                __instance,
+                __instance.AbilityButton,
+                KeyCode.F,
+                49,
+                () => { return false; }
+            )
+            {
+                buttonText = ModTranslation.GetString("TacticianFakeAllianceButtonName"),
                 showButtonText = true
             };
 

--- a/SuperNewRoles/CustomOption/CustomOptionDate.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionDate.cs
@@ -754,6 +754,7 @@ namespace SuperNewRoles.CustomOption
         public static CustomRoleOption TacticianOption;
         public static CustomOption TacticianPlayerCount;
         public static CustomOption TacticianCanUseVent;
+        public static CustomOption TacticianFakeAllianceCount;
         //CustomOption
 
         public static CustomOption QuarreledOption;
@@ -1548,6 +1549,7 @@ namespace SuperNewRoles.CustomOption
             TacticianOption = new CustomRoleOption(929, false, CustomOptionType.Neutral, "TacticianName",RoleClass.Tactician.color, 1);
             TacticianPlayerCount = CustomOption.Create(930, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], TacticianOption);
             TacticianCanUseVent = CustomOption.Create(931, false, CustomOptionType.Neutral, "TacticianCanUseVentSetting", false, TacticianOption);
+            TacticianFakeAllianceCount = CustomOption.Create(932, false, CustomOptionType.Neutral, "TacticianFakeAllianceCountSetting", 1f, 1f, 15f, 1f, TacticianOption, format: "unitSeconds");
             //表示設定
 
             QuarreledOption = CustomOption.Create(432, true, CustomOptionType.Neutral, Cs(RoleClass.Quarreled.color, "QuarreledName"), false, null, isHeader: true);

--- a/SuperNewRoles/CustomOption/CustomOptionDate.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionDate.cs
@@ -750,6 +750,9 @@ namespace SuperNewRoles.CustomOption
         public static CustomOption SuicidalIdeationCommonTask;
         public static CustomOption SuicidalIdeationShortTask;
         public static CustomOption SuicidalIdeationLongTask;
+        
+        public static CustomRoleOption TacticianOption;
+        public static CustomOption TacticianPlayerCount;
         //CustomOption
 
         public static CustomOption QuarreledOption;
@@ -1540,6 +1543,9 @@ namespace SuperNewRoles.CustomOption
             SuicidalIdeationCommonTask = SuicidalIdeationoption.Item1;
             SuicidalIdeationShortTask = SuicidalIdeationoption.Item2;
             SuicidalIdeationLongTask = SuicidalIdeationoption.Item3;
+            
+            TacticianOption = new CustomRoleOption(930, false, CustomOptionType.Neutral, "TacticianName",RoleClass.Tactician.color, 1);
+            TacticianPlayerCount = CustomOption.Create(9302, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], TacticianOption);
             //表示設定
 
             QuarreledOption = CustomOption.Create(432, true, CustomOptionType.Neutral, Cs(RoleClass.Quarreled.color, "QuarreledName"), false, null, isHeader: true);

--- a/SuperNewRoles/CustomOption/CustomOptionDate.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionDate.cs
@@ -753,6 +753,7 @@ namespace SuperNewRoles.CustomOption
         
         public static CustomRoleOption TacticianOption;
         public static CustomOption TacticianPlayerCount;
+        public static CustomOption TacticianCanUseVent;
         //CustomOption
 
         public static CustomOption QuarreledOption;
@@ -1544,8 +1545,9 @@ namespace SuperNewRoles.CustomOption
             SuicidalIdeationShortTask = SuicidalIdeationoption.Item2;
             SuicidalIdeationLongTask = SuicidalIdeationoption.Item3;
             
-            TacticianOption = new CustomRoleOption(930, false, CustomOptionType.Neutral, "TacticianName",RoleClass.Tactician.color, 1);
-            TacticianPlayerCount = CustomOption.Create(9302, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], TacticianOption);
+            TacticianOption = new CustomRoleOption(929, false, CustomOptionType.Neutral, "TacticianName",RoleClass.Tactician.color, 1);
+            TacticianPlayerCount = CustomOption.Create(930, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], TacticianOption);
+            TacticianCanUseVent = CustomOption.Create(931, false, CustomOptionType.Neutral, "TacticianCanUseVentSetting", false, TacticianOption);
             //表示設定
 
             QuarreledOption = CustomOption.Create(432, true, CustomOptionType.Neutral, Cs(RoleClass.Quarreled.color, "QuarreledName"), false, null, isHeader: true);

--- a/SuperNewRoles/CustomRPC/CustomRPC.cs
+++ b/SuperNewRoles/CustomRPC/CustomRPC.cs
@@ -211,10 +211,20 @@ namespace SuperNewRoles.CustomRPC
         KunaiKill,
         SetSecretRoomTeleportStatus,
         ChiefSidekick,
-        StartRevolutionMeeting
+        StartRevolutionMeeting,
+        TacticianAllianceSet,
+        TacticianFakeAllianceSet
     }
     public static class RPCProcedure
     {
+        public static void TacticianAllianceSet(byte sourceid, byte targetid)
+        {
+            RoleClass.Tactician.AlliancePlayer.Add(sourceid, targetid);
+        }
+        public static void TacticianFakeAllianceSet(byte sourceid, byte targetid)
+        {
+            RoleClass.Tactician.FakeAlliancePlayer.Add(sourceid, targetid);
+        }
         public static void StartRevolutionMeeting(byte sourceid)
         {
             PlayerControl source = ModHelpers.playerById(sourceid);
@@ -1264,6 +1274,9 @@ namespace SuperNewRoles.CustomRPC
                             break;
                         case CustomRPC.StartRevolutionMeeting:
                             StartRevolutionMeeting(reader.ReadByte());
+                            break;
+                        case CustomRPC.TacticianAllianceSet:
+                            TacticianAllianceSet(reader.ReadByte(), reader.ReadByte());
                             break;
                     }
                 }

--- a/SuperNewRoles/CustomRPC/CustomRPC.cs
+++ b/SuperNewRoles/CustomRPC/CustomRPC.cs
@@ -139,6 +139,7 @@ namespace SuperNewRoles.CustomRPC
         Dictator,
         Spelunker,
         SuicidalIdeation,
+        Tactician,
         //RoleId
     }
 

--- a/SuperNewRoles/EndGame/EndGame.cs
+++ b/SuperNewRoles/EndGame/EndGame.cs
@@ -507,6 +507,7 @@ namespace SuperNewRoles.EndGame
             notWinners.AddRange(RoleClass.Neet.NeetPlayer);
             notWinners.AddRange(RoleClass.Revolutionist.RevolutionistPlayer);
             notWinners.AddRange(RoleClass.SuicidalIdeation.SuicidalIdeationPlayer);
+            notWinners.AddRange(RoleClass.Tactician.TacticianPlayer);
 
             foreach (PlayerControl p in RoleClass.Survivor.SurvivorPlayer)
             {
@@ -806,7 +807,15 @@ namespace SuperNewRoles.EndGame
             {
                 notWinners.AddRange(players);
             }
-
+            //戦術家の勝利処理のコード　一番下になるようにしてください
+            foreach (PlayerControl player in RoleClass.Tactician.TacticianPlayer)
+            {
+                var AllianceTargetPlayer = RoleClass.Tactician.AlliancePlayer[player.PlayerId];
+                if (TempData.winners.Contains(new WinningPlayerData(ModHelpers.playerById(AllianceTargetPlayer).Data)))
+                {
+                    TempData.winners.Add(new WinningPlayerData(player.Data));
+                }
+            }
             notWinners = new();
             winnersToRemove = new();
             foreach (WinningPlayerData winner in TempData.winners)

--- a/SuperNewRoles/Intro/IntroDate.cs
+++ b/SuperNewRoles/Intro/IntroDate.cs
@@ -189,6 +189,7 @@ namespace SuperNewRoles.Intro
         public static IntroDate DictatorIntro = new("Dictator", RoleClass.Dictator.color, 1, RoleId.Dictator, TeamRoleType.Crewmate);
         public static IntroDate SpelunkerIntro = new("Spelunker", RoleClass.Spelunker.color, 1, RoleId.Spelunker, TeamRoleType.Neutral);
         public static IntroDate SuicidalIdeationIntro = new("SuicidalIdeation", RoleClass.SuicidalIdeation.color, 1, RoleId.SuicidalIdeation, TeamRoleType.Neutral);
+        public static IntroDate TacticianIntro = new("Tactician", RoleClass.Tactician.color, 1, RoleId.Tactician, TeamRoleType.Neutral);
         //イントロオブジェ
     }
 }

--- a/SuperNewRoles/Patch/SetNames.cs
+++ b/SuperNewRoles/Patch/SetNames.cs
@@ -278,6 +278,48 @@ namespace SuperNewRoles.Patch
                 }
             }
         }
+        public static void AllianceSet()
+        {
+            if (RoleClass.Tactician.AlliancePlayer.ContainsKey(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    if (player == PlayerControl.LocalPlayer || player.PlayerId == RoleClass.Tactician.AlliancePlayer[PlayerControl.LocalPlayer.PlayerId])
+                    {
+                        if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ★")))
+                            SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ★"));
+                    }
+                }
+            }
+            if (RoleClass.Tactician.AlliancePlayer.ContainsValue(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    try
+                    {
+                        var PlayerId = RoleClass.Tactician.AlliancePlayer.FirstOrDefault(x => x.Value == player.PlayerId);
+                        if (player == PlayerControl.LocalPlayer || PlayerId.Value == PlayerControl.LocalPlayer.PlayerId)
+                        {
+                            if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ★")))
+                                SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ★"));
+                        }
+                    }
+                    catch { }
+                }
+            }
+            if (PlayerControl.LocalPlayer.IsDead() || PlayerControl.LocalPlayer.IsRole(RoleId.God))
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    var PlayerId = RoleClass.Tactician.AlliancePlayer.FirstOrDefault(x => x.Value == PlayerControl.LocalPlayer.PlayerId);
+                    if (player.PlayerId == RoleClass.Tactician.AlliancePlayer[PlayerControl.LocalPlayer.PlayerId] || player.PlayerId == PlayerId.Value)
+                    {
+                        if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ★")))
+                            SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ★"));
+                    }
+                }
+            }
+        }
     }
     public class SetNameUpdate
     {
@@ -362,6 +404,48 @@ namespace SuperNewRoles.Patch
                         }
                     }
                 }
+                if (RoleClass.Tactician.AlliancePlayer.ContainsKey(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+                {
+                    foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                    {
+                        if (player == PlayerControl.LocalPlayer || player.PlayerId == RoleClass.Tactician.AlliancePlayer[PlayerControl.LocalPlayer.PlayerId])
+                        {
+                            SetNamesClass.SetPlayerNameColors(player);
+                            SetNamesClass.SetPlayerRoleNames(player);
+                        }
+                    }
+                }
+                if (RoleClass.Tactician.AlliancePlayer.ContainsValue(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+                {
+                    foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                    {
+                        try
+                        {
+                            var PlayerId = RoleClass.Tactician.AlliancePlayer.FirstOrDefault(x => x.Value == player.PlayerId);
+                            if (player == PlayerControl.LocalPlayer || PlayerId.Value == PlayerControl.LocalPlayer.PlayerId)
+                            {
+                                SetNamesClass.SetPlayerNameColors(player);
+                                SetNamesClass.SetPlayerRoleNames(player);
+                            }
+                        }
+                        catch { }
+                    }
+                }
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    if (Tactician.CanSeeRoles(player))
+                    {
+                        var PlayerId = RoleClass.Tactician.AlliancePlayer.FirstOrDefault(x => x.Value == player.PlayerId);
+                        if (player.PlayerId == PlayerId.Key || player.PlayerId == PlayerId.Value)
+                        {
+                            if (RoleClass.IsMeeting || player.IsAlive())
+                            {
+                                SetNamesClass.SetPlayerNameColors(player);
+                                SetNamesClass.SetPlayerRoleNames(player);
+                            }
+                        }
+                    }
+                }
                 SetNamesClass.SetPlayerRoleNames(PlayerControl.LocalPlayer);
                 SetNamesClass.SetPlayerNameColors(PlayerControl.LocalPlayer);
             }
@@ -370,6 +454,7 @@ namespace SuperNewRoles.Patch
             SetNamesClass.CelebritySet();
             SetNamesClass.QuarreledSet();
             SetNamesClass.LoversSet();
+            SetNamesClass.AllianceSet();
             if (ModeHandler.IsMode(ModeId.Default))
             {
                 if (Sabotage.SabotageManager.thisSabotage == Sabotage.SabotageManager.CustomSabotage.CognitiveDeficit)

--- a/SuperNewRoles/Patch/SetNames.cs
+++ b/SuperNewRoles/Patch/SetNames.cs
@@ -311,11 +311,51 @@ namespace SuperNewRoles.Patch
             {
                 foreach (PlayerControl player in CachedPlayer.AllPlayers)
                 {
-                    var PlayerId = RoleClass.Tactician.AlliancePlayer.FirstOrDefault(x => x.Value == PlayerControl.LocalPlayer.PlayerId);
-                    if (player.PlayerId == RoleClass.Tactician.AlliancePlayer[PlayerControl.LocalPlayer.PlayerId] || player.PlayerId == PlayerId.Value)
+                    if (RoleClass.Tactician.AlliancePlayer.ContainsKey(player.PlayerId) || RoleClass.Tactician.AlliancePlayer.ContainsValue(player.PlayerId))
                     {
                         if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ★")))
                             SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ★"));
+                    }
+                }
+            }
+        }
+        public static void FakeAllianceSet()
+        {
+            if (RoleClass.Tactician.FakeAlliancePlayer.ContainsKey(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    if (player.PlayerId == RoleClass.Tactician.FakeAlliancePlayer[PlayerControl.LocalPlayer.PlayerId])
+                    {
+                        if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ☆")))
+                            SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ☆"));
+                    }
+                }
+            }
+            if (RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    try
+                    {
+                        var PlayerId = RoleClass.Tactician.FakeAlliancePlayer.FirstOrDefault(x => x.Value == player.PlayerId);
+                        if (player == PlayerControl.LocalPlayer || PlayerId.Value == PlayerControl.LocalPlayer.PlayerId)
+                        {
+                            if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ★")))
+                                SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ★"));
+                        }
+                    }
+                    catch { }
+                }
+            }
+            if (PlayerControl.LocalPlayer.IsDead() || PlayerControl.LocalPlayer.IsRole(RoleId.God))
+            {
+                foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                {
+                    if (RoleClass.Tactician.AlliancePlayer.ContainsValue(player.PlayerId))
+                    {
+                        if (!player.NameText().text.Contains(ModHelpers.Cs(RoleClass.Tactician.color, " ☆")))
+                            SetPlayerNameText(player, player.NameText().text + ModHelpers.Cs(RoleClass.Tactician.color, " ☆"));
                     }
                 }
             }
@@ -431,6 +471,22 @@ namespace SuperNewRoles.Patch
                         catch { }
                     }
                 }
+                if (RoleClass.Tactician.FakeAlliancePlayer.ContainsValue(PlayerControl.LocalPlayer.PlayerId) && !PlayerControl.LocalPlayer.IsDead())
+                {
+                    foreach (PlayerControl player in CachedPlayer.AllPlayers)
+                    {
+                        try
+                        {
+                            var PlayerId = RoleClass.Tactician.FakeAlliancePlayer.FirstOrDefault(x => x.Value == player.PlayerId);
+                            if (player == PlayerControl.LocalPlayer || PlayerId.Value == PlayerControl.LocalPlayer.PlayerId)
+                            {
+                                SetNamesClass.SetPlayerNameColors(player);
+                                SetNamesClass.SetPlayerRoleNames(player);
+                            }
+                        }
+                        catch { }
+                    }
+                }
                 foreach (PlayerControl player in CachedPlayer.AllPlayers)
                 {
                     if (Tactician.CanSeeRoles(player))
@@ -455,6 +511,7 @@ namespace SuperNewRoles.Patch
             SetNamesClass.QuarreledSet();
             SetNamesClass.LoversSet();
             SetNamesClass.AllianceSet();
+            SetNamesClass.FakeAllianceSet();
             if (ModeHandler.IsMode(ModeId.Default))
             {
                 if (Sabotage.SabotageManager.thisSabotage == Sabotage.SabotageManager.CustomSabotage.CognitiveDeficit)

--- a/SuperNewRoles/Roles/Neutral/Tactician.cs
+++ b/SuperNewRoles/Roles/Neutral/Tactician.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Hazel;
+using SuperNewRoles.CustomRPC;
+using SuperNewRoles.Intro;
+using SuperNewRoles.Mode;
+using SuperNewRoles.Roles;
+using System.Linq;
+
+namespace SuperNewRoles.Roles
+{
+    public class Tactician
+    {
+        public static bool CanSeeRoles(PlayerControl p1)
+        {
+            if (RoleClass.Tactician.AlliancePlayer.ContainsKey(p1.PlayerId))
+            {
+                byte p2 = RoleClass.Tactician.AlliancePlayer[p1.PlayerId];
+                PlayerControl p4 = null;
+                foreach (PlayerControl p3 in CachedPlayer.AllPlayers)
+                {
+                    if (p3.PlayerId == p2) p4 = p3;
+                }
+                return p1.IsDead() || p4.IsDead();
+            }
+            return false;
+        }
+    }
+}

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2620,11 +2620,18 @@ namespace SuperNewRoles.Roles
         public static class Tactician
         {
             public static List<PlayerControl> TacticianPlayer;
+            public static Dictionary<byte, byte> AlliancePlayer;
+            public static Dictionary<byte, byte> MyFakeAlliancePlayer;
             public static Color32 color = new(128, 0, 0, byte.MaxValue);
+            public static PlayerControl target;
+            public static bool Alliance;
             public static bool CanUseVent;
             public static void ClearAndReload()
             {
                 TacticianPlayer = new();
+                AlliancePlayer = new Dictionary<byte, byte>();
+                MyFakeAlliancePlayer = new Dictionary<byte, byte>();
+                Alliance = false;
                 CanUseVent = CustomOptions.TacticianCanUseVent.GetBool();
             }
         }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2620,7 +2620,7 @@ namespace SuperNewRoles.Roles
         public static class Tactician
         {
             public static List<PlayerControl> TacticianPlayer;
-            public static Color32 color = ImpostorRed;
+            public static Color32 color = new(128, 0, 0, byte.MaxValue);
             public static bool CanUseVent;
             public static void ClearAndReload()
             {

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2621,17 +2621,19 @@ namespace SuperNewRoles.Roles
         {
             public static List<PlayerControl> TacticianPlayer;
             public static Dictionary<byte, byte> AlliancePlayer;
-            public static Dictionary<byte, byte> MyFakeAlliancePlayer;
+            public static Dictionary<byte, byte> FakeAlliancePlayer;
             public static Color32 color = new(128, 0, 0, byte.MaxValue);
             public static PlayerControl target;
             public static bool Alliance;
+            public static int FakeAlliance;
             public static bool CanUseVent;
             public static void ClearAndReload()
             {
                 TacticianPlayer = new();
                 AlliancePlayer = new Dictionary<byte, byte>();
-                MyFakeAlliancePlayer = new Dictionary<byte, byte>();
+                FakeAlliancePlayer = new Dictionary<byte, byte>();
                 Alliance = false;
+                FakeAlliance = CustomOptions.TacticianFakeAllianceCount.GetInt();
                 CanUseVent = CustomOptions.TacticianCanUseVent.GetBool();
             }
         }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -161,6 +161,7 @@ namespace SuperNewRoles.Roles
             Dictator.ClearAndReload();
             Spelunker.ClearAndReload();
             SuicidalIdeation.ClearAndReload();
+            Tactician.ClearAndReload();
             //ロールクリア
             Quarreled.ClearAndReload();
             Lovers.ClearAndReload();
@@ -2614,6 +2615,16 @@ namespace SuperNewRoles.Roles
                 AddTimeLeft = CustomOptions.SuicidalIdeationAddTimeLeft.GetFloat();
                 ButtonTimer = DateTime.Now;
                 CompletedTask = 0;
+            }
+        }
+        public static class Tactician
+        {
+            public static List<PlayerControl> TacticianPlayer;
+            public static Color32 color = ImpostorRed;
+            public static void ClearAndReload()
+            {
+                TacticianPlayer = new();
+                //くりあぁあんどりろぉどぉ
             }
         }
         //新ロールクラス

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2621,10 +2621,11 @@ namespace SuperNewRoles.Roles
         {
             public static List<PlayerControl> TacticianPlayer;
             public static Color32 color = ImpostorRed;
+            public static bool CanUseVent;
             public static void ClearAndReload()
             {
                 TacticianPlayer = new();
-                //くりあぁあんどりろぉどぉ
+                CanUseVent = CustomOptions.TacticianCanUseVent.GetBool();
             }
         }
         //新ロールクラス

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -1066,6 +1066,7 @@ namespace SuperNewRoles
                 RoleId.Tuna => RoleClass.Tuna.IsUseVent,
                 RoleId.BlackCat => CachedPlayer.LocalPlayer.Data.Role.Role != RoleTypes.GuardianAngel && RoleClass.BlackCat.IsUseVent,
                 RoleId.Spy => RoleClass.Spy.CanUseVent,
+                RoleId.Tactician => RoleClass.Tactician.CanUseVent,
                 _ => false,
             };
         }

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -580,6 +580,9 @@ namespace SuperNewRoles
                 case (RoleId.SuicidalIdeation):
                     RoleClass.SuicidalIdeation.SuicidalIdeationPlayer.Add(player);
                     break;
+                case RoleId.Tactician:
+                    RoleClass.Tactician.TacticianPlayer.Add(player);
+                    break;
                 //ロールアド
                 default:
                     SuperNewRolesPlugin.Logger.LogError($"[SetRole]:No Method Found for Role Type {role}");
@@ -958,7 +961,10 @@ namespace SuperNewRoles
                 case (RoleId.SuicidalIdeation):
                     RoleClass.SuicidalIdeation.SuicidalIdeationPlayer.RemoveAll(ClearRemove);
                     break;
-                    //ロールリモベ
+                    case RoleId.Tactician:
+                    RoleClass.Tactician.TacticianPlayer.RemoveAll(ClearRemove);
+                    break;
+                //ロールリモベ
             }
             ChacheManager.ResetMyRoleChache();
         }
@@ -1011,7 +1017,8 @@ namespace SuperNewRoles
                 case RoleId.Revolutionist:
                 case RoleId.Spelunker:
                 case RoleId.SuicidalIdeation:
-                    //タスククリアか
+                    case RoleId.Tactician:
+                //タスククリアか
                     IsTaskClear = true;
                     break; 
             }
@@ -1167,7 +1174,8 @@ namespace SuperNewRoles
                 case RoleId.Revolutionist:
                 case RoleId.Spelunker:
                 case RoleId.SuicidalIdeation:
-                    //第三か
+                    case RoleId.Tactician:
+                //第三か
                     IsNeutral = true;
                     break;
             }
@@ -1443,6 +1451,7 @@ namespace SuperNewRoles
                 else if (RoleClass.Dictator.DictatorPlayer.IsCheckListPlayerControl(player)) return RoleId.Dictator;
                 else if (RoleClass.Spelunker.SpelunkerPlayer.IsCheckListPlayerControl(player)) return RoleId.Spelunker;
                 else if (RoleClass.SuicidalIdeation.SuicidalIdeationPlayer.IsCheckListPlayerControl(player)) return RoleId.SuicidalIdeation;
+                else if (RoleClass.Tactician.TacticianPlayer.IsCheckListPlayerControl(player)) return RoleId.Tactician;
                 //ロールチェック
             }
             catch (Exception e)


### PR DESCRIPTION
[内容]
戦術家の作成
[新役職]
〜戦術家/Tactician〜
第3陣営
｢同盟を結んで優位に立ち回ろう｣

説明
・このプレイヤーは、他のプレイヤーと｢同盟｣と｢偽同盟｣がくめる  相手は同盟か偽同盟かはわからない
〇同盟
他プレイヤーと同盟を結ぶと、互いの役職がわかるようになる。
同盟したどちらかが死ぬと、もう片方の人の役職が全員にばれる 
同盟相手が勝利したとき、戦術家も追加勝利  
同盟は誰か1人とのみ結べる
〇偽同盟
他プレイヤーと設定最大人数と結べる  
結ぶと、相手は戦術家だとわかるが、自分は相手の役職はわからない(設定変更可能) 
どちらかが死んでもなにもおきない

設定
・偽同盟最大人数
・偽同盟を結ぶ時、相手の役職がわかるか
・ベント入れる