### PR TITLE
ジャッカルのキルボタンのデフォルト状態をキルに変更&キルができた理由のログを細分化

### DIFF
--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -598,26 +598,26 @@ namespace SuperNewRoles.Patches
                             {
                                 SuperNewRolesPlugin.Logger.LogInfo("まだ作ってなくて、設定が有効の時なんでフレンズ作成");
                                 if (target == null || RoleClass.Jackal.CreatePlayers.Contains(__instance.PlayerId)) return false;
-                                RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
-                                target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
-                                target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
-                                Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
-                                RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする
+                                target.RpcProtectPlayer(target, 0);//キルを無効にする為守護をかける
+                                //守護がかかるのを待つためのLateTask
+                                new LateTask(() =>
+                                    {
+                                        RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
+                                        target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
+                                        Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
+                                        RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする
+                                        SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR]フレンズを作ったよ");
+                                    }, 0.5f);
                             }
                             else
                             {
-                                if (target.IsRole(RoleId.Fox)) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 狐の為 キル処理をスキップ");
-                                else //ターゲットが狐ではなく 且つ フレンズを作ってた・フレンズを作る設定では無い場合 普通のキルを行う
-                                {
-                                    // キルができた理由のログを表示する
-                                    if (!RoleClass.Jackal.CanCreateFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] フレンズを作る設定ではない為 普通のキル");
-                                    else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.IsCreatedFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 作ったので 普通のキル");
-                                    else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
-
-                                    __instance.RpcMurderPlayer(target); // キルを行う
-                                }
+                                // キルができた理由のログを表示する(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
+                                if (!RoleClass.Jackal.CanCreateFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] フレンズを作る設定ではない為 普通のキル");
+                                else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.IsCreatedFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 作ったので 普通のキル");
+                                else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
                             }
-                            return false;
+                            break;
                     }
                     break;
                 case ModeId.Detective:

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -603,7 +603,7 @@ namespace SuperNewRoles.Patches
                                 new LateTask(() =>
                                     {
                                         RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
-                                        target.RpcSetRole(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
                                         target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
                                         Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                                         RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -603,7 +603,7 @@ namespace SuperNewRoles.Patches
                                 new LateTask(() =>
                                     {
                                         RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
-                                        target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.RpcSetRole(RoleTypes.GuardianAngel);//守護天使にして
                                         target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
                                         Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                                         RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -606,9 +606,16 @@ namespace SuperNewRoles.Patches
                             }
                             else
                             {
-                                //作ってたら普通のキル
-                                SuperNewRolesPlugin.Logger.LogInfo("作ったので普通のキル");
-                                __instance.RpcMurderPlayer(target);
+                                if (target.IsRole(RoleId.Fox)) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 狐の為 キル処理をスキップ");
+                                else //ターゲットが狐ではなく 且つ フレンズを作ってた・フレンズを作る設定では無い場合 普通のキルを行う
+                                {
+                                    // キルができた理由のログを表示する
+                                    if (!RoleClass.Jackal.CanCreateFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] フレンズを作る設定ではない為 普通のキル");
+                                    else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.IsCreatedFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 作ったので 普通のキル");
+                                    else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
+
+                                    __instance.RpcMurderPlayer(target); // キルを行う
+                                }
                             }
                             return false;
                     }

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -604,6 +604,7 @@ namespace SuperNewRoles.Patches
                                     {
                                         RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
                                         target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
+                                        target.RPCSetRoleUnchecked(RoleTypes.Crewmate);//クルーにして
                                         target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
                                         Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                                         RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする


### PR DESCRIPTION
### [変更点要約]
- ~~ジャッカルのキル対象が狐だった場合、キル処理を行わないように変更した。~~
- SHRジャッカルが、キルをできた理由のログを細分化した。
- ``target.RpcSetRoleDesync(RoleTypes.GuardianAngel);``を``target.RpcSetRole(RoleTypes.GuardianAngel);``に変更した。

### [変更点]
- ジャッカルのキル対象が狐だった場合、キル処理を行わないように変更した。
    - [ジャッカルが狐をキルできてしまうバグ](https://discord.com/channels/943110158484123658/943121352292962324/1007922502674169906 "シャンパンさんのバグ報告")を修正した。

- SHRジャッカルが、キルをできた理由のログを細分化した。
    - ログの条件があっていなかった為、修正した。
        - (フレンズを作る設定ではないのに、キルした時に「作ったので 普通のキル」と記載されていた。)
        
        - ~~["[JackalSHR] 狐の為 キル処理をスキップ"]~~
        ["[JackalSHR] フレンズを作る設定ではない為 普通のキル"]
        ["[JackalSHR] 作ったので 普通のキル"]
        ["[JackalSHR] 不正なキル"] 
        を追加
    
- ``target.RpcSetRoleDesync(RoleTypes.GuardianAngel);``を``target.RpcSetRole(RoleTypes.GuardianAngel);``に変更した。
    - インポをJFSKした時に試合が終わらないバグの修正の為
    
### [追記]
- ~~このバグの報告の後に私が
``「これ「ジャッカルフレンズを作る設定&マッドメイトを作る設定」のせいか!　狐ならキルしないにした方がいいんだなこの二つは・・・」``
と言っていますが、ファストメーカーの方はテストした所問題が無かった為、変更をかけていません。~~
- スタントマンも問題があるとのことだった為、キルボタンが通常でキルボタンとして動くようにして``__instance.RpcMurderPlayer(target);``を別にかけないように変更しました