### PR TITLE
てるてるのサボ設定をSHRで出さないように変更&[,]不足の修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -771,7 +771,7 @@ namespace SuperNewRoles.Buttons
                             var misfire = !Sheriff.IsSheriffKill(Target);
                             if (RoleClass.Chief.SheriffPlayer.Contains(LocalID))
                             {
-                                misfire = Sheriff.IsChiefSheriffKill(Target);
+                                misfire = !Sheriff.IsChiefSheriffKill(Target);
                             }
                             var TargetID = Target.PlayerId;
 

--- a/SuperNewRoles/CustomOption/CustomOptionDate.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionDate.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using SuperNewRoles.Patch;
 using SuperNewRoles.Roles;
 using UnityEngine;
@@ -883,7 +883,7 @@ namespace SuperNewRoles.CustomOption
             JesterOption = new CustomRoleOption(16, true, CustomOptionType.Neutral, "JesterName", RoleClass.Jester.color, 1);
             JesterPlayerCount = CustomOption.Create(17, true, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], JesterOption);
             JesterIsVent = CustomOption.Create(18, true, CustomOptionType.Neutral, "JesterIsVentSetting", false, JesterOption);
-            JesterIsSabotage = CustomOption.Create(19, true, CustomOptionType.Neutral, "JesterIsSabotageSetting", false, JesterOption);
+            JesterIsSabotage = CustomOption.Create(19, false, CustomOptionType.Neutral, "JesterIsSabotageSetting", false, JesterOption);
             JesterIsWinCleartask = CustomOption.Create(20, true, CustomOptionType.Neutral, "JesterIsWinClearTaskSetting", false, JesterOption);
             var jesteroption = SelectTask.TaskSetting(21, 22, 23, JesterIsWinCleartask, CustomOptionType.Neutral, true);
             JesterCommonTask = jesteroption.Item1;
@@ -1602,7 +1602,7 @@ namespace SuperNewRoles.CustomOption
             PartTimerDeathTurn = CustomOption.Create(852, false, CustomOptionType.Neutral, "PartTimerDeathTurn", 3f, 0f, 15f, 1f, PartTimerOption);
             PartTimerCoolTime = CustomOption.Create(853, false, CustomOptionType.Neutral, "NiceScientistCoolDownSetting", 20f, 2.5f, 60f, 2.5f, PartTimerOption);
             PartTimerIsCheckTargetRole = CustomOption.Create(854, false, CustomOptionType.Neutral, "PartTimerIsCheckTargetRole", true, PartTimerOption);
-            
+
             PhotographerOption = new CustomRoleOption(855, false, CustomOptionType.Neutral, "PhotographerName",RoleClass.Photographer.color, 1);
             PhotographerPlayerCount = CustomOption.Create(856, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], PhotographerOption);
             PhotographerCoolTime = CustomOption.Create(857,false,CustomOptionType.Neutral, "NiceScientistCoolDownSetting", 20f, 2.5f, 60f, 2.5f, PhotographerOption);

--- a/SuperNewRoles/CustomRPC/CustomRPC.cs
+++ b/SuperNewRoles/CustomRPC/CustomRPC.cs
@@ -223,7 +223,7 @@ namespace SuperNewRoles.CustomRPC
         UncheckedUsePlatform,
         PartTimerSet,
         SetMatryoshkaDeadbody,
-        SharePhotograph
+        SharePhotograph,
         StefinderIsKilled
     }
     public static class RPCProcedure

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2746,7 +2746,7 @@ namespace SuperNewRoles.Roles
                 _playerDatas = new();
             }
         }
-        
+
         public static class SatsumaAndImo
         {
             public static List<PlayerControl> SatsumaAndImoPlayer;

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -1144,7 +1144,7 @@ namespace SuperNewRoles
             else if (player.IsImpostor()) return true;
             return role switch
             {
-                RoleId.Jester => RoleClass.Jester.IsUseSabo,
+                RoleId.Jester => RoleClass.Jester.IsUseSabo && ModeHandler.IsMode(ModeId.Default),
                 RoleId.Sidekick or RoleId.Jackal => RoleClass.Jackal.IsUseSabo,
                 RoleId.TeleportingJackal => RoleClass.TeleportingJackal.IsUseSabo,
                 RoleId.SidekickSeer or RoleId.JackalSeer => RoleClass.JackalSeer.IsUseSabo,


### PR DESCRIPTION
### [変更点要約]
- SHR時、Mod導入者のみてるてるでサボタージュができた問題の修正。
- CustomRPCで``,``が足りないためbuildできない問題の修正
    - **マージはよ**

### [変更点]
- ジェスターのサボタージュ可能設定がSHRでは表示しないように変更しました。
- RoleHelper.csのコードを変更してSHRモード時に裏の設定が反映されないようにしました。
    - ``RoleId.Jester => RoleClass.Jester.IsUseSabo &&``__``ModeHandler.IsMode(ModeId.Default),``__
