### PR TITLE
さつまといものタスク問題の修正&サブマージドの反転コード消去&人狼モードとdleks ehtのコードをコメントアウト

### DIFF
--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/UpdatePatch.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/UpdatePatch.cs
@@ -93,7 +93,7 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
                     ObjectData.SkinButton_Skin.SetSkin(SaveManager.lastSkin, SaveManager.BodyColor, false);
                     ObjectData.SkinButton_Skin.transform.localScale = new Vector3(0.6f, 0.6f, 0.6f);
 
-                    ObjectData.VisorButton_Visor.SetVisor(FastDestroyableSingleton<HatManager>.Instance.GetVisorById(SaveManager.LastVisor));
+                    ObjectData.VisorButton_Visor.SetVisor(FastDestroyableSingleton<HatManager>.Instance.GetVisorById(SaveManager.LastVisor), SaveManager.BodyColor);
                     ObjectData.VisorButton_Visor.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
                 }
             }

--- a/SuperNewRoles/CustomOption/CustomOptionModel.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionModel.cs
@@ -855,14 +855,9 @@ namespace SuperNewRoles.CustomOption
         public static void Postfix(GameSettingMenu __instance)
         {
             // Setup mapNameTransform
-            var mapNameTransform = __instance.AllItems.FirstOrDefault(x => x.name.Equals("MapName", StringComparison.OrdinalIgnoreCase));
-            if (mapNameTransform == null) return;
-            mapNameTransform.gameObject.active = true;
-
             foreach (Transform i in __instance.AllItems.ToList())
             {
                 float num = -0.5f;
-                if (i.name.Equals("MapName", StringComparison.OrdinalIgnoreCase)) num = 0.25f;
                 if (i.name.Equals("NumImpostors", StringComparison.OrdinalIgnoreCase)) num = -0.5f;
                 if (i.name.Equals("ResetToDefault", StringComparison.OrdinalIgnoreCase)) num = 0f;
                 i.position += new Vector3(0, num, 0);

--- a/SuperNewRoles/CustomOption/CustomOptionModel.cs
+++ b/SuperNewRoles/CustomOption/CustomOptionModel.cs
@@ -503,7 +503,7 @@ namespace SuperNewRoles.CustomOption
                         RegulationSettings.gameObject.SetActive(true);
                         RegulationTabHighlight.enabled = true;
                     }
-                    
+
                 }));
             }
 
@@ -866,7 +866,7 @@ namespace SuperNewRoles.CustomOption
         }
     }
 
-    [HarmonyPatch(typeof(Constants), nameof(Constants.ShouldFlipSkeld))]
+    /*[HarmonyPatch(typeof(Constants), nameof(Constants.ShouldFlipSkeld))]
     class ConstantsShouldFlipSkeldPatch
     {
         public static bool Prefix(ref bool __result)
@@ -896,16 +896,16 @@ namespace SuperNewRoles.CustomOption
                 return false;
             }
         }
-    }
+    }*/
 
-    [HarmonyPatch(typeof(FreeWeekendShower), nameof(FreeWeekendShower.Start))]
+    /*[HarmonyPatch(typeof(FreeWeekendShower), nameof(FreeWeekendShower.Start))]
     class FreeWeekendShowerPatch
     {
         public static bool Prefix()
         {
             return ConstantsShouldFlipSkeldPatch.AprilFools;
         }
-    }
+    }*/
 
     [HarmonyPatch(typeof(GameOptionsData), nameof(GameOptionsData.ToHudString))]
     class Tohudstring

--- a/SuperNewRoles/Helpers/AntiHackingBan.cs
+++ b/SuperNewRoles/Helpers/AntiHackingBan.cs
@@ -48,10 +48,11 @@ namespace SuperNewRoles.Helpers
             {
                 if (AmongUsClient.Instance.AmClient)
                 {
-                    __instance.SetVisor(visorId);
+                    __instance.SetVisor(visorId, __instance.Data.DefaultOutfit.ColorId);
                 }
                 MessageWriter obj = AmongUsClient.Instance.StartRpc(__instance.NetId, 42, SendOption.None);
                 obj.Write(visorId);
+                obj.Write(__instance.Data.DefaultOutfit.ColorId);
                 obj.EndMessage();
                 return false;
             }

--- a/SuperNewRoles/Main.cs
+++ b/SuperNewRoles/Main.cs
@@ -18,7 +18,7 @@ namespace SuperNewRoles
         public const string Id = "jp.ykundesu.supernewroles";
 
         //バージョンと同時にIsBetaも変える
-        public const string VersionString = "1.4.1.8";
+        public const string VersionString = "1.4.1.9";
         public static bool IsBeta
         {
             get

--- a/SuperNewRoles/MapOptions/MapOption.cs
+++ b/SuperNewRoles/MapOptions/MapOption.cs
@@ -63,7 +63,6 @@ namespace SuperNewRoles.MapOptions
                     ValidationMira = RandomMapMira.GetBool();
                     ValidationPolus = RandomMapPolus.GetBool();
                     ValidationAirship = RandomMapAirship.GetBool();
-                    ValidationSubmerged = RandomMapSubmerged.GetBool();
                 }
                 else
                 {
@@ -159,7 +158,6 @@ namespace SuperNewRoles.MapOptions
         public static CustomOption.CustomOption RandomMapMira;
         public static CustomOption.CustomOption RandomMapPolus;
         public static CustomOption.CustomOption RandomMapAirship;
-        public static CustomOption.CustomOption RandomMapSubmerged;
 
         public static CustomOption.CustomOption RestrictDevicesOption;
         public static CustomOption.CustomOption RestrictAdmin;
@@ -201,7 +199,6 @@ namespace SuperNewRoles.MapOptions
             RandomMapMira = CustomOption.CustomOption.Create(456, true, CustomOptionType.Generic, "RMMiraSetting", true, RandomMapOption);
             RandomMapPolus = CustomOption.CustomOption.Create(457, true, CustomOptionType.Generic, "RMPolusSetting", true, RandomMapOption);
             RandomMapAirship = CustomOption.CustomOption.Create(458, true, CustomOptionType.Generic, "RMAirshipSetting", true, RandomMapOption);
-            RandomMapSubmerged = CustomOption.CustomOption.Create(459, true, CustomOptionType.Generic, "RMSubmergedSetting", true, RandomMapOption);
             /*
                         RestrictDevicesOption = CustomOption.CustomOption.Create(460, false, CustomOptionType.Generic, "RestrictDevicesSetting", true, MapOptionSetting);
                         RestrictAdmin = CustomOption.CustomOption.Create(461, false, CustomOptionType.Generic, "RestrictAdminSetting", false, RestrictDevicesOption);

--- a/SuperNewRoles/Mode/ModeHandler.cs
+++ b/SuperNewRoles/Mode/ModeHandler.cs
@@ -154,7 +154,7 @@ namespace SuperNewRoles.Mode
             Zombie.ZombieOptions.Load();
             RandomColor.RandomColorOptions.Load();
             Detective.DetectiveOptions.Load();
-            Werewolf.WerewolfOptions.Load();
+            //Werewolf.WerewolfOptions.Load();
             //LevelUp.main.Load();
 
             PlusMode.Options.Load();

--- a/SuperNewRoles/Mode/Werewolf/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/Werewolf/RoleSelectHandler.cs
@@ -65,7 +65,7 @@ namespace SuperNewRoles.Mode.Werewolf
                     }
                 }
             }
-            if (WerewolfOptions.WerewolfHunterOption.GetString().Replace("0%", "") != "")
+            /*if (WerewolfOptions.WerewolfHunterOption.GetString().Replace("0%", "") != "")
             {
                 SuperNewRolesPlugin.Logger.LogInfo("[WereWolf] ADDWOLF@ame");
                 int OptionDate = int.Parse(WerewolfOptions.WerewolfHunterOption.GetString().Replace("0%", ""));
@@ -81,7 +81,7 @@ namespace SuperNewRoles.Mode.Werewolf
                         Crewnotonepar.Add(ThisRoleId);
                     }
                 }
-            }
+            }*/
             AllRoleSetClass.Impoonepar = Impoonepar;
             AllRoleSetClass.Imponotonepar = Imponotonepar;
             AllRoleSetClass.Neutonepar = Neutonepar;

--- a/SuperNewRoles/Mode/Werewolf/WerewolfOptions.cs
+++ b/SuperNewRoles/Mode/Werewolf/WerewolfOptions.cs
@@ -3,7 +3,7 @@ using SuperNewRoles.CustomOption;
 namespace SuperNewRoles.Mode.Werewolf
 {
     class WerewolfOptions
-    {
+    {/*
         public static CustomOption.CustomOption WerewolfMode;
         public static CustomOption.CustomOption WerewolfHunterOption;
         public static void Load()
@@ -11,5 +11,5 @@ namespace SuperNewRoles.Mode.Werewolf
             WerewolfMode = CustomOption.CustomOption.Create(506, true, CustomOptionType.Generic, "SettingWerewolfMode", false, ModeHandler.ModeSetting);
             WerewolfHunterOption = CustomOption.CustomOption.Create(507, true, CustomOptionType.Generic, "HunterName", CustomOptions.rates, WerewolfMode);
         }
-    }
+    */}
 }

--- a/SuperNewRoles/OutfitManager.cs
+++ b/SuperNewRoles/OutfitManager.cs
@@ -9,7 +9,7 @@ namespace SuperNewRoles
             SuperNewRolesPlugin.Logger.LogInfo("チェンジ");
             pc.RawSetName(outfit.PlayerName);
             pc.RawSetHat(outfit.HatId, outfit.ColorId);
-            pc.RawSetVisor(outfit.VisorId);
+            pc.RawSetVisor(outfit.VisorId, outfit.ColorId);
             pc.RawSetColor(outfit.ColorId);
             ModHelpers.SetSkinWithAnim(pc.MyPhysics, outfit.SkinId);
 

--- a/SuperNewRoles/Patch/InversionMap.cs
+++ b/SuperNewRoles/Patch/InversionMap.cs
@@ -38,13 +38,6 @@ namespace SuperNewRoles.Patch
                     ShipStatus.Instance.MeetingSpawnCenter = new Vector2(-19.5f, -17f);
                     ShipStatus.Instance.MeetingSpawnCenter2 = new Vector2(-19.5f, -17f);
                 }
-                else if (SubmergedCompatibility.isSubmerged())
-                {
-                    ShipStatus.Instance.InitialSpawnCenter = new Vector2(-3.4f, -28.35f);
-                    ShipStatus.Instance.MeetingSpawnCenter = new Vector2(-3.4f, -28.35f);
-                    ShipStatus.Instance.MeetingSpawnCenter2 = new Vector2(-3.4f, -28.35f);
-                    ShipStatus.Instance.transform.localScale = new Vector3(-0.8f, 0.8f, 0.9412f);
-                }
                 /*else if(PlayerControl.GameOptions.MapId == 4 && CustomOptionHolder.InversionAShip.GetBool())
                 {
                     airship = GameObject.Find("Airship(Clone)");

--- a/SuperNewRoles/Patch/RandomSpawn.cs
+++ b/SuperNewRoles/Patch/RandomSpawn.cs
@@ -29,7 +29,7 @@ namespace SuperNewRoles.Patch
             {
                 PassiveButton passiveButton = __instance.LocationButtons[i];
                 SpawnInMinigame.SpawnLocation pt = array[i];
-                passiveButton.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => __instance.SpawnAt(pt.Location)));
+                passiveButton.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => __instance.SpawnAt(pt)));
                 passiveButton.GetComponent<SpriteAnim>().Stop();
                 passiveButton.GetComponent<SpriteRenderer>().sprite = pt.Image;
                 // passiveButton.GetComponentInChildren<TextMeshPro>().text = DestroyableSingleton<TranslationController>.Instance.GetString(pt.Name, Array.Empty<object>());

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -1077,6 +1077,7 @@ namespace SuperNewRoles
                 case RoleId.Tuna:
                 case RoleId.BlackCat:
                 case RoleId.Neet:
+                case RoleId.SatsumaAndImo:
                 case RoleId.Revolutionist:
                 case RoleId.Spelunker:
                 case RoleId.SuicidalIdeation:


### PR DESCRIPTION
### [注意点&質問]
- fix/v2022-8-24から分岐しています。Developにプルリクかけていますが、fix/v2022-8-24にかけた方がいいですかね・・・
- Developのままでよいならこれはfix/v2022-8-24がマージされた後のmergeでおねがいします。

### [変更点要約]
- さつまといものタスクをクリアした。
- サブマージド反転関連のコードを消去した。
- 人狼モード関連のコードをコメントアウトした。
- dleks eht を選択するとSkeldになるように変更した。

###  [変更点]
- さつまといものタスクをクリアした。
    - さつまといもがタスクを終了しないとクルー勝利ができなかった問題を修正した。

- サブマージド反転関連のコードを消去した。
    - サブマージドのライセンス違反になるようなので消去しました。

- 人狼モード関連のコードをコメントアウトした。

- dleks eht を選択するとSkeldになるように変更した。
    - マップ選択の文字も消したかったのですがコードが見つからなかった為、そのままにしています。
    - ドレスクにするコードをコメントアウトした結果、
    dleks ehtを選択するとクラッシュではなくスケルドでマップが始まるようになりました。