### PR TITLE
到達できないコードなどを修正

### DIFF
--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using HarmonyLib;
 using Hazel;
@@ -17,16 +17,9 @@ namespace SuperNewRoles
         public static bool doReplace = false;
         public static CustomRpcSender sender;
         public static List<(PlayerControl, RoleTypes)> StoragedData = new();
-        public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] RoleTypes roleType)
+        public static bool Prefix()
         {
             return true;
-            if (!ModeHandler.IsMode(ModeId.SuperHostRoles)) return true;
-            if (doReplace && sender != null)
-            {
-                StoragedData.Add((__instance, roleType));
-                return false;
-            }
-            else return true;
         }
         public static void Release()
         {

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/AwakePatch.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/AwakePatch.cs
@@ -56,28 +56,28 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             var SkinButton = GameObject.Instantiate(HatButton, ClosetTab);
             var SkinButton_Passive = SkinButton.Button;
             SkinButton_Passive.OnClick = new();
-            SkinButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.SkinShow()));
+            SkinButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.CosmicShow("SkinGroup")));
             ObjectData.SkinButton = SkinButton;
             SkinButton.name = "SkinButton";
 
             var PetButton = GameObject.Instantiate(HatButton, ClosetTab);
             var PetButton_Passive = PetButton.Button;
             PetButton_Passive.OnClick = new();
-            PetButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.PetShow()));
+            PetButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.CosmicShow("PetsGroup")));
             ObjectData.PetButton = PetButton;
             PetButton.name = "PetButton";
 
             var VisorButton = GameObject.Instantiate(HatButton, ClosetTab);
             var VisorButton_Passive = VisorButton.Button;
             VisorButton_Passive.OnClick = new();
-            VisorButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.VisorShow()));
+            VisorButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.CosmicShow("VisorGroup")));
             ObjectData.VisorButton = VisorButton;
             VisorButton.name = "VisorButton";
 
             var NamePlateButton = GameObject.Instantiate(HatButton, ClosetTab);
             var NamePlateButton_Passive = NamePlateButton.Button;
             NamePlateButton_Passive.OnClick = new();
-            NamePlateButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.NamePlateShow()));
+            NamePlateButton_Passive.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ObjectData.CosmicShow("NameplateGroup")));
             ObjectData.NamePlateButton = NamePlateButton;
             NamePlateButton.name = "NamePlateButton";
 

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
@@ -46,12 +46,6 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             PlayerCustomizationMenu.Instance.transform.FindChild("HatsGroup").gameObject.SetActive(true);
             ShowDefaultTabButton();
         }
-        public static void SkinShow()
-        {
-            ResetShow();
-            IsShow = true;
-            PlayerCustomizationMenu.Instance.transform.FindChild("SkinGroup").gameObject.SetActive(true);
-        }
         public static void CubeShow()
         {
             ResetShow();

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
@@ -44,7 +44,7 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             IsShow = true;
             HideDefaultTabButton();
             PlayerCustomizationMenu.Instance.transform.FindChild("HatsGroup").gameObject.SetActive(true);
-            ShowHatTabsButton();
+            ShowDefaultTabButton();
         }
         public static void SkinShow()
         {
@@ -60,23 +60,10 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             PlayerCustomizationMenu.Instance.cubesTab.gameObject.SetActive(true);
             PlayerCustomizationMenu.Instance.transform.FindChild("Background/RightPanel/CubeView").gameObject.SetActive(true);
         }
-        public static void PetShow()
-        {
+        public static void CosmicShow(string obj){
             ResetShow();
             IsShow = true;
-            PlayerCustomizationMenu.Instance.transform.FindChild("PetsGroup").gameObject.SetActive(true);
-        }
-        public static void VisorShow()
-        {
-            ResetShow();
-            IsShow = true;
-            PlayerCustomizationMenu.Instance.transform.FindChild("VisorGroup").gameObject.SetActive(true);
-        }
-        public static void NamePlateShow()
-        {
-            ResetShow();
-            IsShow = true;
-            PlayerCustomizationMenu.Instance.transform.FindChild("NameplateGroup").gameObject.SetActive(true);
+            PlayerCustomizationMenu.Instance.transform.FindChild(obj).gameObject.SetActive(true);
         }
         public static void ColorShow()
         {
@@ -88,46 +75,6 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
                 chip.gameObject.SetActive(true);
             }
             ColorText.gameObject.SetActive(true);
-        }
-        public static void HideHatTabsButton()
-        {
-        }
-        public static void ShowHatTabsButton()
-        {
-            //SuperNewRolesPlugin.Logger.LogInfo(CustomHats.IsEnd);
-            //if (!CustomHats.IsEnd)
-            {
-                ShowDefaultTabButton();
-                return;
-            }
-            SuperNewRolesPlugin.Logger.LogInfo(HatTabButtons.Length);
-            if (HatTabButtons.Length > 0)
-            {
-                foreach (Transform obj in HatTabButtons)
-                {
-                    obj.gameObject.SetActive(true);
-                }
-                return;
-            }
-            Transform parent = PlayerCustomizationMenu.Instance.Tabs[0].Button.transform.parent.parent.parent;
-            List<Transform> Tabs = new();
-            SuperNewRolesPlugin.Logger.LogInfo(CustomHats.Keys.Count);
-            int i = 1;
-            foreach (string key in CustomHats.Keys)
-            {
-                var obj = GameObject.Instantiate(PlayerCustomizationMenu.Instance.Tabs[0].Button.transform.parent.parent, parent);
-                obj.GetChild(0).gameObject.SetActive(true);
-                PassiveButton button = obj.GetChild(0).FindChild("Tab Background").GetComponent<PassiveButton>();
-                button.OnClick = new();
-                button.OnClick.AddListener((UnityEngine.Events.UnityAction)(() => ClickHatTab(key)));
-                obj.transform.localPosition = new Vector3(-3.75f + (i * 0.75f), 0, -5);
-                obj.name = key;
-                Tabs.Add(obj);
-                i++;
-                SuperNewRolesPlugin.Logger.LogInfo("追加:" + key);
-            }
-            HatTabButtons = Tabs.ToArray();
-            ClickHatTab(CustomHats.Keys[0]);
         }
         public static void ClickHatTab(string package)
         {
@@ -172,7 +119,6 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             ClosetHide();
             PresetHide();
             ShowDefaultTabButton();
-            HideHatTabsButton();
             foreach (TabButton button in PlayerCustomizationMenu.Instance.Tabs)
             {
                 GameObject btn = button.Tab.gameObject;

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsMenus/Patch/ObjectData.cs
@@ -54,6 +54,10 @@ namespace SuperNewRoles.CustomCosmetics.CustomCosmeticsMenus.Patch
             PlayerCustomizationMenu.Instance.cubesTab.gameObject.SetActive(true);
             PlayerCustomizationMenu.Instance.transform.FindChild("Background/RightPanel/CubeView").gameObject.SetActive(true);
         }
+        /// <summary>
+        /// GameObjectのSetActiveをtrueにする
+        /// </summary>
+        /// <param name="obj">trueにしたいGameObject</param>
         public static void CosmicShow(string obj){
             ResetShow();
             IsShow = true;

--- a/SuperNewRoles/CustomCosmetics/DownLoadCustomPlate.cs
+++ b/SuperNewRoles/CustomCosmetics/DownLoadCustomPlate.cs
@@ -14,7 +14,6 @@ namespace SuperNewRoles.CustomCosmetics
     [HarmonyPatch]
     public class CustomPlates
     {
-
         public class CustomPlate
         {
             public string author { get; set; }
@@ -29,16 +28,16 @@ namespace SuperNewRoles.CustomCosmetics
         public static bool running = false;
         public static List<string> fetchs = new();
         public static List<CustomPlates.CustomPlate> platedetails = new();
-        public static void Load()
+        public static async void Load()
         {
-            Patches.CredentialsPatch.LogoPatch.FetchBoosters();
+            await Patches.CredentialsPatch.LogoPatch.FetchBoosters();
             if (running)
                 return;
             IsEndDownload = false;
             Directory.CreateDirectory(Path.GetDirectoryName(Application.dataPath) + @"\SuperNewRoles\");
             Directory.CreateDirectory(Path.GetDirectoryName(Application.dataPath) + @"\SuperNewRoles\CustomPlatesChache\");
             SuperNewRolesPlugin.Logger.LogInfo("[CustomPlate:Download] ダウンロード開始");
-            FetchHats("https://raw.githubusercontent.com/ykundesu/SuperNewNamePlates/main");
+            await FetchHats("https://raw.githubusercontent.com/ykundesu/SuperNewNamePlates/main");
             running = true;
         }
         private static string SanitizeResourcePath(string res)

--- a/SuperNewRoles/MapCustoms/main.cs
+++ b/SuperNewRoles/MapCustoms/main.cs
@@ -42,12 +42,15 @@ namespace SuperNewRoles.MapCustoms
             //配電盤を移動させる
             MoveElecPad.MoveElecPads();
 
-            GameObject gapRoom = DestroyableSingleton<ShipStatus>.Instance.FastRooms[SystemTypes.GapRoom].gameObject;
-            // ぬ～んを消す
-            if (MapCustomHandler.IsMapCustom(MapCustomHandler.MapCustomId.Airship) && MapCustom.AirshipDisableMovingPlatform.GetBool())
+            if (ShipStatus.Instance.FastRooms.ContainsKey(SystemTypes.GapRoom))
             {
-                gapRoom.GetComponentInChildren<MovingPlatformBehaviour>().gameObject.SetActive(false);
-                gapRoom.GetComponentsInChildren<PlatformConsole>().ForEach(x => x.gameObject.SetActive(false));
+                GameObject gapRoom = DestroyableSingleton<ShipStatus>.Instance.FastRooms[SystemTypes.GapRoom].gameObject;
+                // ぬ～んを消す
+                if (MapCustomHandler.IsMapCustom(MapCustomHandler.MapCustomId.Airship) && MapCustom.AirshipDisableMovingPlatform.GetBool())
+                {
+                    gapRoom.GetComponentInChildren<MovingPlatformBehaviour>().gameObject.SetActive(false);
+                    gapRoom.GetComponentsInChildren<PlatformConsole>().ForEach(x => x.gameObject.SetActive(false));
+                }
             }
         }
     }

--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -257,7 +257,6 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             }
             bool IsDemonVIew = false;
             bool IsArsonistVIew = false;
-            bool IsSatsumaAndImoView = false;
             if ((player.IsDead() || player.IsRole(RoleId.God)) && !IsUnchecked)
             {
                 if (Demon.IsViewIcon(player))
@@ -274,7 +273,6 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 {
                     if (RoleClass.SatsumaAndImo.TeamNumber == 1) { MySuffix += ModHelpers.Cs(Palette.White, " (C)"); }
                     else { MySuffix += ModHelpers.Cs(RoleClass.ImpostorRed, " (M)"); }
-                    IsSatsumaAndImoView = true;
                 }
                 NewName = "(<size=75%>" + ModHelpers.Cs(introdate.color, introdate.Name) + TaskText + "</size>)" + ModHelpers.Cs(introdate.color, Name + MySuffix);
             }

--- a/SuperNewRoles/Patch/FixedUpdate.cs
+++ b/SuperNewRoles/Patch/FixedUpdate.cs
@@ -1,4 +1,4 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using SuperNewRoles.Buttons;
 using SuperNewRoles.CustomOption;
 using SuperNewRoles.CustomRPC;
@@ -82,7 +82,6 @@ namespace SuperNewRoles.Patch
             }
 
         }
-        private static bool ProDown = false;
         public static bool IsProDown;
 
         public static void Postfix(PlayerControl __instance)

--- a/SuperNewRoles/Patch/LogoAndStamp.cs
+++ b/SuperNewRoles/Patch/LogoAndStamp.cs
@@ -353,7 +353,6 @@ namespace SuperNewRoles.Patches
                 }
             }
 
-            private static readonly Task DownloadTask = null;
             public static async Task<bool> DownloadSubmarged()
             {
                 try

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -30,8 +30,8 @@ namespace SuperNewRoles.Roles
             }
             Meetingsheriff_updatepatch.Change();
         }
-        public static PassiveButton RightButton;
-        public static PassiveButton LeftButton;
+        public static PassiveButton RightButton = null;
+        public static PassiveButton LeftButton = null;
         public static bool IsFlag;
         public static bool IsSHRFlag;
         private static Sprite m_Meeting_AreaTabChange;

--- a/SuperNewRoles/Roles/Role/RoleTemplate.cs
+++ b/SuperNewRoles/Roles/Role/RoleTemplate.cs
@@ -12,7 +12,7 @@ namespace SuperNewRoles.Roles
         {
             public static List<Role> allRoles = new();
             public PlayerControl player;
-            public RoleId roleId;
+            public RoleId? roleId = null;
 
             public abstract void OnMeetingStart();
             public abstract void OnMeetingEnd();
@@ -31,7 +31,7 @@ namespace SuperNewRoles.Roles
         public abstract class RoleBase<T> : Role where T : RoleBase<T>, new()
         {
             public static List<T> players = new();
-            public static RoleId RoleType;
+            public static RoleId? RoleType = null;
 
             public void Init(PlayerControl player)
             {


### PR DESCRIPTION
## 変更内容
#### マップ改造の「ぬーんを無効化する」オプションで、null参照エラーが出てしまう問題を修正
・if文でSystemTypes.GapRoomならという条件を入れて修正
・動作確認済

#### 使用されていない値を削除
・いろいろ消しました

#### 割り当てられていない値にnullなどを割り当て
・いろいろ割り当てました

#### awaitできるものをawait
・awaitしたらクラッシュするものがあったのでそれ以外await

#### ObjectDataを色々
・到達できないコードを修正
　-修正した結果１メソッドを呼び出すだけになったためこのメソッドを削除
・PetShowなどほとんど同じ処理をしていたため、CosmicShowでgameObjectをstringで指定するように変更


## レビュアーに重点的に確認してもらいたいこと
・カスタムコスメ系がきちんと動作するか
　-元から動作が不安定なため