### PR TITLE
Refact/desync and set role

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -100,101 +100,45 @@ namespace SuperNewRoles.Mode.SuperHostRoles
         public static void SetCustomRoles()
         {
             /*============インポスターにDesync============*/
-            List<PlayerControl> DesyncImpostors = new();
-            DesyncImpostors.AddRange(RoleClass.Jackal.JackalPlayer);
-            DesyncImpostors.AddRange(RoleClass.Sheriff.SheriffPlayer);
-            DesyncImpostors.AddRange(RoleClass.Demon.DemonPlayer);
-            DesyncImpostors.AddRange(RoleClass.Truelover.trueloverPlayer);
-            DesyncImpostors.AddRange(RoleClass.FalseCharges.FalseChargesPlayer);
-            DesyncImpostors.AddRange(RoleClass.MadMaker.MadMakerPlayer);
+            SetRoleDesync(RoleClass.Jackal.JackalPlayer, RoleTypes.Impostor);
+            SetRoleDesync(RoleClass.Sheriff.SheriffPlayer, RoleTypes.Impostor);
+            SetRoleDesync(RoleClass.Demon.DemonPlayer, RoleTypes.Impostor);
+            SetRoleDesync(RoleClass.Truelover.trueloverPlayer, RoleTypes.Impostor);
+            SetRoleDesync(RoleClass.FalseCharges.FalseChargesPlayer, RoleTypes.Impostor);
+            SetRoleDesync(RoleClass.MadMaker.MadMakerPlayer, RoleTypes.Impostor);
             /*============インポスターにDesync============*/
 
 
             /*============エンジニアに役職設定============*/
-            List<PlayerControl> SetRoleEngineers = new();
-            if (RoleClass.Jester.IsUseVent) SetRoleEngineers.AddRange(RoleClass.Jester.JesterPlayer);
-            if (RoleClass.JackalFriends.IsUseVent) SetRoleEngineers.AddRange(RoleClass.JackalFriends.JackalFriendsPlayer);
-            if (RoleClass.MadMate.IsUseVent) SetRoleEngineers.AddRange(RoleClass.MadMate.MadMatePlayer);
-            if (RoleClass.MadMayor.IsUseVent) SetRoleEngineers.AddRange(RoleClass.MadMayor.MadMayorPlayer);
-            if (RoleClass.MadStuntMan.IsUseVent) SetRoleEngineers.AddRange(RoleClass.MadStuntMan.MadStuntManPlayer);
-            if (RoleClass.MadJester.IsUseVent) SetRoleEngineers.AddRange(RoleClass.MadJester.MadJesterPlayer);
-            if (RoleClass.Fox.IsUseVent) SetRoleEngineers.AddRange(RoleClass.Fox.FoxPlayer);
-            if (RoleClass.MayorFriends.IsUseVent) SetRoleEngineers.AddRange(RoleClass.MayorFriends.MayorFriendsPlayer);
-            if (RoleClass.Tuna.IsUseVent) SetRoleEngineers.AddRange(RoleClass.Tuna.TunaPlayer);
-            SetRoleEngineers.AddRange(RoleClass.Technician.TechnicianPlayer);
-            if (RoleClass.BlackCat.IsUseVent) SetRoleEngineers.AddRange(RoleClass.BlackCat.BlackCatPlayer);
+            if (RoleClass.Jester.IsUseVent) SetVanillaRole(RoleClass.Jester.JesterPlayer, RoleTypes.Engineer);
+            if (RoleClass.JackalFriends.IsUseVent) SetVanillaRole(RoleClass.JackalFriends.JackalFriendsPlayer, RoleTypes.Engineer);
+            if (RoleClass.MadMate.IsUseVent) SetVanillaRole(RoleClass.MadMate.MadMatePlayer, RoleTypes.Engineer);
+            if (RoleClass.MadMayor.IsUseVent) SetVanillaRole(RoleClass.MadMayor.MadMayorPlayer, RoleTypes.Engineer);
+            if (RoleClass.MadStuntMan.IsUseVent) SetVanillaRole(RoleClass.MadStuntMan.MadStuntManPlayer, RoleTypes.Engineer);
+            if (RoleClass.MadJester.IsUseVent) SetVanillaRole(RoleClass.MadJester.MadJesterPlayer, RoleTypes.Engineer);
+            if (RoleClass.Fox.IsUseVent) SetVanillaRole(RoleClass.Fox.FoxPlayer, RoleTypes.Engineer);
+            if (RoleClass.MayorFriends.IsUseVent) SetVanillaRole(RoleClass.MayorFriends.MayorFriendsPlayer, RoleTypes.Engineer);
+            if (RoleClass.Tuna.IsUseVent) SetVanillaRole(RoleClass.Tuna.TunaPlayer, RoleTypes.Engineer);
+            SetVanillaRole(RoleClass.Technician.TechnicianPlayer, RoleTypes.Engineer);
+            if (RoleClass.BlackCat.IsUseVent) SetVanillaRole(RoleClass.BlackCat.BlackCatPlayer, RoleTypes.Engineer);
             /*============エンジニアに役職設定============*/
 
 
             /*============シェイプシフターDesync============*/
-            List<PlayerControl> DesyncShapeshifters = new();
-            DesyncShapeshifters.AddRange(RoleClass.Arsonist.ArsonistPlayer);
-            DesyncShapeshifters.AddRange(RoleClass.RemoteSheriff.RemoteSheriffPlayer);
-            DesyncShapeshifters.AddRange(RoleClass.ToiletFan.ToiletFanPlayer);
-            DesyncShapeshifters.AddRange(RoleClass.NiceButtoner.NiceButtonerPlayer);
+            SetRoleDesync(RoleClass.Arsonist.ArsonistPlayer, RoleTypes.Shapeshifter);
+            SetRoleDesync(RoleClass.RemoteSheriff.RemoteSheriffPlayer, RoleTypes.Shapeshifter);
+            SetRoleDesync(RoleClass.ToiletFan.ToiletFanPlayer, RoleTypes.Shapeshifter);
+            SetRoleDesync(RoleClass.NiceButtoner.NiceButtonerPlayer, RoleTypes.Shapeshifter);
             /*============シェイプシフターDesync============*/
 
 
             /*============シェイプシフター役職設定============*/
-            List<PlayerControl> SetRoleShapeshifters = new();
-            SetRoleShapeshifters.AddRange(RoleClass.SelfBomber.SelfBomberPlayer);
-            SetRoleShapeshifters.AddRange(RoleClass.Samurai.SamuraiPlayer);
-            SetRoleShapeshifters.AddRange(RoleClass.EvilButtoner.EvilButtonerPlayer);
-            SetRoleShapeshifters.AddRange(RoleClass.SuicideWisher.SuicideWisherPlayer);
+            SetVanillaRole(RoleClass.SelfBomber.SelfBomberPlayer, RoleTypes.Shapeshifter, false);
+            SetVanillaRole(RoleClass.Samurai.SamuraiPlayer, RoleTypes.Shapeshifter, false);
+            SetVanillaRole(RoleClass.EvilButtoner.EvilButtonerPlayer, RoleTypes.Shapeshifter, false);
+            SetVanillaRole(RoleClass.SuicideWisher.SuicideWisherPlayer, RoleTypes.Shapeshifter, false);
             /*============シェイプシフター役職設定============*/
 
-            foreach (PlayerControl Player in DesyncImpostors)
-            {
-                if (!Player.IsMod())
-                {
-                    int PlayerCID = Player.GetClientId();
-                    sender.RpcSetRole(Player, RoleTypes.Impostor, PlayerCID);
-                    foreach (var pc in PlayerControl.AllPlayerControls)
-                    {
-                        if (pc.PlayerId == Player.PlayerId) continue;
-                        sender.RpcSetRole(pc, RoleTypes.Scientist, PlayerCID);
-                    }
-                    //他視点で科学者にするループ
-                    foreach (var pc in PlayerControl.AllPlayerControls)
-                    {
-                        if (pc.PlayerId == Player.PlayerId) continue;
-                        if (pc.PlayerId == 0) Player.SetRole(RoleTypes.Scientist); //ホスト視点用
-                        else sender.RpcSetRole(Player, RoleTypes.Scientist, pc.GetClientId());
-                    }
-                }
-                else
-                {
-                    //ホストは代わりに普通のクルーにする
-                    Player.SetRole(RoleTypes.Crewmate); //ホスト視点用
-                    sender.RpcSetRole(Player, RoleTypes.Crewmate);
-                }
-            }
-            foreach (PlayerControl Player in DesyncShapeshifters)
-            {
-                if (!Player.IsMod())
-                {
-                    int PlayerCID = Player.GetClientId();
-                    sender.RpcSetRole(Player, RoleTypes.Shapeshifter, PlayerCID);
-                    foreach (var pc in PlayerControl.AllPlayerControls)
-                    {
-                        if (pc.PlayerId == Player.PlayerId) continue;
-                        sender.RpcSetRole(pc, RoleTypes.Scientist, PlayerCID);
-                    }
-                    //他視点で科学者にするループ
-                    foreach (var pc in PlayerControl.AllPlayerControls)
-                    {
-                        if (pc.PlayerId == Player.PlayerId) continue;
-                        if (pc.PlayerId == 0) Player.SetRole(RoleTypes.Scientist); //ホスト視点用
-                        else sender.RpcSetRole(Player, RoleTypes.Scientist, pc.GetClientId());
-                    }
-                }
-                else
-                {
-                    //ホストは代わりに普通のクルーにする
-                    Player.SetRole(RoleTypes.Crewmate); //ホスト視点用
-                    sender.RpcSetRole(Player, RoleTypes.Crewmate);
-                }
-            }
             foreach (PlayerControl Player in RoleClass.Egoist.EgoistPlayer)
             {
                 if (!Player.IsMod())
@@ -260,19 +204,55 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                     else Player.SetRole(RoleTypes.Crewmate);
                 }
             }
-
-            foreach (PlayerControl p in SetRoleEngineers)
+            return;
+        }
+        /// <summary>
+        /// Desyncで役職をセットする
+        /// </summary>
+        /// <param name="player">ターゲット</param>
+        /// <param name="roleTypes">Desyncしたい役職(他視点は科学者固定)</param>
+        public static void SetRoleDesync(List<PlayerControl> player, RoleTypes roleTypes)
+        {
+            foreach (PlayerControl Player in player)
             {
-                if (!p.IsMod())
+                if (!Player.IsMod())
                 {
-                    sender.RpcSetRole(p, RoleTypes.Engineer);
+                    int PlayerCID = Player.GetClientId();
+                    sender.RpcSetRole(Player, roleTypes, PlayerCID);
+                    foreach (var pc in PlayerControl.AllPlayerControls)
+                    {
+                        if (pc.PlayerId == Player.PlayerId) continue;
+                        sender.RpcSetRole(pc, RoleTypes.Scientist, PlayerCID);
+                    }
+                    //他視点で科学者にするループ
+                    foreach (var pc in PlayerControl.AllPlayerControls)
+                    {
+                        if (pc.PlayerId == Player.PlayerId) continue;
+                        if (pc.PlayerId == 0) Player.SetRole(RoleTypes.Scientist); //ホスト視点用
+                        else sender.RpcSetRole(Player, RoleTypes.Scientist, pc.GetClientId());
+                    }
+                }
+                else
+                {
+                    //ホストは代わりに普通のクルーにする
+                    Player.SetRole(RoleTypes.Crewmate); //ホスト視点用
+                    sender.RpcSetRole(Player, RoleTypes.Crewmate);
                 }
             }
-            foreach (PlayerControl p in SetRoleShapeshifters)
+        }
+        /// <summary>
+        /// バニラ役職をセットする
+        /// </summary>
+        /// <param name="player">ターゲット</param>
+        /// <param name="roleTypes">セットする役職</param>
+        /// <param name="isNotModOnly">非Mod導入者のみか(概定はtrue)</param>
+        public static void SetVanillaRole(List<PlayerControl> player, RoleTypes roleTypes, bool isNotModOnly = true)
+        {
+            foreach (PlayerControl p in player)
             {
-                sender.RpcSetRole(p, RoleTypes.Shapeshifter);
+                if (!p.IsMod() && isNotModOnly) return;// Mod導入者ではないかつ、非導入者のみなら破棄
+                sender.RpcSetRole(p, roleTypes);
             }
-            return;
         }
         public static void CrewOrImpostorSet()
         {

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -215,6 +215,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
         {
             foreach (PlayerControl Player in player)
             {
+                Logger.Info($"{Player.name}({Player.GetRole()})=>{roleTypes}を実行", "SetRoleDesync");
                 if (!Player.IsMod())
                 {
                     int PlayerCID = Player.GetClientId();
@@ -250,7 +251,12 @@ namespace SuperNewRoles.Mode.SuperHostRoles
         {
             foreach (PlayerControl p in player)
             {
-                if (!p.IsMod() && isNotModOnly) return;// Mod導入者ではないかつ、非導入者のみなら破棄
+                if (!p.IsMod() && isNotModOnly)
+                {
+                    Logger.Info($"{p.name}({p.GetRole()})=>{roleTypes}Mod導入者ではないかつ、非導入者のみなので破棄", "SetVanillaRole");
+                    return;// Mod導入者ではないかつ、非導入者のみなら破棄
+                }
+                Logger.Info($"{p.name}({p.GetRole()})=>{roleTypes}を実行", "SetVanillaRole");
                 sender.RpcSetRole(p, roleTypes);
             }
         }

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -251,10 +251,10 @@ namespace SuperNewRoles.Mode.SuperHostRoles
         {
             foreach (PlayerControl p in player)
             {
-                if (!p.IsMod() && isNotModOnly)
+                if (p.IsMod() && isNotModOnly)
                 {
-                    Logger.Info($"{p.name}({p.GetRole()})=>{roleTypes}Mod導入者ではないかつ、非導入者のみなので破棄", "SetVanillaRole");
-                    return;// Mod導入者ではないかつ、非導入者のみなら破棄
+                    Logger.Info($"{p.name}({p.GetRole()})=>{roleTypes}Mod導入者かつ、非導入者のみなので破棄", "SetVanillaRole");
+                    return;
                 }
                 Logger.Info($"{p.name}({p.GetRole()})=>{roleTypes}を実行", "SetVanillaRole");
                 sender.RpcSetRole(p, roleTypes);

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -235,8 +235,8 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 }
                 else
                 {
-                    //ホストは代わりに普通のクルーにする
-                    Player.SetRole(RoleTypes.Crewmate); //ホスト視点用
+                    //Modクライアントは代わりに普通のクルーにする
+                    Player.SetRole(RoleTypes.Crewmate); //Modクライアント視点用
                     sender.RpcSetRole(Player, RoleTypes.Crewmate);
                 }
             }


### PR DESCRIPTION
## SHRの役職セットと、Desyncの役職セットをメソッド化
・従来のList<PlayerControl>にAddする方式から、引数で役職と、ターゲットを呼び出す方式に変更