### PR TITLE
Feature/version log

### DIFF
--- a/SuperNewRoles/Main.cs
+++ b/SuperNewRoles/Main.cs
@@ -67,6 +67,7 @@ namespace SuperNewRoles
             SuperNewRoles.Logger.Info($"{ThisAssembly.Git.Commit}", "コミットId");
             SuperNewRoles.Logger.Info($"{ThisAssembly.Git.Commits}", "コミット数");
             SuperNewRoles.Logger.Info($"{ThisAssembly.Git.BaseTag}", "タグ");
+            SuperNewRoles.Logger.Info($"{VersionString}", "バージョン");
             Logger.LogInfo(ModTranslation.GetString("\n---------------\nSuperNewRoles\n" + ModTranslation.GetString("StartLogText") + "\n---------------"));
 
             var assembly = Assembly.GetExecutingAssembly();
@@ -85,15 +86,6 @@ namespace SuperNewRoles
                 }
             }
         }
-        /*
-        [HarmonyPatch(typeof(TranslationController), nameof(TranslationController.GetString), new Type[] { typeof(StringNames), typeof(Il2CppReferenceArray<Il2CppSystem.Object>) })]
-        class TranslateControllerMessagePatch
-        {
-            static void Postfix(ref string __result, [HarmonyArgument(0)] StringNames id)
-            {
-                SuperNewRolesPlugin.Logger.LogInfo(id+":"+__result);
-            }
-        }*/
         [HarmonyPatch(typeof(StatsManager), nameof(StatsManager.AmBanned), MethodType.Getter)]
         public static class AmBannedPatch
         {

--- a/SuperNewRoles/Main.cs
+++ b/SuperNewRoles/Main.cs
@@ -79,20 +79,13 @@ namespace SuperNewRoles
             assembly = Assembly.GetExecutingAssembly();
             string[] resourceNames = assembly.GetManifestResourceNames();
             foreach (string resourceName in resourceNames)
-            {
                 if (resourceName.EndsWith(".png"))
-                {
                     ModHelpers.LoadSpriteFromResources(resourceName, 115f);
-                }
-            }
         }
         [HarmonyPatch(typeof(StatsManager), nameof(StatsManager.AmBanned), MethodType.Getter)]
         public static class AmBannedPatch
         {
-            public static void Postfix(out bool __result)
-            {
-                __result = false;
-            }
+            public static void Postfix(out bool __result) => __result = false;
         }
         [HarmonyPatch(typeof(ChatController), nameof(ChatController.Update))]
         public static class ChatControllerAwakePatch


### PR DESCRIPTION
・ブランチなどに加えVersionStringも表示
　-タグとバージョンの違いがないかどうかの検証用など
・不要なコードを削除
・AmBannedPatchのPostfixを=>で処理する。
　-「=>」は**一つのみ**メソッド等の呼び出しや、代入をする