### PR TITLE
fix/FetchBoosters_CreditsData.jsonでnullエラーを吐いていた問題を修正

### DIFF
--- a/CreditsData.json
+++ b/CreditsData.json
@@ -14,5 +14,7 @@
     { "name": "kibou102", "id": 100 },
     { "name": "windows7", "id": 100 },
     { "name": "渋谷先生", "id": 100 }
-  ]
+  ],
+
+  "Translate":[]
 }


### PR DESCRIPTION
・CreditsData.jsonに"Translate"の項目が無いせいでnullエラーを吐いていた問題をおそらく修正