### PR TITLE
[WIP(work in progress)]New role/schrodingers cat

### DIFF
--- a/SuperNewRoles/AllRoleSetClass.cs
+++ b/SuperNewRoles/AllRoleSetClass.cs
@@ -927,6 +927,7 @@ namespace SuperNewRoles
                 RoleId.Slugger => CustomOptions.SluggerPlayerCount.GetFloat(),
                 RoleId.ShiftActor => Roles.Impostor.ShiftActor.ShiftActorPlayerCount.GetFloat(),
                 RoleId.ConnectKiller => CustomOptions.ConnectKillerPlayerCount.GetFloat(),
+                RoleId.SchrodingersCat => Roles.Neutral.SchrodingersCat.PlayerCount.GetFloat(),
                 //プレイヤーカウント
                 _ => 1,
             };

--- a/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
@@ -42,6 +42,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 case RoleId.FalseCharges:
                 case RoleId.ToiletFan:
                 case RoleId.NiceButtoner:
+                case RoleId.SchrodingersCat:
                     break;
                 default:
                     return true;

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleHelper.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleHelper.cs
@@ -17,6 +17,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 case RoleId.Arsonist:
                 case RoleId.ToiletFan:
                 case RoleId.NiceButtoner:
+                case RoleId.SchrodingersCat:
                     IsCrewVision = true;
                     break;
                     //クルー視界か

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using SuperNewRoles.Roles;
+using SuperNewRoles.Roles.Neutral;
 
 namespace SuperNewRoles.Mode.SuperHostRoles
 {
@@ -29,18 +30,38 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 //ジャッカルがいるなら
                 if (CustomOptions.JackalOption.GetSelection() != 0)
                 {
-                    for (int i = 0; i < (PlayerControl.GameOptions.NumImpostors + 2); i++)
+                    if (SchrodingersCat.Option.GetSelection() != 0)
                     {
-                        PlayerControl bot = BotManager.Spawn("[SHR] 暗転対策BOT" + (i + 1));
-                        if (i == 0)
+                        for (int i = 0; i < (PlayerControl.GameOptions.NumImpostors + 4); i++)
                         {
-                            impostor++;
-                            bot.RpcSetRole(RoleTypes.Impostor);
+                            PlayerControl bot = BotManager.Spawn("[SHR] 暗転くん" + (i + 1));
+                            if (i == 0||i==1)
+                            {
+                                impostor++;
+                                bot.RpcSetRole(RoleTypes.Impostor);
+                            }
+                            if (i > 0)
+                            {
+                                crewmate++;
+                                bot.RpcSetRole(RoleTypes.Crewmate);
+                            }
                         }
-                        if (i > 0)
+                    }
+                    else
+                    {
+                        for (int i = 0; i < (PlayerControl.GameOptions.NumImpostors + 2); i++)
                         {
-                            crewmate++;
-                            bot.RpcSetRole(RoleTypes.Crewmate);
+                            PlayerControl bot = BotManager.Spawn("[SHR] 暗転対策BOT" + (i + 1));
+                            if (i == 0)
+                            {
+                                impostor++;
+                                bot.RpcSetRole(RoleTypes.Impostor);
+                            }
+                            if (i > 0)
+                            {
+                                crewmate++;
+                                bot.RpcSetRole(RoleTypes.Crewmate);
+                            }
                         }
                     }
                 }
@@ -102,6 +123,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             SetRoleDesync(RoleClass.Truelover.trueloverPlayer, RoleTypes.Impostor);
             SetRoleDesync(RoleClass.FalseCharges.FalseChargesPlayer, RoleTypes.Impostor);
             SetRoleDesync(RoleClass.MadMaker.MadMakerPlayer, RoleTypes.Impostor);
+            SetRoleDesync(SchrodingersCat.Player, RoleTypes.Impostor);
             /*============インポスターにDesync============*/
 
 

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -157,6 +157,7 @@ namespace SuperNewRoles.Modules
         Slugger,
         ShiftActor,
         ConnectKiller,
+        SchrodingersCat,
         //RoleId
     }
 

--- a/SuperNewRoles/Modules/IntroDate.cs
+++ b/SuperNewRoles/Modules/IntroDate.cs
@@ -219,6 +219,7 @@ namespace SuperNewRoles.Modules
         public static IntroDate SluggerIntro = new("Slugger", RoleClass.Slugger.color, 1, RoleId.Slugger, TeamRoleType.Impostor);
         public static IntroDate ShiftActorIntro = new("ShiftActor", Roles.Impostor.ShiftActor.color, 1, RoleId.ShiftActor, TeamRoleType.Impostor);
         public static IntroDate ConnectKillerIntro = new("ConnectKiller", RoleClass.ConnectKiller.color, 1, RoleId.ConnectKiller, TeamRoleType.Impostor);
+        public static IntroDate SchrodingersCatIntro = new("SchrodingersCat", Roles.Neutral.SchrodingersCat.Color, 1, RoleId.SchrodingersCat, TeamRoleType.Neutral);
         //イントロオブジェ
     }
 }

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -397,6 +397,7 @@ namespace SuperNewRoles.Patches
                         case RoleId.RemoteSheriff:
                         case RoleId.ToiletFan:
                         case RoleId.NiceButtoner:
+                        case RoleId.SchrodingersCat:
                             return false;
                         case RoleId.Egoist:
                             if (!RoleClass.Egoist.UseKill) return false;
@@ -632,6 +633,11 @@ namespace SuperNewRoles.Patches
                         }
                     }
                 }
+                else if (target.IsRole(RoleId.SchrodingersCat))
+                {
+                    Roles.Neutral.SchrodingersCat.CatRoleChange(target, __instance);
+                    return false;
+                }
             }
             Logger.Info("全スタントマン系通過", "CheckMurder");
             __instance.RpcMurderPlayerCheck(target);
@@ -763,6 +769,9 @@ namespace SuperNewRoles.Patches
                         case RoleId.Fox:
                             Fox.FoxMurderPatch.Prefix(__instance, target);
                             break;
+                        case RoleId.SchrodingersCat:
+                            Roles.Neutral.SchrodingersCat.CatRoleChange(target, __instance);
+                            return false;
                     }
                 }
             }

--- a/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
+++ b/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
@@ -60,6 +60,9 @@ namespace SuperNewRoles.Roles.Neutral
                         cat.RPCSetRoleUnchecked(RoleTypes.Crewmate);
                         cat.SetRole(RoleId.DefaultRole);
                         SetNamesClass.SetPlayerNameColor(cat,Palette.White);
+                        if (!cat.IsMod()){
+                            cat.RpcSetRoleDesync(RoleTypes.GuardianAngel);
+                        }
                         break;
                     case RoleId.Egoist:
                         cat.SetRole(RoleId.Egoist);

--- a/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
+++ b/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
@@ -17,10 +17,10 @@ namespace SuperNewRoles.Roles.Neutral
         private static CustomOption BecomeRoleByJackal;
         public static void SetupCustomOptions()
         {
-            Option = new(985, false, CustomOptionType.Neutral, "SchrodingersCatName", Color, 1);
-            PlayerCount = CustomOption.Create(986, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], Option);
-            BecomeRoleByImpostor = CustomOption.Create(987, false, CustomOptionType.Neutral, "BecomeRolesByImpostor", new string[] { "ImpostorName", "MadmateName" }, Option);
-            BecomeRoleByJackal = CustomOption.Create(988, false, CustomOptionType.Neutral, "BecomeRolesByJackal", new string[] { "JackalName", "JackalFriendsName" }, Option);
+            Option = new(985, true, CustomOptionType.Neutral, "SchrodingersCatName", Color, 1);
+            PlayerCount = CustomOption.Create(986, true, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], Option);
+            BecomeRoleByImpostor = CustomOption.Create(987, true, CustomOptionType.Neutral, "BecomeRolesByImpostor", new string[] { "ImpostorName", "MadmateName" }, Option);
+            BecomeRoleByJackal = CustomOption.Create(988, true, CustomOptionType.Neutral, "BecomeRolesByJackal", new string[] { "JackalName", "JackalFriendsName" }, Option);
         }
 
         public static List<PlayerControl> Player;
@@ -66,7 +66,7 @@ namespace SuperNewRoles.Roles.Neutral
                         SetNamesClass.SetPlayerNameColor(cat,RoleClass.Egoist.color);
                         break;
                     case RoleId.SchrodingersCat:
-                        Logger.SendInGame("自爆");
+                        Logger.Info("自爆", "Change SchrodingersCat Role");
                         break;
                     default:
                         Logger.Info($"だれですか({killer.GetRole()})", "Change SchrodingersCat Role");

--- a/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
+++ b/SuperNewRoles/Roles/Neutral/SchrodingersCat.cs
@@ -1,0 +1,78 @@
+using SuperNewRoles.Patch;
+using static SuperNewRoles.Modules.CustomOptions;
+using System.Collections.Generic;
+using UnityEngine;
+using SuperNewRoles.Helpers;
+using SuperNewRoles.Mode.SuperHostRoles;
+
+namespace SuperNewRoles.Roles.Neutral
+{
+    public static class SchrodingersCat
+    {
+        private const int OptionId = 999;
+
+        public static CustomRoleOption Option;
+        public static CustomOption PlayerCount;
+        private static CustomOption BecomeRoleByImpostor;
+        private static CustomOption BecomeRoleByJackal;
+        public static void SetupCustomOptions()
+        {
+            Option = new(985, false, CustomOptionType.Neutral, "SchrodingersCatName", Color, 1);
+            PlayerCount = CustomOption.Create(986, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], Option);
+            BecomeRoleByImpostor = CustomOption.Create(987, false, CustomOptionType.Neutral, "BecomeRolesByImpostor", new string[] { "ImpostorName", "MadmateName" }, Option);
+            BecomeRoleByJackal = CustomOption.Create(988, false, CustomOptionType.Neutral, "BecomeRolesByJackal", new string[] { "JackalName", "JackalFriendsName" }, Option);
+        }
+
+        public static List<PlayerControl> Player;
+        public static Color32 Color = new(128, 128, 128, byte.MaxValue);
+        private static int BeImpRole; // 1ならインポスター、2ならマッドメイト
+        private static int BeJacRole;
+        public static void ClearAndReload()
+        {
+            Player = new();
+            BeImpRole = BecomeRoleByImpostor.GetSelection();
+            BeJacRole = BecomeRoleByJackal.GetSelection();
+        }
+
+        public static void CatRoleChange(PlayerControl cat,PlayerControl killer){
+            killer.RpcShowGuardEffect(cat);
+            cat.RpcShowGuardEffect(killer);
+            if (killer.IsImpostor()){
+                SetNamesClass.SetPlayerNameColor(cat,RoleClass.ImpostorRed);
+                if (BeImpRole == 1){
+                    cat.RPCSetRoleUnchecked(RoleTypes.Impostor);
+                    cat.SetRole(RoleId.DefaultRole);
+                } else {
+                    cat.SetRole(RoleId.MadMate);
+                }
+            } else if (killer.IsJackalTeam()) {
+                SetNamesClass.SetPlayerNameColor(cat,RoleClass.Jackal.color);
+                if (BeJacRole == 1) {
+                    cat.SetRole(RoleId.Jackal);
+                } else {
+                    cat.SetRole(RoleId.JackalFriends);
+                }
+            } else {
+                switch (killer.GetRole()){
+                    case RoleId.Sheriff:
+                    case RoleId.RemoteSheriff:
+                    case RoleId.MeetingSheriff:
+                        cat.RPCSetRoleUnchecked(RoleTypes.Crewmate);
+                        cat.SetRole(RoleId.DefaultRole);
+                        SetNamesClass.SetPlayerNameColor(cat,Palette.White);
+                        break;
+                    case RoleId.Egoist:
+                        cat.SetRole(RoleId.Egoist);
+                        SetNamesClass.SetPlayerNameColor(cat,RoleClass.Egoist.color);
+                        break;
+                    case RoleId.SchrodingersCat:
+                        Logger.SendInGame("自爆");
+                        break;
+                    default:
+                        Logger.Info($"だれですか({killer.GetRole()})", "Change SchrodingersCat Role");
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -178,6 +178,7 @@ namespace SuperNewRoles.Roles
             Slugger.ClearAndReload();
             Impostor.ShiftActor.ClearAndReload();
             ConnectKiller.ClearAndReload();
+            Neutral.SchrodingersCat.ClearAndReload();
             //ロールクリア
             Quarreled.ClearAndReload();
             Lovers.ClearAndReload();

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -619,6 +619,9 @@ namespace SuperNewRoles
                 case RoleId.ConnectKiller:
                     RoleClass.ConnectKiller.ConnectKillerPlayer.Add(player);
                     break;
+                case RoleId.SchrodingersCat:
+                    Roles.Neutral.SchrodingersCat.Player.Add(player);
+                    break;
                 //ロールアド
                 default:
                     SuperNewRolesPlugin.Logger.LogError($"[SetRole]:No Method Found for Role Type {role}");
@@ -1039,6 +1042,9 @@ namespace SuperNewRoles
                 case RoleId.ConnectKiller:
                     RoleClass.ConnectKiller.ConnectKillerPlayer.RemoveAll(ClearRemove);
                     break;
+                case RoleId.SchrodingersCat:
+                    Roles.Neutral.SchrodingersCat.Player.RemoveAll(ClearRemove);
+                    break;
                 //ロールリモベ
             }
             ChacheManager.ResetMyRoleChache();
@@ -1097,6 +1103,7 @@ namespace SuperNewRoles
                 case RoleId.Stefinder:
                 case RoleId.PartTimer:
                 case RoleId.Photographer:
+                case RoleId.SchrodingersCat:
                 //タスククリアか
                     IsTaskClear = true;
                     break;
@@ -1260,6 +1267,7 @@ namespace SuperNewRoles
                 case RoleId.Stefinder:
                 case RoleId.PartTimer:
                 case RoleId.Photographer:
+                case RoleId.SchrodingersCat:
                 //第三か
                     IsNeutral = true;
                     break;
@@ -1555,6 +1563,7 @@ namespace SuperNewRoles
                 else if (RoleClass.Slugger.SluggerPlayer.IsCheckListPlayerControl(player)) return RoleId.Slugger;
                 else if (ShiftActor.Player.IsCheckListPlayerControl(player)) return RoleId.ShiftActor;
                 else if (RoleClass.ConnectKiller.ConnectKillerPlayer.IsCheckListPlayerControl(player)) return RoleId.ConnectKiller;
+                else if (Roles.Neutral.SchrodingersCat.Player.IsCheckListPlayerControl(player)) return RoleId.SchrodingersCat;
                 //ロールチェック
             }
             catch (Exception e)


### PR DESCRIPTION
### シュレディンガーの猫
・アイデア元:TheOtherRolesGM-Haoming様
#### 説明
キルされるとキルした相手の陣営の役職に変化する。
#### 仕様
インポスターにキルされた場合インポスターになるか、マッドメイトになるかを設定で変更可。(ジャッカルも同様)
　#####キル想定役職
　　インポスター陣営(IsImpostor)
　　ジャッカル陣営(IsJackalTeam)
　　エゴイスト
　　シェリフ
　　リモートシェリフ
　　ミーティングシェリフ

#### SHRについて
RoleId.SchrodingersCatはDesyncImpostorをセット。
キルやベント、広い視界などの能力は使用不可に。
ジャッカル猫とジャッカルのような「ジャッカル二人」になる可能性があるためBot数を調整
シェリフにキルされた場合は守護天使をセット。

**開発版アガルタを所有していないため**
# 動作未確認