### PR TITLE
Feature/DarkKillerSupportSHR

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -1,7 +1,5 @@
 using HarmonyLib;
 using Hazel;
-
-
 using SuperNewRoles.Roles;
 
 namespace SuperNewRoles.Mode.SuperHostRoles
@@ -171,6 +169,9 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                 case RoleId.Doppelganger:
                     optdata.RoleOptions.ShapeshifterDuration = RoleClass.Doppelganger.DurationTime;
                     optdata.RoleOptions.ShapeshifterCooldown = RoleClass.Doppelganger.CoolTime;
+                    break;
+                case RoleId.DarkKiller:
+                    optdata.killCooldown = KillCoolSet(CustomOptions.DarkKillerKillCoolTime.GetFloat());
                     break;
             }
             if (player.IsDead()) optdata.AnonymousVotes = false;

--- a/SuperNewRoles/Modules/CustomOptionDate.cs
+++ b/SuperNewRoles/Modules/CustomOptionDate.cs
@@ -1289,9 +1289,9 @@ namespace SuperNewRoles.Modules
             FoxIsImpostorLight = CustomOption.Create(313, true, CustomOptionType.Neutral, "MadMateImpostorLightSetting", false, FoxOption);
             FoxReport = CustomOption.Create(314, true, CustomOptionType.Neutral, "MinimalistReportSetting", true, FoxOption);
 
-            DarkKillerOption = new CustomRoleOption(315, false, CustomOptionType.Impostor, "DarkKillerName", RoleClass.DarkKiller.color, 1);
-            DarkKillerPlayerCount = CustomOption.Create(316, false, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], DarkKillerOption);
-            DarkKillerKillCoolTime = CustomOption.Create(317, false, CustomOptionType.Impostor, "DarkKillerKillCoolSetting", 20f, 2.5f, 60f, 2.5f, DarkKillerOption);
+            DarkKillerOption = new CustomRoleOption(315, true, CustomOptionType.Impostor, "DarkKillerName", RoleClass.DarkKiller.color, 1);
+            DarkKillerPlayerCount = CustomOption.Create(316, true, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], DarkKillerOption);
+            DarkKillerKillCoolTime = CustomOption.Create(317, true, CustomOptionType.Impostor, "DarkKillerKillCoolSetting", 20f, 2.5f, 60f, 2.5f, DarkKillerOption);
 
             SeerOption = new CustomRoleOption(318, false, CustomOptionType.Crewmate, "SeerName", RoleClass.Seer.color, 1);
             SeerPlayerCount = CustomOption.Create(319, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], SeerOption);

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -580,6 +580,10 @@ namespace SuperNewRoles.Patches
                                 else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
                             }
                             break;
+                        case RoleId.DarkKiller:
+                            var ma = MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>();
+                            if (ma != null && !ma.IsActive) return true;
+                            return false;
                     }
                     break;
                 case ModeId.Detective:


### PR DESCRIPTION
・ダークキラーをSHRに対応しました
 - MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>()がIsActiveではないなら
 - CheckMurderのreturnをtrueにしています。