### PR TITLE
SHRでの名前変更を修正

### DIFF
--- a/SuperNewRoles/ModHelpers.cs
+++ b/SuperNewRoles/ModHelpers.cs
@@ -525,10 +525,6 @@ namespace SuperNewRoles
         {
             return AccessTools.Method(self.GetType(), nameof(Il2CppObjectBase.TryCast)).MakeGenericMethod(type).Invoke(self, Array.Empty<object>());
         }
-        internal static string Cs(object unityEngine, string v)
-        {
-            throw new NotImplementedException();
-        }
 
         public static Dictionary<string, Texture2D> CachedTexture = new();
 

--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -85,9 +85,12 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             //必要がないなら処理しない
             if (player.IsMod() && DiePlayers.Count < 1) return;
 
+            var introdate = IntroDate.GetIntroDate(player.GetRole(), player);
+
             string Name = player.GetDefaultName();
             string NewName = "";
             string MySuffix = "";
+            string RoleNameText = ModHelpers.Cs(introdate.color, introdate.Name);
             Dictionary<byte, string> ChangePlayers = new();
 
             foreach (PlayerControl CelebrityPlayer in RoleClass.Celebrity.CelebrityPlayer)
@@ -184,8 +187,6 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                                 ChangePlayers[Player.PlayerId] = ChangePlayers[Player.PlayerId] + ModHelpers.Cs(RoleClass.ImpostorRed, " (M)");
                             }
                         }
-
-
                     }
                 }
             }
@@ -213,25 +214,24 @@ namespace SuperNewRoles.Mode.SuperHostRoles
             {
                 if (RoleClass.Sheriff.KillCount.ContainsKey(player.PlayerId))
                 {
-                    MySuffix += "(残り" + RoleClass.Sheriff.KillCount[player.PlayerId] + "発)";
+                    RoleNameText += ModHelpers.Cs(introdate.color, $"{RoleClass.Sheriff.KillCount[player.PlayerId]}");
                 }
             }
             else if (player.IsRole(RoleId.RemoteSheriff))
             {
                 if (RoleClass.RemoteSheriff.KillCount.ContainsKey(player.PlayerId))
                 {
-                    MySuffix += "(残り" + RoleClass.RemoteSheriff.KillCount[player.PlayerId] + "発)";
+                    RoleNameText += ModHelpers.Cs(introdate.color, $"{RoleClass.RemoteSheriff.KillCount[player.PlayerId]}");
                 }
             }
             else if (player.IsRole(RoleId.Mafia))
             {
                 if (Mafia.IsKillFlag())
                 {
-                    MySuffix += " (キル可能)";
+                    RoleNameText += " (OK)";
                 }
             }
 
-            var introdate = IntroDate.GetIntroDate(player.GetRole(), player);
             string TaskText = "";
             if (!player.IsClearTask())
             {
@@ -282,7 +282,7 @@ namespace SuperNewRoles.Mode.SuperHostRoles
                         IsArsonistVIew = true;
                     }
                 }
-                NewName = "<size=75%>" + ModHelpers.Cs(introdate.color, introdate.Name) + TaskText + "</size>\n" + ModHelpers.Cs(introdate.color, Name + MySuffix);
+                NewName = "<size=75%>" + RoleNameText + TaskText + "</size>\n" + ModHelpers.Cs(introdate.color, Name + MySuffix);
                 SuperNewRolesPlugin.Logger.LogInfo(NewName);
             }
             if (!player.IsMod())

--- a/SuperNewRoles/Patch/EndGame.cs
+++ b/SuperNewRoles/Patch/EndGame.cs
@@ -598,6 +598,7 @@ namespace SuperNewRoles.Patch
             bool SuicidalIdeationWin = gameOverReason == (GameOverReason)CustomGameOverReason.SuicidalIdeationWin;
             bool HitmanWin = gameOverReason == (GameOverReason)CustomGameOverReason.HitmanWin;
             bool PhotographerWin = gameOverReason == (GameOverReason)CustomGameOverReason.PhotographerWin;
+            bool CrewmateWin = gameOverReason is (GameOverReason)CustomGameOverReason.CrewmateWin or GameOverReason.HumansByVote or GameOverReason.HumansByTask or GameOverReason.ImpostorDisconnect;
             bool BUGEND = gameOverReason == (GameOverReason)CustomGameOverReason.BugEnd;
             if (ModeHandler.IsMode(ModeId.SuperHostRoles) && EndData != null)
             {
@@ -715,6 +716,12 @@ namespace SuperNewRoles.Patch
             {
                 (TempData.winners = new()).Add(new(WinnerPlayer.Data));
                 AdditionalTempData.winCondition = WinCondition.PhotographerWin;
+            }
+            else if (CrewmateWin)
+            {
+                if (RoleClass.SatsumaAndImo.TeamNumber == 1)//クルーなら
+                    foreach (PlayerControl smp in RoleClass.SatsumaAndImo.SatsumaAndImoPlayer)
+                        TempData.winners.Add(new(smp.Data));//さつまいもも勝ち
             }
 
             if (TempData.winners.ToArray().Any(x => x.IsImpostor))

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -1577,7 +1577,7 @@ namespace SuperNewRoles
         }
         public static bool IsAlive(this PlayerControl player)
         {
-            return !IsDead(player);
+            return player != null && !player.Data.Disconnected && !player.Data.IsDead;
         }
         public static bool IsDead(this CachedPlayer player)
         {
@@ -1585,7 +1585,7 @@ namespace SuperNewRoles
         }
         public static bool IsAlive(this CachedPlayer player)
         {
-            return !IsDead(player);
+            return player != null && !player.Data.Disconnected && !player.Data.IsDead;
         }
     }
 }


### PR DESCRIPTION
～通常～
・さつまといものクルーメイト勝利が正常に動作しない問題を修正
～SHR～
・シェリフとリモートシェリフのカウントを役職名の右に表示されるように変更
・マフィアのキル可能かを役職名の右に表示されるように変更