### PR TITLE
fix SHR Arsonist CoolTime

### DIFF
--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -531,7 +531,7 @@ namespace SuperNewRoles.Patches
                                     }
                                     else
                                     {//塗れなかったらキルクールリセット
-                                        SyncSetting.OptionData.DeepCopy().KillCooldown = SyncSetting.KillCoolSet(0f);
+                                        __instance.RpcShowGuardEffect(__instance);
                                     }
                                 }, RoleClass.Arsonist.DurationTime, "SHR Arsonist Douse");
                             }


### PR DESCRIPTION
killcoolに代入は非modがリセットされないのでRpcShowGuardEffectを自分にしてキルクールリセット