### PR TITLE
Refactoring/CreateMadMate[MadとFriendsを作るコードのメソッド化]

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1138,8 +1138,7 @@ namespace SuperNewRoles.Buttons
                     var target = SetTarget();
                     if (!target.Data.Role.IsImpostor && target && RoleHelpers.IsAlive(PlayerControl.LocalPlayer) && PlayerControl.LocalPlayer.CanMove && !RoleClass.MadMaker.IsCreateMadmate)
                     {
-                        target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
-                        target.SetRoleRPC(RoleId.MadMate);
+                        Madmate.CreateMadMate(target);
                         RoleClass.MadMaker.IsCreateMadmate = true;
                     }
                     else if (target.Data.Role.IsImpostor)
@@ -1794,8 +1793,7 @@ namespace SuperNewRoles.Buttons
                     var target = SetTarget();
                     if (!target.Data.Role.IsImpostor && target && RoleHelpers.IsAlive(PlayerControl.LocalPlayer) && PlayerControl.LocalPlayer.CanMove && RoleClass.EvilHacker.IsCreateMadmate)
                     {
-                        target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
-                        target.SetRoleRPC(RoleId.MadMate);
+                        Madmate.CreateMadMate(target);
                         RoleClass.EvilHacker.IsCreateMadmate = false;
                     }
                     else if (target.Data.Role.IsImpostor)
@@ -2092,8 +2090,7 @@ namespace SuperNewRoles.Buttons
                     if (target && PlayerControl.LocalPlayer.CanMove && !RoleClass.FastMaker.IsCreatedMadMate)
                     {
                         PlayerControl.LocalPlayer.RpcShowGuardEffect(target); // 守護エフェクトの表示
-                        target.RPCSetRoleUnchecked(RoleTypes.Crewmate);//くるぅにして
-                        target.SetRoleRPC(RoleId.MadMate);//マッドにする
+                        Madmate.CreateMadMate(target);//くるぅにして、マッドにする
                         RoleClass.FastMaker.IsCreatedMadMate = true;//作ったことに
                         SuperNewRolesPlugin.Logger.LogInfo("[FastMakerButton]マッドを作ったから普通のキルボタンに戻すよ!");
                     }

--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -162,6 +162,14 @@ namespace SuperNewRoles.Helpers
             AmongUsClient.Instance.FinishRpcImmediately(writer);
             RPCProcedure.UncheckedSetVanilaRole(player.PlayerId, (byte)roletype);
         }
+        /// <summary>
+        /// 役職をリセットし、新しい役職に変更します。
+        /// </summary>
+        public static void ResetAndSetRole(this PlayerControl target, RoleId RoleId)
+        {
+            target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
+            target.SetRoleRPC(RoleId);
+        }
 
         public static void RpcResetAbilityCooldown(this PlayerControl target)
         {
@@ -179,8 +187,10 @@ namespace SuperNewRoles.Helpers
             }
         }
 
-        public static void RpcOpenToilet() {
-            foreach (var i in new[] { 79, 80, 81, 82 }) {
+        public static void RpcOpenToilet()
+        {
+            foreach (var i in new[] { 79, 80, 81, 82 })
+            {
                 Logger.Info($"amount:{i}", "RpcOpenToilet");
                 ShipStatus.Instance.RpcRepairSystem(SystemTypes.Doors, i);
             }

--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -165,6 +165,8 @@ namespace SuperNewRoles.Helpers
         /// <summary>
         /// 役職をリセットし、新しい役職に変更します。
         /// </summary>
+        /// <param name="target">役職が変更される対象(PlayerControl)</param>
+        /// <param name="RoleId">変更先の役職(RoleId)</param>
         public static void ResetAndSetRole(this PlayerControl target, RoleId RoleId)
         {
             target.RPCSetRoleUnchecked(RoleTypes.Crewmate);

--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -1,7 +1,7 @@
-using System.Linq;
 using Hazel;
 using InnerNet;
-
+using SuperNewRoles.Mode.SuperHostRoles;
+using System.Linq;
 using UnityEngine;
 using static MeetingHud;
 
@@ -171,6 +171,7 @@ namespace SuperNewRoles.Helpers
         {
             target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
             target.SetRoleRPC(RoleId);
+            Logger.Info($"[{target.GetDefaultName()}] の役職を [{RoleId}] に変更しました。");
         }
 
         public static void RpcResetAbilityCooldown(this PlayerControl target)

--- a/SuperNewRoles/Patch/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patch/PlayerControlPatch.cs
@@ -558,8 +558,7 @@ namespace SuperNewRoles.Patches
                                 __instance.RpcShowGuardEffect(target);
                                 RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
                                 target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にして
-                                target.RPCSetRoleUnchecked(RoleTypes.Crewmate);//クルーにして
-                                target.SetRoleRPC(RoleId.JackalFriends);//フレンズにする
+                                Jackal.CreateJackalFriends(target);//クルーにして フレンズにする
                                 Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                                 RoleClass.Jackal.IsCreatedFriend = true;//作ったことにする
                                 SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR]フレンズを作ったよ");

--- a/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
+++ b/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
-
 using SuperNewRoles.Patch;
+using System.Collections.Generic;
+using static SuperNewRoles.Helpers.RPCHelper;
 
 namespace SuperNewRoles.Roles
 {
@@ -43,6 +43,13 @@ namespace SuperNewRoles.Roles
                 return true;
             }
             return false;
+        }
+        /// <summary>
+        /// (役職をリセットし、)マッドメイトに割り当てます。
+        /// </summary>
+        public static void CreateMadMate(PlayerControl target)
+        {
+            target.ResetAndSetRole(RoleId.MadMate);
         }
     }
 }

--- a/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
+++ b/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
@@ -47,6 +47,7 @@ namespace SuperNewRoles.Roles
         /// <summary>
         /// (役職をリセットし、)マッドメイトに割り当てます。
         /// </summary>
+        /// <param name="target">役職がMadMateに変更される対象</param>
         public static void CreateMadMate(PlayerControl target)
         {
             target.ResetAndSetRole(RoleId.MadMate);

--- a/SuperNewRoles/Roles/Neutral/Jackal.cs
+++ b/SuperNewRoles/Roles/Neutral/Jackal.cs
@@ -52,6 +52,7 @@ namespace SuperNewRoles.Roles
         /// <summary>
         /// (役職をリセットし、)ジャッカルフレンズに割り当てます。
         /// </summary>
+        /// <param name="target">役職がJackalFriendsに変更される対象</param>
         public static void CreateJackalFriends(PlayerControl target)
         {
             target.ResetAndSetRole(RoleId.JackalFriends);

--- a/SuperNewRoles/Roles/Neutral/Jackal.cs
+++ b/SuperNewRoles/Roles/Neutral/Jackal.cs
@@ -1,5 +1,6 @@
 using Hazel;
 using SuperNewRoles.Buttons;
+using static SuperNewRoles.Helpers.RPCHelper;
 using static SuperNewRoles.Patches.PlayerControlFixedUpdatePatch;
 
 namespace SuperNewRoles.Roles
@@ -47,6 +48,13 @@ namespace SuperNewRoles.Roles
                     JackalPlayerOutLineTarget();
                 }
             }
+        }
+        /// <summary>
+        /// (役職をリセットし、)ジャッカルフレンズに割り当てます。
+        /// </summary>
+        public static void CreateJackalFriends(PlayerControl target)
+        {
+            target.ResetAndSetRole(RoleId.JackalFriends);
         }
     }
 }


### PR DESCRIPTION
# [変更点要約]
- [役職をリセットして変更するメソッド(ResetAndSetRole)]の作成
- ResetAndSetRoleを使用して、マッドメイトにするメソッド(CreateMadMate)の作成
- ResetAndSetRoleを使用して、ジャッカルフレンズにするメソッド(CreateJackalFriends)の作成

# [変更点]
- [役職をリセットして変更するメソッド(ResetAndSetRole)]の作成
    - ``target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
    target.SetRoleRPC(RoleId);``
        - 思ったより使用されていなかった為、
        (計4回(MadMate3回+JAckalFriends1回))作る必要がなかったかもしれません。
        - 必要なさそうな場合このメソッドを消して、
        [CreateMadMate]&[CreateJackalFriends]直で行うようにする為、**指摘をください**。
<br>

- ResetAndSetRoleを使用して、マッドメイトにするメソッド(CreateMadMate)の作成
    - SHRでは、``target.RPCSetRoleUnchecked(RoleTypes.Crewmate);``を用いず、
    ``target.RpcSetRoleDesync(RoleTypes.GuardianAngel);``だけを用いていた為、変更していません。
<br>

- ResetAndSetRoleを使用して、ジャッカルフレンズにするメソッド(CreateJackalFriends)の作成

# [追記]
- EvilSeerにMadMateを作る能力を追加しようとして、Mad作る役職は複数あるはずの為まとめようかと思い変更しました。
- そしたら思ったよりMadを作る役職及び相手の役職を変更させる役職がいませんでした。