### PR TITLE
イビルハッカーがマッドを作るボタンの修正(不要なコードの消去&キーコードの変更)

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1809,8 +1809,8 @@ namespace SuperNewRoles.Buttons
                 new Vector3(-2.7f, -0.06f, 0),
                 __instance,
                 __instance.AbilityButton,
-                KeyCode.Q,
-                8,
+                null,
+                0,
                 () => { return false; }
             )
             {

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1798,10 +1798,6 @@ namespace SuperNewRoles.Buttons
                         target.SetRoleRPC(RoleId.MadMate);
                         RoleClass.EvilHacker.IsCreateMadmate = false;
                     }
-                    else if (target.Data.Role.IsImpostor)
-                    {
-                        PlayerControl.LocalPlayer.RpcMurderPlayer(PlayerControl.LocalPlayer);
-                    }
                 },
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.EvilHacker && ModeHandler.IsMode(ModeId.Default) && RoleClass.EvilHacker.IsCreateMadmate; },
                 () =>


### PR DESCRIPTION
# [注意]
- #522 マージ後のマージでおねがいします。
    - 「マッドを作るメソッド」を含んだ状態のままプルリクしている為。
- 本来はプルリク予定だった機能でこのコードを利用したかった為、
その機能の作成の一環として修正プルリクを混ぜ込むつもりでした。
- プルリク予定だった機能の差分が大きくなりそうだった為、予定を変更し分割しました。

# [変更点要約]
- MadMateを作るボタンに含まれていた「Impostorをターゲットにすると自殺する」コードの削除
- MadMateを作るボタンがキルボタンとキーコードが被っていた問題の修正

# [変更点]
- MadMateを作るボタンに含まれていた「Impostorをターゲットにすると自殺する」コードの削除
- MadMateを作るボタンがキルボタンとキーコードが被っていた問題の修正
    - キーコードをQからnullと、8から0に変更
        - nullを使ってキーコードを割り当てないようにするコードはTORGM-Hさんを参考にさせていただきました。