### PR TITLE
カスタムオプションの表示がおかしい設定の修正

### DIFF
--- a/SuperNewRoles/MapOptions/MapOption.cs
+++ b/SuperNewRoles/MapOptions/MapOption.cs
@@ -175,7 +175,7 @@ namespace SuperNewRoles.MapOptions
             RandomMapPolus = CustomOption.Create(457, true, CustomOptionType.Generic, "RMPolusSetting", true, RandomMapOption);
             RandomMapAirship = CustomOption.Create(458, true, CustomOptionType.Generic, "RMAirshipSetting", true, RandomMapOption);
 
-            RandomSpawnOption = CustomOption.Create(955, false, CustomOptionType.Generic, "RandomSpawnOption", false, null);
+            RandomSpawnOption = CustomOption.Create(955, false, CustomOptionType.Generic, "RandomSpawnOption", false, MapOptionSetting);
 
             ReactorDurationOption = CustomOption.Create(468, true, CustomOptionType.Generic, "ReactorDurationSetting", false, MapOptionSetting);
             PolusReactorTimeLimit = CustomOption.Create(469, true, CustomOptionType.Generic, "PolusReactorTime", 30f, 0f, 100f, 1f, ReactorDurationOption);

--- a/SuperNewRoles/Modules/CustomOptionDate.cs
+++ b/SuperNewRoles/Modules/CustomOptionDate.cs
@@ -910,7 +910,7 @@ namespace SuperNewRoles.Modules
 
             Sabotage.Options.Load();
 
-            IsAlwaysReduceCooldown = Create(682, false, CustomOptionType.Generic, "IsAlwaysReduceCooldown", false, null);
+            IsAlwaysReduceCooldown = Create(682, false, CustomOptionType.Generic, "IsAlwaysReduceCooldown", false, null, isHeader: true);
             IsAlwaysReduceCooldownExceptInVent = Create(954, false, CustomOptionType.Generic, "IsAlwaysReduceCooldownExceptInVent", false, IsAlwaysReduceCooldown);
             IsAlwaysReduceCooldownExceptOnTask = Create(684, false, CustomOptionType.Generic, "IsAlwaysReduceCooldownExceptOnTask", true, IsAlwaysReduceCooldown);
 


### PR DESCRIPTION
マップオプションのランダムスポーンがマップオプションがオフでも出てくる問題？を修正
常にキルクールが進むがサボタージュ設定とくっついて表示される問題？の修正