### PR TITLE
マトリョーシカ修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2290,6 +2290,15 @@ namespace SuperNewRoles.Buttons
             MatryoshkaButton = new(
                 () =>
                 {
+                    if (MatryoshkaButton.isEffectActive)
+                    {
+                        MatryoshkaButton.isEffectActive = false;
+                        RoleClass.Matryoshka.WearLimit--;
+                        Roles.Impostor.Matryoshka.RpcSet(null, false);
+                        MatryoshkaButton.MaxTimer = CustomOptions.MatryoshkaCoolTime.GetFloat();
+                        MatryoshkaButton.Timer = MatryoshkaButton.MaxTimer;
+                        return;
+                    }
                     foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(PlayerControl.LocalPlayer.GetTruePosition(), PlayerControl.LocalPlayer.MaxReportDistance, Constants.PlayersOnlyMask))
                     {
                         if (collider2D.tag == "DeadBody")

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2290,37 +2290,27 @@ namespace SuperNewRoles.Buttons
             MatryoshkaButton = new(
                 () =>
                 {
-                    if (RoleClass.Matryoshka.IsLocalOn)
+                    foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(PlayerControl.LocalPlayer.GetTruePosition(), PlayerControl.LocalPlayer.MaxReportDistance, Constants.PlayersOnlyMask))
                     {
-                        Roles.Impostor.Matryoshka.RpcSet(null, false);
-                        MatryoshkaButton.MaxTimer = CustomOptions.MatryoshkaCoolTime.GetFloat();
-                        MatryoshkaButton.Timer = MatryoshkaButton.MaxTimer;
-                    }
-                    else
-                    {
-                        foreach (Collider2D collider2D in Physics2D.OverlapCircleAll(PlayerControl.LocalPlayer.GetTruePosition(), PlayerControl.LocalPlayer.MaxReportDistance, Constants.PlayersOnlyMask))
+                        if (collider2D.tag == "DeadBody")
                         {
-                            if (collider2D.tag == "DeadBody")
+                            DeadBody component = collider2D.GetComponent<DeadBody>();
+                            Vector2 truePosition = PlayerControl.LocalPlayer.GetTruePosition();
+                            Vector2 truePosition2 = component.TruePosition;
+                            Logger.Info((!component.Reported).ToString() + $"{truePosition2} : {truePosition} : {Vector2.Distance(truePosition2, truePosition) <= PlayerControl.LocalPlayer.MaxReportDistance} : {Vector2.Distance(truePosition2, truePosition)} : {PlayerControl.LocalPlayer.MaxReportDistance}");
+                            if (!component.Reported)
                             {
-                                DeadBody component = collider2D.GetComponent<DeadBody>();
-                                Vector2 truePosition = PlayerControl.LocalPlayer.GetTruePosition();
-                                Vector2 truePosition2 = component.TruePosition;
-                                Logger.Info((!component.Reported).ToString() + $"{truePosition2} : {truePosition} : {Vector2.Distance(truePosition2, truePosition) <= PlayerControl.LocalPlayer.MaxReportDistance} : {Vector2.Distance(truePosition2, truePosition)} : {PlayerControl.LocalPlayer.MaxReportDistance}");
-                                if (!component.Reported)
+                                if (Vector2.Distance(truePosition2, truePosition) <= PlayerControl.LocalPlayer.MaxReportDistance && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false))
                                 {
-                                    if (Vector2.Distance(truePosition2, truePosition) <= PlayerControl.LocalPlayer.MaxReportDistance && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false))
+                                    if (RoleClass.Matryoshka.Datas.Values.All(data =>
                                     {
-                                        if (RoleClass.Matryoshka.Datas.Values.All(data =>
-                                        {
-                                            return data.Item1 == null || data.Item1.ParentId != component.ParentId;
-                                        }))
-                                        {
-                                            GameData.PlayerInfo playerInfo = GameData.Instance.GetPlayerById(component.ParentId);
-                                            Roles.Impostor.Matryoshka.RpcSet(playerInfo.Object, true);
-                                            RoleClass.Matryoshka.WearLimit--;
-                                            RoleClass.Matryoshka.MyKillCoolTime += CustomOptions.MatryoshkaAddKillCoolTime.GetFloat();
-                                            break;
-                                        }
+                                        return data == null || data.ParentId != component.ParentId;
+                                    }))
+                                    {
+                                        GameData.PlayerInfo playerInfo = GameData.Instance.GetPlayerById(component.ParentId);
+                                        Roles.Impostor.Matryoshka.RpcSet(playerInfo.Object, true);
+                                        RoleClass.Matryoshka.MyKillCoolTime += CustomOptions.MatryoshkaAddKillCoolTime.GetFloat();
+                                        break;
                                     }
                                 }
                             }
@@ -2340,12 +2330,19 @@ namespace SuperNewRoles.Buttons
                         MatryoshkaButton.Sprite = RoleClass.Matryoshka.PutOnButtonSprite;
                         MatryoshkaButton.buttonText = ModTranslation.GetString("MatryoshkaPutOnButtonName");
                     }
+                    MatryoshkaButton.HasEffect = __instance.ReportButton.graphic.color == Palette.EnabledColor;
                     return (__instance.ReportButton.graphic.color == Palette.EnabledColor || RoleClass.Matryoshka.IsLocalOn) && PlayerControl.LocalPlayer.CanMove;
                 },
                 () =>
                 {
                     MatryoshkaButton.MaxTimer = CustomOptions.MatryoshkaCoolTime.GetFloat();
                     MatryoshkaButton.Timer = MatryoshkaButton.MaxTimer;
+                    MatryoshkaButton.effectCancellable = true;
+                    MatryoshkaButton.EffectDuration = CustomOptions.MatryoshkaWearTime.GetFloat();
+                    if (RoleClass.Matryoshka.IsLocalOn)
+                    {
+                        RoleClass.Matryoshka.WearLimit--;
+                    }
                     Roles.Impostor.Matryoshka.RpcSet(null, false);
                 },
                 RoleClass.Matryoshka.PutOnButtonSprite,
@@ -2357,6 +2354,14 @@ namespace SuperNewRoles.Buttons
                 () =>
                 {
                     return false;
+                },
+                true,
+                5f,
+                () => {
+                    RoleClass.Matryoshka.WearLimit--;
+                    Roles.Impostor.Matryoshka.RpcSet(null, false);
+                    MatryoshkaButton.MaxTimer = CustomOptions.MatryoshkaCoolTime.GetFloat();
+                    MatryoshkaButton.Timer = MatryoshkaButton.MaxTimer;
                 }
                 )
             {

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2311,7 +2311,7 @@ namespace SuperNewRoles.Buttons
                             {
                                 if (Vector2.Distance(truePosition2, truePosition) <= PlayerControl.LocalPlayer.MaxReportDistance && !PhysicsHelpers.AnythingBetween(truePosition, truePosition2, Constants.ShipAndObjectsMask, false))
                                 {
-                                    if (RoleClass.Matryoshka.Datas.Values.All(data =>
+                                    if (RoleClass.Matryoshka.Data.Values.All(data =>
                                     {
                                         return data == null || data.ParentId != component.ParentId;
                                     }))

--- a/SuperNewRoles/Roles/Impostor/Matryoshka.cs
+++ b/SuperNewRoles/Roles/Impostor/Matryoshka.cs
@@ -12,20 +12,12 @@ namespace SuperNewRoles.Roles.Impostor
     {
         public static void FixedUpdate()
         {
-            foreach (var Data in RoleClass.Matryoshka.Datas.ToArray())
+            foreach (var Data in RoleClass.Matryoshka.Datas)
             {
-                if (Data.Value.Item1 != null) continue;
-                Data.Value.Item1.Reported = !CustomOptions.MatryoshkaWearReport.GetBool();
-                Data.Value.Item1.bodyRenderer.enabled = false;
-                Data.Value.Item1.transform.position = ModHelpers.PlayerById(Data.Key).transform.position;
-                RoleClass.Matryoshka.Datas[Data.Key] = (Data.Value.Item1, Data.Value.Item2 - Time.fixedDeltaTime);
-                if (RoleClass.Matryoshka.Datas[Data.Key].Item2 <= 0) continue;
-                if (Data.Key == CachedPlayer.LocalPlayer.PlayerId)
-                {
-                    Buttons.HudManagerStartPatch.MatryoshkaButton.MaxTimer = CustomOptions.MatryoshkaCoolTime.GetFloat();
-                    Buttons.HudManagerStartPatch.MatryoshkaButton.Timer = Buttons.HudManagerStartPatch.MatryoshkaButton.MaxTimer;
-                }
-                Set(ModHelpers.PlayerById(Data.Key), null, false);
+                if (Data.Value == null) continue;
+                Data.Value.Reported = !CustomOptions.MatryoshkaWearReport.GetBool();
+                Data.Value.bodyRenderer.enabled = false;
+                Data.Value.transform.position = ModHelpers.PlayerById(Data.Key).transform.position;
             }
         }
         public static void WrapUp()
@@ -44,13 +36,16 @@ namespace SuperNewRoles.Roles.Impostor
             }
             if (!Is)
             {
-                if (RoleClass.Matryoshka.Datas[source.PlayerId].Item1 != null)
+                if (RoleClass.Matryoshka.Datas.ContainsKey(source.PlayerId))
                 {
-                    RoleClass.Matryoshka.Datas[source.PlayerId].Item1.Reported = false;
-                    if (RoleClass.Matryoshka.Datas[source.PlayerId].Item1.bodyRenderer != null)
-                        RoleClass.Matryoshka.Datas[source.PlayerId].Item1.bodyRenderer.enabled = true;
+                    if (RoleClass.Matryoshka.Datas[source.PlayerId] != null)
+                    {
+                        RoleClass.Matryoshka.Datas[source.PlayerId].Reported = false;
+                        if (RoleClass.Matryoshka.Datas[source.PlayerId].bodyRenderer != null)
+                            RoleClass.Matryoshka.Datas[source.PlayerId].bodyRenderer.enabled = true;
+                    }
+                    RoleClass.Matryoshka.Datas.Remove(source.PlayerId);
                 }
-                RoleClass.Matryoshka.Datas[source.PlayerId] = (null, 0);
             }
             else
             {
@@ -59,7 +54,7 @@ namespace SuperNewRoles.Roles.Impostor
                 {
                     if (GameData.Instance.GetPlayerById(array[i].ParentId).PlayerId == target.PlayerId)
                     {
-                        RoleClass.Matryoshka.Datas[source.PlayerId] = (array[i], RoleClass.Matryoshka.WearDefaultTime);
+                        RoleClass.Matryoshka.Datas[source.PlayerId] = array[i];
                     }
                 }
             }

--- a/SuperNewRoles/Roles/Impostor/Matryoshka.cs
+++ b/SuperNewRoles/Roles/Impostor/Matryoshka.cs
@@ -12,7 +12,7 @@ namespace SuperNewRoles.Roles.Impostor
     {
         public static void FixedUpdate()
         {
-            foreach (var Data in RoleClass.Matryoshka.Datas)
+            foreach (var Data in RoleClass.Matryoshka.Data)
             {
                 if (Data.Value == null) continue;
                 Data.Value.Reported = !CustomOptions.MatryoshkaWearReport.GetBool();
@@ -22,7 +22,7 @@ namespace SuperNewRoles.Roles.Impostor
         }
         public static void WrapUp()
         {
-            RoleClass.Matryoshka.Datas = new();
+            RoleClass.Matryoshka.Data = new();
         }
         public static void Set(PlayerControl source, PlayerControl target, bool Is)
         {
@@ -36,15 +36,15 @@ namespace SuperNewRoles.Roles.Impostor
             }
             if (!Is)
             {
-                if (RoleClass.Matryoshka.Datas.ContainsKey(source.PlayerId))
+                if (RoleClass.Matryoshka.Data.ContainsKey(source.PlayerId))
                 {
-                    if (RoleClass.Matryoshka.Datas[source.PlayerId] != null)
+                    if (RoleClass.Matryoshka.Data[source.PlayerId] != null)
                     {
-                        RoleClass.Matryoshka.Datas[source.PlayerId].Reported = false;
-                        if (RoleClass.Matryoshka.Datas[source.PlayerId].bodyRenderer != null)
-                            RoleClass.Matryoshka.Datas[source.PlayerId].bodyRenderer.enabled = true;
+                        RoleClass.Matryoshka.Data[source.PlayerId].Reported = false;
+                        if (RoleClass.Matryoshka.Data[source.PlayerId].bodyRenderer != null)
+                            RoleClass.Matryoshka.Data[source.PlayerId].bodyRenderer.enabled = true;
                     }
-                    RoleClass.Matryoshka.Datas.Remove(source.PlayerId);
+                    RoleClass.Matryoshka.Data.Remove(source.PlayerId);
                 }
             }
             else
@@ -54,7 +54,7 @@ namespace SuperNewRoles.Roles.Impostor
                 {
                     if (GameData.Instance.GetPlayerById(array[i].ParentId).PlayerId == target.PlayerId)
                     {
-                        RoleClass.Matryoshka.Datas[source.PlayerId] = array[i];
+                        RoleClass.Matryoshka.Data[source.PlayerId] = array[i];
                     }
                 }
             }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2449,8 +2449,8 @@ namespace SuperNewRoles.Roles
             public static float WearDefaultTime;
             public static float WearTime;
             public static float MyKillCoolTime;
-            public static bool IsLocalOn => !Datas.Keys.All(data => data != CachedPlayer.LocalPlayer.PlayerId || Datas[data].Item1 == null);
-            public static Dictionary<byte, (DeadBody, float)> Datas;
+            public static bool IsLocalOn => !Datas.Keys.All(data => data != CachedPlayer.LocalPlayer.PlayerId);
+            public static Dictionary<byte, DeadBody> Datas;
             public static Sprite PutOnButtonSprite => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.MatryoshkaPutOnButton.png", 115f);
            public static Sprite TakeOffButtonSprite => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.MatryoshkaTakeOffButton.png", 115f);
             public static void ClearAndReload()

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -2449,8 +2449,8 @@ namespace SuperNewRoles.Roles
             public static float WearDefaultTime;
             public static float WearTime;
             public static float MyKillCoolTime;
-            public static bool IsLocalOn => !Datas.Keys.All(data => data != CachedPlayer.LocalPlayer.PlayerId);
-            public static Dictionary<byte, DeadBody> Datas;
+            public static bool IsLocalOn => !Data.Keys.All(data => data != CachedPlayer.LocalPlayer.PlayerId);
+            public static Dictionary<byte, DeadBody> Data;
             public static Sprite PutOnButtonSprite => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.MatryoshkaPutOnButton.png", 115f);
            public static Sprite TakeOffButtonSprite => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.MatryoshkaTakeOffButton.png", 115f);
             public static void ClearAndReload()
@@ -2458,7 +2458,7 @@ namespace SuperNewRoles.Roles
                 MatryoshkaPlayer = new();
                 WearLimit = CustomOptions.MatryoshkaWearLimit.GetInt();
                 WearTime = 0;
-                Datas = new();
+                Data = new();
                 MyKillCoolTime = PlayerControl.GameOptions.killCooldown;
             }
         }


### PR DESCRIPTION
・死体を着たときに死体が消えない問題を修正
・死体を脱いだときに死体が移動しない問題を修正
・来ている死体を通報出来るがONのとき通報出来ない問題を修正
・「まとう」を使い切ったとき、着た段階でボタンが消えてしまい死体を着たままになる問題を修正
・ついでにマトリョーシカの残り効果時間を視認可能に修正