### PR TITLE
コネクトキラーの能力をカスタムベントに対応

### DIFF
--- a/SuperNewRoles/MapCustoms/00_AllMaps/AdditionalVent.cs
+++ b/SuperNewRoles/MapCustoms/00_AllMaps/AdditionalVent.cs
@@ -75,7 +75,8 @@ namespace SuperNewRoles.MapCustoms
             {
                 SuperNewRolesPlugin.Logger.LogInfo("べんとおおおお");
                 AdditionalVents vents1 = new(new Vector3(23.5483f, -5.589f, PlayerControl.LocalPlayer.transform.position.z + 1f)); // 診察室
-                AdditionalVents vents2 = new(new Vector3(24.8562f, 5.2692f, PlayerControl.LocalPlayer.transform.position.z + 1f)); // ラウンジ
+                AdditionalVents vents2 = new(
+                    new Vector3(CustomOptions.ConnectKillerOption.GetSelection() == 0 ? 24.8562f : 26.8562f, 5.2692f, PlayerControl.LocalPlayer.transform.position.z + 1f)); // ラウンジ
                 AdditionalVents vents3 = new(new Vector3(5.9356f, 3.0133f, PlayerControl.LocalPlayer.transform.position.z + 1f)); // メイン
                 vents1.vent.Right = vents2.vent;//診察-ラウンジ
                 vents2.vent.Left = vents1.vent;//ラウンジ-診察

--- a/SuperNewRoles/Modules/VentData.cs
+++ b/SuperNewRoles/Modules/VentData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Agartha;
 using HarmonyLib;
+using SuperNewRoles.MapCustoms;
 
 namespace SuperNewRoles.Modules
 {
@@ -34,7 +35,7 @@ namespace SuperNewRoles.Modules
                     ventMap["NavVentSouth"].Vent.Right = connect ? ventMap["NavVentNorth"] : new Vent();
 
                     ventMap["ShieldsVent"].Vent.Left = connect ? ventMap["WeaponsVent"] : new Vent();
-                    ventMap["WeaponsVent"].Vent.Center = connect ? ventMap["ShieldsVent"] : new Vent();
+                    ventMap["WeaponsVent"].Vent.Left = connect ? ventMap["ShieldsVent"] : new Vent();
 
                     ventMap["ReactorVent"].Vent.Left = connect ? ventMap["UpperReactorVent"] : new Vent();
                     ventMap["UpperReactorVent"].Vent.Left = connect ? ventMap["ReactorVent"] : new Vent();
@@ -45,36 +46,25 @@ namespace SuperNewRoles.Modules
                     ventMap["REngineVent"].Vent.Center = connect ? ventMap["LEngineVent"] : new Vent();
                     ventMap["LEngineVent"].Vent.Center = connect ? ventMap["REngineVent"] : new Vent();
 
-                    if (ventMap.ContainsKey("StorageVent"))
+                    ventMap["AdminVent"].Vent.Center = connect ? ventMap["MedVent"] : new Vent();
+                    ventMap["MedVent"].Vent.Center = connect ? ventMap["AdminVent"] : new Vent();
+
+                    ventMap["CafeVent"].Vent.Center = connect ? ventMap["WeaponsVent"] : new Vent();
+                    ventMap["WeaponsVent"].Vent.Center = connect ? ventMap["CafeVent"] : new Vent();
+                    break;
+                case 1:
+                    //MIRA HQ
+                    if (MapCustom.MiraAdditionalVents.GetBool())
                     {
-                        ventMap["AdminVent"].Vent.Center = connect ? ventMap["StorageVent"] : new Vent();
-                        ventMap["StorageVent"].Vent.Left = connect ? ventMap["ElecVent"] : new Vent();
-                        ventMap["StorageVent"].Vent.Right = connect ? ventMap["AdminVent"] : new Vent();
+                        ventMap["AdditionalVent_12"].Vent.Center = connect ? ventMap["LaunchVent"] : new Vent();
+                        ventMap["LaunchVent"].Vent.Center = connect ? ventMap["AdditionalVent_12"] : new Vent();
 
-                        ventMap["StorageVent"].Vent.Center = connect ? ventMap["CafeUpperVent"] : new Vent();
+                        ventMap["AdditionalVent_13"].Vent.Right = connect ? ventMap["MedVent"] : new Vent();
+                        ventMap["MedVent"].Vent.Center = connect ? ventMap["AdditionalVent_13"] : new Vent();
+
+                        ventMap["AdditionalVent_14"].Vent.Center = connect ? ventMap["YHallRightVent"] : new Vent();
+                        ventMap["YHallRightVent"].Vent.Center = connect ? ventMap["AdditionalVent_14"] : new Vent();
                     }
-                    else
-                    {
-                        ventMap["AdminVent"].Vent.Center = connect ? ventMap["MedVent"] : new Vent();
-                        ventMap["MedVent"].Vent.Center = connect ? ventMap["AdminVent"] : new Vent();
-                    }
-
-                    if (ventMap.ContainsKey("CafeUpperVent"))
-                    {
-                        ventMap["CafeUpperVent"].Vent.Left = connect ? ventMap["LEngineVent"] : new Vent();
-                        ventMap["LEngineVent"].Vent.Right = connect ? ventMap["CafeUpperVent"] : new Vent();
-
-                        ventMap["CafeUpperVent"].Vent.Center = connect ? ventMap["StorageVent"] : new Vent();
-
-                        ventMap["CafeUpperVent"].Vent.Right = connect ? ventMap["WeaponsVent"] : new Vent();
-                        ventMap["WeaponsVent"].Vent.Left = connect ? ventMap["CafeUpperVent"] : new Vent();
-                    }
-                    else
-                    {
-                        ventMap["CafeVent"].Vent.Center = connect ? ventMap["WeaponsVent"] : new Vent();
-                        ventMap["WeaponsVent"].Vent.Center = connect ? ventMap["CafeVent"] : new Vent();
-                    }
-
                     break;
                 case 2:
                     //Polus
@@ -89,6 +79,18 @@ namespace SuperNewRoles.Modules
 
                     ventMap["AdminVent"].Vent.Center = connect ? ventMap["OfficeVent"] : new Vent();
                     ventMap["OfficeVent"].Vent.Center = connect ? ventMap["AdminVent"] : new Vent();
+
+                    if (MapCustom.PolusAdditionalVents.GetBool())
+                    {
+                        ventMap["AdditionalVent_12"].Vent.Center = connect ? ventMap["BathroomVent"] : new Vent();
+                        ventMap["BathroomVent"].Vent.Left = connect ? ventMap["AdditionalVent_12"] : new Vent();
+
+                        ventMap["AdditionalVent_13"].Vent.Right = connect ? ventMap["SouthVent"] : new Vent();
+                        ventMap["SouthVent"].Vent.Left = connect ? ventMap["AdditionalVent_13"] : new Vent();
+
+                        ventMap["AdditionalVent_14"].Vent.Center = connect ? ventMap["ScienceBuildingVent"] : new Vent();
+                        ventMap["ScienceBuildingVent"].Vent.Center = connect ? ventMap["AdditionalVent_14"] : new Vent();
+                    }
                     break;
                 case 3 when MapData.IsMap(CustomMapNames.Agartha):
                     break;
@@ -100,11 +102,35 @@ namespace SuperNewRoles.Modules
                     ventMap["EjectionVent"].Vent.Right = connect ? ventMap["KitchenVent"] : new Vent();
                     ventMap["KitchenVent"].Vent.Center = connect ? ventMap["EjectionVent"] : new Vent();
 
-                    ventMap["HallwayVent1"].Vent.Right = connect ? ventMap["HallwayVent2"] : new Vent();
+                    ventMap["HallwayVent1"].Vent.Center = connect ? ventMap["HallwayVent2"] : new Vent();
                     ventMap["HallwayVent2"].Vent.Center = connect ? ventMap["HallwayVent1"] : new Vent();
 
                     ventMap["GaproomVent2"].Vent.Center = connect ? ventMap["RecordsVent"] : new Vent();
                     ventMap["RecordsVent"].Vent.Center = connect ? ventMap["GaproomVent2"] : new Vent();
+
+                    if (MapCustom.AirShipAdditionalVents.GetBool())
+                    {
+                        ventMap["AdditionalVent_12"].Vent.Left = connect ? ventMap["AdditionalVent_16"] : new Vent();
+                        ventMap["AdditionalVent_16"].Vent.Center = connect ? ventMap["AdditionalVent_12"] : new Vent();
+
+                        ventMap["AdditionalVent_12"].Vent.Center = connect ? ventMap["AdditionalVent_17"] : new Vent();
+                        ventMap["AdditionalVent_17"].Vent.Center = connect ? ventMap["AdditionalVent_12"] : new Vent();
+
+                        ventMap["AdditionalVent_13"].Vent.Center = connect ? ventMap["StorageVent"] : new Vent();
+                        ventMap["StorageVent"].Vent.Center = connect ? ventMap["AdditionalVent_13"] : new Vent();
+
+                        ventMap["AdditionalVent_14"].Vent.Center = connect ? ventMap["AdditionalVent_15"] : new Vent();
+                        ventMap["AdditionalVent_15"].Vent.Center = connect ? ventMap["AdditionalVent_14"] : new Vent();
+
+                        ventMap["AdditionalVent_14"].Vent.Left = connect ? ventMap["EjectionVent"] : new Vent();
+                        ventMap["EjectionVent"].Vent.Center = connect ? ventMap["AdditionalVent_14"] : new Vent();
+
+                        ventMap["AdditionalVent_15"].Vent.Left = connect ? ventMap["EngineVent"] : new Vent();
+                        ventMap["EngineVent"].Vent.Center = connect ? ventMap["AdditionalVent_15"] : new Vent();
+
+                        ventMap["AdditionalVent_17"].Vent.Right = connect ? ventMap["ShowersVent"] : new Vent();
+                        ventMap["ShowersVent"].Vent.Center = connect ? ventMap["AdditionalVent_17"] : new Vent();
+                    }
                     break;
             }
         }


### PR DESCRIPTION
コネクトキラーの能力でカスタムベントに飛べるように変更しました。
ついでにコミュサボ中に一部のベントが一方通行になるバグを修正しました。

ちょっとだけカスタムベントの所を変更しています。
貨物のベントからラウンジの追加ベントに飛ぶ矢印とアーカイブに飛ぶ矢印が重なってしまった為、
ラウンジの追加ベントをコネクトキラーが選出された場合に少し右に移動しています。