### PR TITLE
フリーターバグ修正

### DIFF
--- a/SuperNewRoles/Patch/FixedUpdate.cs
+++ b/SuperNewRoles/Patch/FixedUpdate.cs
@@ -126,6 +126,7 @@ namespace SuperNewRoles.Patch
                     JackalSeer.JackalSeerFixedPatch.Postfix(__instance, MyRole);
                     Roles.CrewMate.Psychometrist.FixedUpdate();
                     Roles.Impostor.Matryoshka.FixedUpdate();
+                    Roles.Neutral.PartTimer.FixedUpdate();
                     ReduceKillCooldown(__instance);
                     if (PlayerControl.LocalPlayer.IsAlive())
                     {

--- a/SuperNewRoles/Roles/Neutral/PartTimer.cs
+++ b/SuperNewRoles/Roles/Neutral/PartTimer.cs
@@ -1,3 +1,5 @@
+using SuperNewRoles.Helpers;
+
 namespace SuperNewRoles.Roles.Neutral
 {
     public static class PartTimer
@@ -21,7 +23,7 @@ namespace SuperNewRoles.Roles.Neutral
             if (!PlayerControl.LocalPlayer.IsRole(RoleId.PartTimer)) return;
             if (RoleClass.PartTimer.DeathTurn <= 0 && CachedPlayer.LocalPlayer.IsAlive() && !RoleClass.PartTimer.IsLocalOn)
             {
-                PlayerControl.LocalPlayer.RpcMurderPlayer(PlayerControl.LocalPlayer);
+                PlayerControl.LocalPlayer.RpcExiledUnchecked();
             }
             RoleClass.PartTimer.DeathTurn--;
         }

--- a/SuperNewRoles/Roles/Neutral/PartTimer.cs
+++ b/SuperNewRoles/Roles/Neutral/PartTimer.cs
@@ -19,7 +19,7 @@ namespace SuperNewRoles.Roles.Neutral
         public static void WrapUp()
         {
             if (!PlayerControl.LocalPlayer.IsRole(RoleId.PartTimer)) return;
-            if (RoleClass.PartTimer.DeathTurn <= 0)
+            if (RoleClass.PartTimer.DeathTurn <= 0 && CachedPlayer.LocalPlayer.IsAlive() && !RoleClass.PartTimer.IsLocalOn)
             {
                 PlayerControl.LocalPlayer.RpcMurderPlayer(PlayerControl.LocalPlayer);
             }


### PR DESCRIPTION
・就職しても餓死ターンが経過すると死亡してしまう問題を修正
・就職先が死亡してもバイトボタンが出現しない問題を修正
・餓死すると毎ターン自殺し、死体が出現する問題を修正
・餓死時、湧き位置から動けなくなる問題を修正