### PR TITLE
会議終了コマンドバグ修正

### DIFF
--- a/SuperNewRoles/Patch/FixedUpdate.cs
+++ b/SuperNewRoles/Patch/FixedUpdate.cs
@@ -55,7 +55,8 @@ namespace SuperNewRoles.Patch
             // 会議を強制終了
             if (ModHelpers.GetManyKeyDown(new[] { KeyCode.M, KeyCode.LeftShift, KeyCode.RightShift }) && RoleClass.IsMeeting)
             {
-                MeetingHud.Instance.RpcClose();
+                if (MeetingHud.Instance != null)
+                    MeetingHud.Instance.RpcClose();
             }
 
             // 以下フリープレイのみ

--- a/SuperNewRoles/Patch/FixedUpdate.cs
+++ b/SuperNewRoles/Patch/FixedUpdate.cs
@@ -55,7 +55,7 @@ namespace SuperNewRoles.Patch
             // 会議を強制終了
             if (ModHelpers.GetManyKeyDown(new[] { KeyCode.M, KeyCode.LeftShift, KeyCode.RightShift }) && RoleClass.IsMeeting)
             {
-                FastDestroyableSingleton<MeetingHud>.Instance.RpcClose();
+                MeetingHud.Instance.RpcClose();
             }
 
             // 以下フリープレイのみ


### PR DESCRIPTION
・FastDestroyableSingletonが使われている問題を修正
・MeetingHud.Instanceのnullチェックを追加