### PR TITLE
YJさんのハットを一時的に読み込みしないよう変更

### DIFF
--- a/SuperNewRoles/CustomCosmetics/CustomHats.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomHats.cs
@@ -464,7 +464,8 @@ namespace SuperNewRoles.CustomCosmetics
             { "https://raw.githubusercontent.com/ykundesu/SuperNewNamePlates/master", "SuperNewNamePlates" },
 
             { "https://raw.githubusercontent.com/hinakkyu/TheOtherHats/master", "mememurahat" },
-            { "https://raw.githubusercontent.com/Ujet222/TOPHats/main", "YJ" },
+            // Jsonエラーが出ている為一時的に消去
+            // { "https://raw.githubusercontent.com/Ujet222/TOPHats/main", "YJ" },
 
             { "https://raw.githubusercontent.com/haoming37/TheOtherHats-GM-Haoming/master", "TheOtherRolesGMHaoming"},
             { "https://raw.githubusercontent.com/yukinogatari/TheOtherHats-GM/master", "TheOtherRolesGM"},


### PR DESCRIPTION
Yjさんのハットリポジトリでjsonエラーが生じている為に、
ハットをダウンロード中unitycrashが生じたり、
プリセットを変えてもModハットが反映されなかったりしている問題があることから、
(現状別の理由でハット表示が壊れている為プリセット変更でしかハットを変更できない)、
一時的にコメントアウトして読み込みしないようにしました。

(jsonerror問題についてはプルリクをかけています(https://github.com/Ujet222/TOPHats/pull/2))
