### PR TITLE
マトリョーシカサイドキックバグ修正

### DIFF
--- a/SuperNewRoles/Roles/Impostor/Matryoshka.cs
+++ b/SuperNewRoles/Roles/Impostor/Matryoshka.cs
@@ -17,7 +17,12 @@ namespace SuperNewRoles.Roles.Impostor
                 if (Data.Value == null) continue;
                 Data.Value.Reported = !CustomOptions.MatryoshkaWearReport.GetBool();
                 Data.Value.bodyRenderer.enabled = false;
-                Data.Value.transform.position = ModHelpers.PlayerById(Data.Key).transform.position;
+                PlayerControl player = ModHelpers.PlayerById(Data.Key);
+                Data.Value.transform.position = player.transform.position;
+                if (!player.IsRole(RoleId.Matryoshka))
+                {
+                    Set(player, null, false);
+                }
             }
         }
         public static void WrapUp()


### PR DESCRIPTION
マトリョーシカの役職が変更された場合、そのまま着たままになってしまう問題を修正