### PR TITLE
殺し屋が正常に勝利できない問題を修正

### DIFF
--- a/SuperNewRoles/Patch/EndGame.cs
+++ b/SuperNewRoles/Patch/EndGame.cs
@@ -693,6 +693,15 @@ namespace SuperNewRoles.Patch
             }
             else if (HitmanWin)
             {
+                if (WinnerPlayer == null)
+                {
+                    foreach (PlayerControl p in PlayerControl.AllPlayerControls) if (p.IsRole(RoleId.Hitman)) WinnerPlayer = p;
+                    if (WinnerPlayer == null)
+                    {
+                        Logger.Error("エラー:殺し屋が生存していませんでした");
+                        WinnerPlayer = PlayerControl.LocalPlayer;
+                    }
+                }
                 (TempData.winners = new()).Add(new(WinnerPlayer.Data));
                 AdditionalTempData.winCondition = WinCondition.HitmanWin;
             }


### PR DESCRIPTION
殺し屋の1人生存勝利の場合、WinnerPlayerがnullになり正常に勝利できない問題を修正