### PR TITLE
殺し屋のエンドゲームのログにtagが存在しなかった為buildでき無かった問題を修正

### DIFF
--- a/SuperNewRoles/Patch/EndGame.cs
+++ b/SuperNewRoles/Patch/EndGame.cs
@@ -698,7 +698,7 @@ namespace SuperNewRoles.Patch
                     foreach (PlayerControl p in PlayerControl.AllPlayerControls) if (p.IsRole(RoleId.Hitman)) WinnerPlayer = p;
                     if (WinnerPlayer == null)
                     {
-                        Logger.Error("エラー:殺し屋が生存していませんでした");
+                        Logger.Error("エラー:殺し屋が生存していませんでした","HitmanWin");
                         WinnerPlayer = PlayerControl.LocalPlayer;
                     }
                 }


### PR DESCRIPTION
SSIA