### PR TITLE
パブロフの犬バグ修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -168,6 +168,7 @@ namespace SuperNewRoles.Buttons
                     writer.Write(IsSelfDeath);
                     writer.EndRPC();
                     RPCProcedure.PavlovsOwnerCreateDog(CachedPlayer.LocalPlayer.PlayerId, target.PlayerId, IsSelfDeath);
+                    RoleClass.Pavlovsowner.CurrentChildPlayer = target;
                 },
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Pavlovsowner && RoleClass.Pavlovsowner.CanCreateDog; },
                 () =>


### PR DESCRIPTION
・正常に自分の犬がセットされない問題を修正
→これにより複数回指名できる問題が修正