### PR TITLE
デバッグモードで[MurderPlayer]が発生したらメッセージで通知を行う設定を追加

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionDate.cs
+++ b/SuperNewRoles/Modules/CustomOptionDate.cs
@@ -30,6 +30,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomOption IsDebugMode;
         public static CustomOption DebugModeFastStart;
+        public static CustomOption IsMurderPlayerAnnounce;
 
         public static CustomOption DisconnectNotPCOption;
 
@@ -957,6 +958,7 @@ namespace SuperNewRoles.Modules
             {
                 IsDebugMode = Create(10, true, CustomOptionType.Generic, "デバッグモード", false, null, isHeader: true);
                 DebugModeFastStart = Create(681, true, CustomOptionType.Generic, "即開始", false, IsDebugMode);
+                IsMurderPlayerAnnounce = Create(1073, true, CustomOptionType.Generic, "IsMurderPlayerAnnounce", false, IsDebugMode);
             }
 
             DisconnectNotPCOption = Create(11, true, CustomOptionType.Generic, Cs(Color.white, "DisconnectNotPC"), true, null, isHeader: true);

--- a/SuperNewRoles/Modules/CustomOptionDate.cs
+++ b/SuperNewRoles/Modules/CustomOptionDate.cs
@@ -958,7 +958,7 @@ namespace SuperNewRoles.Modules
             {
                 IsDebugMode = Create(10, true, CustomOptionType.Generic, "デバッグモード", false, null, isHeader: true);
                 DebugModeFastStart = Create(681, true, CustomOptionType.Generic, "即開始", false, IsDebugMode);
-                IsMurderPlayerAnnounce = Create(1073, true, CustomOptionType.Generic, "IsMurderPlayerAnnounce", false, IsDebugMode);
+                IsMurderPlayerAnnounce = Create(1073, true, CustomOptionType.Generic, "MurderPlayer発生時に通知を行う", false, IsDebugMode);
             }
 
             DisconnectNotPCOption = Create(11, true, CustomOptionType.Generic, Cs(Color.white, "DisconnectNotPC"), true, null, isHeader: true);

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -100,16 +100,15 @@ namespace SuperNewRoles.Patches
             }
             return IsDebugModeBool;
         }
-        public static class ExileControllerWrapUpPatch
+        public static class MurderPlayerPatch
         {
-            public static class MurderPlayerPatch
+            /// <summary>
+            /// MurderPlayerが発動した時に通知します。
+            /// </summary>
+            public static void Announce()
             {
-                public static void Postfix([HarmonyArgument(0)] PlayerControl target)
-                {
-                    
-                }
+                
             }
-
         }
     }
 }

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -107,7 +107,7 @@ namespace SuperNewRoles.Patches
             /// </summary>
             public static void Announce()
             {
-                
+                if (!(IsDebugMode() && CustomOptions.IsMurderPlayerAnnounce.GetBool())) return;
             }
         }
     }

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -108,6 +108,8 @@ namespace SuperNewRoles.Patches
             public static void Announce()
             {
                 if (!(IsDebugMode() && CustomOptions.IsMurderPlayerAnnounce.GetBool())) return;
+
+                new CustomMessage(ModTranslation.GetString("MurderPlayerAnnounceMessage"), 5f);
             }
         }
     }

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -100,5 +100,16 @@ namespace SuperNewRoles.Patches
             }
             return IsDebugModeBool;
         }
+        public static class ExileControllerWrapUpPatch
+        {
+            public static class MurderPlayerPatch
+            {
+                public static void Postfix([HarmonyArgument(0)] PlayerControl target)
+                {
+                    
+                }
+            }
+
+        }
     }
 }

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -109,7 +109,7 @@ namespace SuperNewRoles.Patches
             {
                 if (!(IsDebugMode() && CustomOptions.IsMurderPlayerAnnounce.GetBool())) return;
 
-                new CustomMessage(ModTranslation.GetString("MurderPlayerAnnounceMessage"), 5f);
+                new CustomMessage("MurderPlayerが発生しました", 5f);
             }
         }
     }

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -912,6 +912,7 @@ namespace SuperNewRoles.Patches
 
             SerialKiller.MurderPlayer(__instance, target);
             Seer.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
+            DebugMode.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
             Roles.CrewMate.KnightProtected_Patch.MurderPlayerPatch.Postfix(target);
 
             if (ModeHandler.IsMode(ModeId.SuperHostRoles))

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -912,7 +912,7 @@ namespace SuperNewRoles.Patches
 
             SerialKiller.MurderPlayer(__instance, target);
             Seer.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
-            DebugMode.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
+            DebugMode.MurderPlayerPatch.Announce();
             Roles.CrewMate.KnightProtected_Patch.MurderPlayerPatch.Postfix(target);
 
             if (ModeHandler.IsMode(ModeId.SuperHostRoles))

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -291,8 +291,6 @@ CopsImpostorCome,Remaining until the Imposter arrives,インポスターが来�
 CopsSpawnLoading,Waiting for all players to spawn...\nLoading: {0} people remaining</color></size>,全プレイヤーのスポーンを待っています...\nロドー中:残り{0}人</color></size>,等待所有玩家进入行动阶段...\n载入中:还剩{0}人</color></size>
 CRHideNameSetting,Hide Name,名前を隠す,隐藏昵称
 IsOldMode,OldMode,オルドモード,怀旧模式
-IsMurderPlayerAnnounce,Notification when MurderPlayer occurs.,MurderPlayer発生時に通知を行う,当MurderPlayer发生时通知。
-MurderPlayerAnnounceMessage,MurderPlayer has occurred!,MurderPlayerが発生しました,发生了MurderPlayer。
 CrewMateName,Crewmate,クルーメイト,船员
 CrewMateTitle1,Use Task,タスクを行う,找出内鬼
 CrewMateDescription,Default Crewmate.,通常のクルーメイトです。,普通船员。

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -291,6 +291,7 @@ CopsImpostorCome,Remaining until the Imposter arrives,インポスターが来�
 CopsSpawnLoading,Waiting for all players to spawn...\nLoading: {0} people remaining</color></size>,全プレイヤーのスポーンを待っています...\nロドー中:残り{0}人</color></size>,等待所有玩家进入行动阶段...\n载入中:还剩{0}人</color></size>
 CRHideNameSetting,Hide Name,名前を隠す,隐藏昵称
 IsOldMode,OldMode,オルドモード,怀旧模式
+IsMurderPlayerAnnounce,Notification when MurderPlayer occurs.,MurderPlayer発生時に通知を行う,当MurderPlayer发生时通知。
 CrewMateName,Crewmate,クルーメイト,船员
 CrewMateTitle1,Use Task,タスクを行う,找出内鬼
 CrewMateDescription,Default Crewmate.,通常のクルーメイトです。,普通船员。

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -292,6 +292,7 @@ CopsSpawnLoading,Waiting for all players to spawn...\nLoading: {0} people remain
 CRHideNameSetting,Hide Name,名前を隠す,隐藏昵称
 IsOldMode,OldMode,オルドモード,怀旧模式
 IsMurderPlayerAnnounce,Notification when MurderPlayer occurs.,MurderPlayer発生時に通知を行う,当MurderPlayer发生时通知。
+MurderPlayerAnnounceMessage,MurderPlayer has occurred!,MurderPlayerが発生しました,发生了MurderPlayer。
 CrewMateName,Crewmate,クルーメイト,船员
 CrewMateTitle1,Use Task,タスクを行う,找出内鬼
 CrewMateDescription,Default Crewmate.,通常のクルーメイトです。,普通船员。


### PR DESCRIPTION
# [新機能]
- Debugモードで[MurderPlayer]が発生したらメッセージで通知を行う設定を追加した。

# [テストプレイ]
- ホストの設定が反映されることを確認
- 設定がオフの時反映されないことを確認