### PR TITLE
デバッグモードで[MurderPlayer]が発生したらメッセージで通知を行う設定を追加

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -30,6 +30,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomOption IsDebugMode;
         public static CustomOption DebugModeFastStart;
+        public static CustomOption IsMurderPlayerAnnounce;
 
         public static CustomOption DisconnectNotPCOption;
 
@@ -957,6 +958,7 @@ namespace SuperNewRoles.Modules
             {
                 IsDebugMode = Create(10, true, CustomOptionType.Generic, "デバッグモード", false, null, isHeader: true);
                 DebugModeFastStart = Create(681, true, CustomOptionType.Generic, "即開始", false, IsDebugMode);
+                IsMurderPlayerAnnounce = Create(1073, true, CustomOptionType.Generic, "MurderPlayer発生時に通知を行う", false, IsDebugMode);
             }
 
             DisconnectNotPCOption = Create(11, true, CustomOptionType.Generic, Cs(Color.white, "DisconnectNotPC"), true, null, isHeader: true);

--- a/SuperNewRoles/Patches/DebugModePatch.cs
+++ b/SuperNewRoles/Patches/DebugModePatch.cs
@@ -89,5 +89,19 @@ namespace SuperNewRoles.Patches
             }
         }
         public static bool IsDebugMode() => ConfigRoles.DebugMode.Value && CustomOptionHolder.IsDebugMode.GetBool();
+
+        public static class MurderPlayerPatch
+        {
+            /// <summary>
+            /// MurderPlayerが発動した時に通知します。
+            /// </summary>
+            public static void Announce()
+            {
+                if (!(IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())) return;
+
+                new CustomMessage("MurderPlayerが発生しました", 5f);
+                Logger.Info("MurderPlayerが発生しました", "DebugMode");
+            }
+        }
     }
 }

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -912,6 +912,7 @@ namespace SuperNewRoles.Patches
 
             SerialKiller.MurderPlayer(__instance, target);
             Seer.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
+            DebugMode.MurderPlayerPatch.Announce();
             Roles.Crewmate.KnightProtected_Patch.MurderPlayerPatch.Postfix(target);
 
             if (ModeHandler.IsMode(ModeId.SuperHostRoles))


### PR DESCRIPTION
#668 をDev_fixからの分岐で作り直しました

ちゃっかりlogを付け足しました