### PR TITLE
シェリフ系役職が誤爆時対象を殺す設定を追加

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -145,7 +145,7 @@ namespace SuperNewRoles.Buttons
             VampireCreateDependentsButton = new(
                 () =>
                 {
-                    var target = SetTarget(Crewmateonly:true);
+                    var target = SetTarget(Crewmateonly: true);
                     target.SetRoleRPC(RoleId.Dependents);
                     target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
                     RoleClass.Vampire.CreatedDependents = true;
@@ -153,7 +153,7 @@ namespace SuperNewRoles.Buttons
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Vampire && !RoleClass.Vampire.CreatedDependents; },
                 () =>
                 {
-                    return SetTarget(Crewmateonly:true) && PlayerControl.LocalPlayer.CanMove;
+                    return SetTarget(Crewmateonly: true) && PlayerControl.LocalPlayer.CanMove;
                 },
                 () =>
                 {
@@ -1238,13 +1238,19 @@ namespace SuperNewRoles.Buttons
                             {
                                 misfire = !Sheriff.IsChiefSheriffKill(Target);
                             }
+                            var AlwaysKill = !Sheriff.IsSheriffKill(Target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool();
+                            if (RoleClass.Chief.SheriffPlayer.Contains(LocalID))
+                            {
+                                AlwaysKill = !Sheriff.IsChiefSheriffKill(Target) && CustomOptionHolder.ChiefSheriffKillOpponentWhenMisfiring.GetBool();
+                            }
                             var TargetID = Target.PlayerId;
 
-                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire);
+                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, AlwaysKill);
                             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SheriffKill, SendOption.Reliable, -1);
                             killWriter.Write(LocalID);
                             killWriter.Write(TargetID);
                             killWriter.Write(misfire);
+                            killWriter.Write(AlwaysKill);
                             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.SheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.SheriffHauntedWolfKill : FinalStatus.SheriffKill));
                             Sheriff.ResetKillCooldown();

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1238,19 +1238,19 @@ namespace SuperNewRoles.Buttons
                             {
                                 misfire = !Sheriff.IsChiefSheriffKill(Target);
                             }
-                            var AlwaysKill = !Sheriff.IsSheriffKill(Target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool();
+                            var alwaysKill = !Sheriff.IsSheriffKill(Target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool();
                             if (RoleClass.Chief.SheriffPlayer.Contains(LocalID))
                             {
-                                AlwaysKill = !Sheriff.IsChiefSheriffKill(Target) && CustomOptionHolder.ChiefSheriffKillOpponentWhenMisfiring.GetBool();
+                                alwaysKill = !Sheriff.IsChiefSheriffKill(Target) && CustomOptionHolder.ChiefSheriffKillOpponentWhenMisfiring.GetBool();
                             }
                             var TargetID = Target.PlayerId;
 
-                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, AlwaysKill);
+                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, alwaysKill);
                             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SheriffKill, SendOption.Reliable, -1);
                             killWriter.Write(LocalID);
                             killWriter.Write(TargetID);
                             killWriter.Write(misfire);
-                            killWriter.Write(AlwaysKill);
+                            killWriter.Write(alwaysKill);
                             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.SheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.SheriffHauntedWolfKill : FinalStatus.SheriffKill));
                             Sheriff.ResetKillCooldown();

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1238,10 +1238,10 @@ namespace SuperNewRoles.Buttons
                             {
                                 misfire = !Sheriff.IsChiefSheriffKill(Target);
                             }
-                            var alwaysKill = !Sheriff.IsSheriffKill(Target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool();
+                            var alwaysKill = !Sheriff.IsSheriffKill(Target) && CustomOptionHolder.SheriffAlwaysKills.GetBool();
                             if (RoleClass.Chief.SheriffPlayer.Contains(LocalID))
                             {
-                                alwaysKill = !Sheriff.IsChiefSheriffKill(Target) && CustomOptionHolder.ChiefSheriffKillOpponentWhenMisfiring.GetBool();
+                                alwaysKill = !Sheriff.IsChiefSheriffKill(Target) && CustomOptionHolder.ChiefSheriffAlwaysKills.GetBool();
                             }
                             var TargetID = Target.PlayerId;
 

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -96,6 +96,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption SheriffCoolTime;
         public static CustomOption SheriffKillMaxCount;
         public static CustomOption SheriffCanKillImpostor;
+        public static CustomOption SheriffCanKillCrewmate;
         //=============================================
         public static CustomOption SheriffMadRoleKill;
         //シェリフマッドキル
@@ -113,6 +114,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption RemoteSheriffOption;
         public static CustomOption RemoteSheriffPlayerCount;
         public static CustomOption RemoteSheriffCoolTime;
+        public static CustomOption RemoteSheriffCanKillCrewmate;
         public static CustomOption RemoteSheriffMadRoleKill;
         public static CustomOption RemoteSheriffNeutralKill;
         public static CustomOption RemoteSheriffLoversKill;
@@ -121,6 +123,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomRoleOption MeetingSheriffOption;
         public static CustomOption MeetingSheriffPlayerCount;
+        public static CustomOption MeetingSheriffCanKillCrewmate;
         public static CustomOption MeetingSheriffMadRoleKill;
         public static CustomOption MeetingSheriffNeutralKill;
         public static CustomOption MeetingSheriffKillMaxCount;
@@ -615,6 +618,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption ChiefOption;
         public static CustomOption ChiefPlayerCount;
         public static CustomOption ChiefSheriffCoolTime;
+        public static CustomOption ChiefSheriffCanKillCrewmate;
         public static CustomOption ChiefSheriffCanKillNeutral;
         public static CustomOption ChiefSheriffCanKillLovers;
         public static CustomOption ChiefSheriffCanKillMadRole;
@@ -1060,6 +1064,7 @@ namespace SuperNewRoles.Modules
             SheriffCoolTime = Create(39, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
             SheriffKillMaxCount = Create(43, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
             SheriffCanKillImpostor = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
+            SheriffCanKillCrewmate = Create(732, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, SheriffOption);
             SheriffMadRoleKill = Create(42, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
             SheriffFriendsRoleKill = Create(708, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, SheriffOption);
             SheriffNeutralKill = Create(40, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
@@ -1069,6 +1074,7 @@ namespace SuperNewRoles.Modules
             RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
             RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
             RemoteSheriffCoolTime = Create(46, true, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
+            RemoteSheriffCanKillCrewmate = Create(733, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, RemoteSheriffOption);
             RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, RemoteSheriffOption);
             RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
             RemoteSheriffMadRoleKill = Create(49, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
@@ -1077,6 +1083,7 @@ namespace SuperNewRoles.Modules
 
             MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
             MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
+            MeetingSheriffCanKillCrewmate = Create(734, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, MeetingSheriffOption);
             MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
             MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
             MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
@@ -1504,6 +1511,7 @@ namespace SuperNewRoles.Modules
             ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
             ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
             ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
+            ChiefSheriffCanKillCrewmate = Create(732, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, ChiefOption);
             ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
             ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
             ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -615,10 +615,10 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption ChiefOption;
         public static CustomOption ChiefPlayerCount;
         public static CustomOption ChiefSheriffCoolTime;
-        public static CustomOption ChiefIsNeutralKill;
-        public static CustomOption ChiefIsLoversKill;
-        public static CustomOption ChiefIsMadRoleKill;
-        public static CustomOption ChiefKillLimit;
+        public static CustomOption ChiefSheriffCanKillNeutral;
+        public static CustomOption ChiefSheriffCanKillLovers;
+        public static CustomOption ChiefSheriffCanKillMadRole;
+        public static CustomOption ChiefSheriffKillLimit;
 
         public static CustomRoleOption CleanerOption;
         public static CustomOption CleanerPlayerCount;
@@ -895,7 +895,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption CamouflagerCamouflageQuarreled;
         public static CustomOption CamouflagerCamouflageChangeColor;
         public static CustomOption CamouflagerCamouflageColor;
-        
+
         public static CustomRoleOption CupidOption;
         public static CustomOption CupidPlayerCount;
         public static CustomOption CupidCoolTime;
@@ -906,16 +906,16 @@ namespace SuperNewRoles.Modules
         public static CustomOption HamburgerShopCommonTask;
         public static CustomOption HamburgerShopShortTask;
         public static CustomOption HamburgerShopLongTask;
-        
+
         public static CustomRoleOption PenguinOption;
         public static CustomOption PenguinPlayerCount;
         public static CustomOption PenguinCoolTime;
         public static CustomOption PenguinDurationTime;
         public static CustomOption PenguinCanDefaultKill;
-        
+
         public static CustomRoleOption DependentsOption;
         public static CustomOption DependentsPlayerCount;
-        
+
         //CustomOption
 
         public static CustomOption GMOption;
@@ -1504,10 +1504,10 @@ namespace SuperNewRoles.Modules
             ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
             ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
             ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
-            ChiefIsNeutralKill = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
-            ChiefIsLoversKill = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
-            ChiefIsMadRoleKill = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
-            ChiefKillLimit = Create(630, false, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, ChiefOption, format: "unitSeconds");
+            ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
+            ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
+            ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
+            ChiefSheriffKillLimit = Create(630, false, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, ChiefOption, format: "unitSeconds");
 
             CleanerOption = SetupCustomRoleOption(396, false, RoleId.Cleaner);
             CleanerPlayerCount = Create(397, false, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], CleanerOption);
@@ -1842,7 +1842,7 @@ namespace SuperNewRoles.Modules
             EvilGuesserPlayerCount = Create(974, false, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], EvilGuesserOption);
             EvilGuesserShortMaxCount = Create(975, false, CustomOptionType.Impostor, "EvilGuesserShortMaxCountSetting", 2f, 1f, 15f, 1f, EvilGuesserOption);
             EvilGuesserShortOneMeetingCount = Create(976, false, CustomOptionType.Impostor, "EvilGuesserOneMeetingShortSetting", true, EvilGuesserOption);
-            
+
             CupidOption = SetupCustomRoleOption(1079, false, RoleId.Cupid);
             CupidPlayerCount = Create(1080, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], CupidOption);
             CupidCoolTime = Create(1081, false, CustomOptionType.Neutral, "NiceScientistCoolDownSetting", 20f, 2.5f, 180f, 2.5f, CupidOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1083,7 +1083,7 @@ namespace SuperNewRoles.Modules
 
             MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
             MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
-            MeetingSheriffKillOpponentWhenMisfiring = Create(734, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, MeetingSheriffOption);
+            MeetingSheriffKillOpponentWhenMisfiring = Create(734, false, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, MeetingSheriffOption);
             MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
             MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
             MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -96,7 +96,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption SheriffCoolTime;
         public static CustomOption SheriffKillMaxCount;
         public static CustomOption SheriffCanKillImpostor;
-        public static CustomOption SheriffCommitsSuicideWhenHeMisfires;
+        public static CustomOption SheriffKillOpponentWhenMisfiring;
         //=============================================
         public static CustomOption SheriffMadRoleKill;
         //シェリフマッドキル
@@ -114,7 +114,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption RemoteSheriffOption;
         public static CustomOption RemoteSheriffPlayerCount;
         public static CustomOption RemoteSheriffCoolTime;
-        public static CustomOption RemoteSheriffCommitsSuicideWhenHeMisfires;
+        public static CustomOption RemoteSheriffKillOpponentWhenMisfiring;
         public static CustomOption RemoteSheriffMadRoleKill;
         public static CustomOption RemoteSheriffNeutralKill;
         public static CustomOption RemoteSheriffLoversKill;
@@ -123,7 +123,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomRoleOption MeetingSheriffOption;
         public static CustomOption MeetingSheriffPlayerCount;
-        public static CustomOption MeetingSheriffCommitsSuicideWhenHeMisfires;
+        public static CustomOption MeetingSheriffKillOpponentWhenMisfiring;
         public static CustomOption MeetingSheriffMadRoleKill;
         public static CustomOption MeetingSheriffNeutralKill;
         public static CustomOption MeetingSheriffKillMaxCount;
@@ -618,7 +618,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption ChiefOption;
         public static CustomOption ChiefPlayerCount;
         public static CustomOption ChiefSheriffCoolTime;
-        public static CustomOption ChiefSheriffCommitsSuicideWhenHeMisfires;
+        public static CustomOption ChiefSheriffKillOpponentWhenMisfiring;
         public static CustomOption ChiefSheriffCanKillNeutral;
         public static CustomOption ChiefSheriffCanKillLovers;
         public static CustomOption ChiefSheriffCanKillMadRole;
@@ -1064,7 +1064,7 @@ namespace SuperNewRoles.Modules
             SheriffCoolTime = Create(39, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
             SheriffKillMaxCount = Create(43, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
             SheriffCanKillImpostor = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
-            SheriffCommitsSuicideWhenHeMisfires = Create(732, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, SheriffOption);
+            SheriffKillOpponentWhenMisfiring = Create(732, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, SheriffOption);
             SheriffMadRoleKill = Create(42, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
             SheriffFriendsRoleKill = Create(708, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, SheriffOption);
             SheriffNeutralKill = Create(40, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
@@ -1074,7 +1074,7 @@ namespace SuperNewRoles.Modules
             RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
             RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
             RemoteSheriffCoolTime = Create(46, true, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
-            RemoteSheriffCommitsSuicideWhenHeMisfires = Create(733, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, RemoteSheriffOption);
+            RemoteSheriffKillOpponentWhenMisfiring = Create(733, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, RemoteSheriffOption);
             RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, RemoteSheriffOption);
             RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
             RemoteSheriffMadRoleKill = Create(49, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
@@ -1083,7 +1083,7 @@ namespace SuperNewRoles.Modules
 
             MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
             MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
-            MeetingSheriffCommitsSuicideWhenHeMisfires = Create(734, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, MeetingSheriffOption);
+            MeetingSheriffKillOpponentWhenMisfiring = Create(734, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, MeetingSheriffOption);
             MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
             MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
             MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
@@ -1511,7 +1511,7 @@ namespace SuperNewRoles.Modules
             ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
             ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
             ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
-            ChiefSheriffCommitsSuicideWhenHeMisfires = Create(732, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, ChiefOption);
+            ChiefSheriffKillOpponentWhenMisfiring = Create(732, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, ChiefOption);
             ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
             ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
             ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -96,7 +96,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption SheriffCoolTime;
         public static CustomOption SheriffKillMaxCount;
         public static CustomOption SheriffCanKillImpostor;
-        public static CustomOption SheriffCanKillCrewmate;
+        public static CustomOption SheriffCommitsSuicideWhenHeMisfires;
         //=============================================
         public static CustomOption SheriffMadRoleKill;
         //シェリフマッドキル
@@ -114,7 +114,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption RemoteSheriffOption;
         public static CustomOption RemoteSheriffPlayerCount;
         public static CustomOption RemoteSheriffCoolTime;
-        public static CustomOption RemoteSheriffCanKillCrewmate;
+        public static CustomOption RemoteSheriffCommitsSuicideWhenHeMisfires;
         public static CustomOption RemoteSheriffMadRoleKill;
         public static CustomOption RemoteSheriffNeutralKill;
         public static CustomOption RemoteSheriffLoversKill;
@@ -123,7 +123,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomRoleOption MeetingSheriffOption;
         public static CustomOption MeetingSheriffPlayerCount;
-        public static CustomOption MeetingSheriffCanKillCrewmate;
+        public static CustomOption MeetingSheriffCommitsSuicideWhenHeMisfires;
         public static CustomOption MeetingSheriffMadRoleKill;
         public static CustomOption MeetingSheriffNeutralKill;
         public static CustomOption MeetingSheriffKillMaxCount;
@@ -618,7 +618,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption ChiefOption;
         public static CustomOption ChiefPlayerCount;
         public static CustomOption ChiefSheriffCoolTime;
-        public static CustomOption ChiefSheriffCanKillCrewmate;
+        public static CustomOption ChiefSheriffCommitsSuicideWhenHeMisfires;
         public static CustomOption ChiefSheriffCanKillNeutral;
         public static CustomOption ChiefSheriffCanKillLovers;
         public static CustomOption ChiefSheriffCanKillMadRole;
@@ -1064,7 +1064,7 @@ namespace SuperNewRoles.Modules
             SheriffCoolTime = Create(39, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
             SheriffKillMaxCount = Create(43, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
             SheriffCanKillImpostor = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
-            SheriffCanKillCrewmate = Create(732, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, SheriffOption);
+            SheriffCommitsSuicideWhenHeMisfires = Create(732, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, SheriffOption);
             SheriffMadRoleKill = Create(42, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
             SheriffFriendsRoleKill = Create(708, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, SheriffOption);
             SheriffNeutralKill = Create(40, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
@@ -1074,7 +1074,7 @@ namespace SuperNewRoles.Modules
             RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
             RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
             RemoteSheriffCoolTime = Create(46, true, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
-            RemoteSheriffCanKillCrewmate = Create(733, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, RemoteSheriffOption);
+            RemoteSheriffCommitsSuicideWhenHeMisfires = Create(733, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, RemoteSheriffOption);
             RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, RemoteSheriffOption);
             RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
             RemoteSheriffMadRoleKill = Create(49, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
@@ -1083,7 +1083,7 @@ namespace SuperNewRoles.Modules
 
             MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
             MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
-            MeetingSheriffCanKillCrewmate = Create(734, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, MeetingSheriffOption);
+            MeetingSheriffCommitsSuicideWhenHeMisfires = Create(734, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, MeetingSheriffOption);
             MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
             MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
             MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
@@ -1511,7 +1511,7 @@ namespace SuperNewRoles.Modules
             ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
             ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
             ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
-            ChiefSheriffCanKillCrewmate = Create(732, true, CustomOptionType.Crewmate, "SheriffCanKillCrewmateSetting", false, ChiefOption);
+            ChiefSheriffCommitsSuicideWhenHeMisfires = Create(732, true, CustomOptionType.Crewmate, "SheriffCommitsSuicideWhenHeMisfires", false, ChiefOption);
             ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
             ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
             ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -96,7 +96,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption SheriffCoolTime;
         public static CustomOption SheriffKillMaxCount;
         public static CustomOption SheriffCanKillImpostor;
-        public static CustomOption SheriffKillOpponentWhenMisfiring;
+        public static CustomOption SheriffAlwaysKills;
         //=============================================
         public static CustomOption SheriffMadRoleKill;
         //シェリフマッドキル
@@ -114,7 +114,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption RemoteSheriffOption;
         public static CustomOption RemoteSheriffPlayerCount;
         public static CustomOption RemoteSheriffCoolTime;
-        public static CustomOption RemoteSheriffKillOpponentWhenMisfiring;
+        public static CustomOption RemoteSheriffAlwaysKills;
         public static CustomOption RemoteSheriffMadRoleKill;
         public static CustomOption RemoteSheriffNeutralKill;
         public static CustomOption RemoteSheriffLoversKill;
@@ -123,7 +123,7 @@ namespace SuperNewRoles.Modules
 
         public static CustomRoleOption MeetingSheriffOption;
         public static CustomOption MeetingSheriffPlayerCount;
-        public static CustomOption MeetingSheriffKillOpponentWhenMisfiring;
+        public static CustomOption MeetingSheriffAlwaysKills;
         public static CustomOption MeetingSheriffMadRoleKill;
         public static CustomOption MeetingSheriffNeutralKill;
         public static CustomOption MeetingSheriffKillMaxCount;
@@ -618,7 +618,7 @@ namespace SuperNewRoles.Modules
         public static CustomRoleOption ChiefOption;
         public static CustomOption ChiefPlayerCount;
         public static CustomOption ChiefSheriffCoolTime;
-        public static CustomOption ChiefSheriffKillOpponentWhenMisfiring;
+        public static CustomOption ChiefSheriffAlwaysKills;
         public static CustomOption ChiefSheriffCanKillNeutral;
         public static CustomOption ChiefSheriffCanKillLovers;
         public static CustomOption ChiefSheriffCanKillMadRole;
@@ -1064,7 +1064,7 @@ namespace SuperNewRoles.Modules
             SheriffCoolTime = Create(39, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
             SheriffKillMaxCount = Create(43, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
             SheriffCanKillImpostor = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
-            SheriffKillOpponentWhenMisfiring = Create(732, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, SheriffOption);
+            SheriffAlwaysKills = Create(732, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, SheriffOption);
             SheriffMadRoleKill = Create(42, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
             SheriffFriendsRoleKill = Create(708, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, SheriffOption);
             SheriffNeutralKill = Create(40, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
@@ -1074,7 +1074,7 @@ namespace SuperNewRoles.Modules
             RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
             RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
             RemoteSheriffCoolTime = Create(46, true, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
-            RemoteSheriffKillOpponentWhenMisfiring = Create(733, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, RemoteSheriffOption);
+            RemoteSheriffAlwaysKills = Create(733, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, RemoteSheriffOption);
             RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, RemoteSheriffOption);
             RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
             RemoteSheriffMadRoleKill = Create(49, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
@@ -1083,7 +1083,7 @@ namespace SuperNewRoles.Modules
 
             MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
             MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
-            MeetingSheriffKillOpponentWhenMisfiring = Create(734, false, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, MeetingSheriffOption);
+            MeetingSheriffAlwaysKills = Create(734, false, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, MeetingSheriffOption);
             MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
             MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
             MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
@@ -1511,7 +1511,7 @@ namespace SuperNewRoles.Modules
             ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
             ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
             ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
-            ChiefSheriffKillOpponentWhenMisfiring = Create(732, true, CustomOptionType.Crewmate, "SheriffKillOpponentWhenMisfiring", false, ChiefOption);
+            ChiefSheriffAlwaysKills = Create(732, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, ChiefOption);
             ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNewtralSetting", false, ChiefOption);
             ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
             ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -787,16 +787,19 @@ namespace SuperNewRoles.Modules
         public static void SetLovers(byte playerid1, byte playerid2)
             => RoleHelpers.SetLovers(ModHelpers.PlayerById(playerid1), ModHelpers.PlayerById(playerid2));
 
-        public static void SheriffKill(byte SheriffId, byte TargetId, bool MissFire)
+        public static void SheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool AlwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);
             PlayerControl target = ModHelpers.PlayerById(TargetId);
             if (sheriff == null || target == null) return;
 
-            if (MissFire)
+            if (AlwaysKill)
             {
-                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool()) target.MurderPlayer(target);
-                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool()) target.MurderPlayer(target);
+                sheriff.MurderPlayer(target);
+                sheriff.MurderPlayer(sheriff);
+            }
+            else if (MissFire)
+            {
                 sheriff.MurderPlayer(sheriff);
             }
             else
@@ -1252,7 +1255,7 @@ namespace SuperNewRoles.Modules
                             SetRole(reader.ReadByte(), reader.ReadByte());
                             break;
                         case CustomRPC.SheriffKill:
-                            SheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean());
+                            SheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean(), reader.ReadBoolean());
                             break;
                         case CustomRPC.MeetingSheriffKill:
                             MeetingSheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean());

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -796,6 +796,8 @@ namespace SuperNewRoles.Modules
             if (MissFire)
             {
                 sheriff.MurderPlayer(sheriff);
+                if(sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
+                else if(sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
             }
             else
             {

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -845,15 +845,15 @@ namespace SuperNewRoles.Modules
             }
             if (AlwaysKill)
             {
-                sheriff.Exiled();
-                if (PlayerControl.LocalPlayer == sheriff)
-                {
-                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, sheriff.Data);
-                }
                 target.Exiled();
                 if (PlayerControl.LocalPlayer == target)
                 {
                     FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, target.Data);
+                }
+                sheriff.Exiled();
+                if (PlayerControl.LocalPlayer == sheriff)
+                {
+                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, sheriff.Data);
                 }
             }
             else if (MissFire)

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -821,7 +821,7 @@ namespace SuperNewRoles.Modules
                 }
             }
         }
-        public static void MeetingSheriffKill(byte SheriffId, byte TargetId, bool MissFire)
+        public static void MeetingSheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool AlwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);
             PlayerControl target = ModHelpers.PlayerById(TargetId);
@@ -829,7 +829,11 @@ namespace SuperNewRoles.Modules
             if (sheriff == null || target == null) return;
             if (!PlayerControl.LocalPlayer.IsAlive())
             {
-                FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, sheriff.name + "は" + target.name + "をシェリフキルした！");
+                FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, $"{sheriff.name} は {target.name} をシェリフキルした！");
+                if (AlwaysKill)
+                {
+                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, $"{target.name} をキルしたが誤射だった! {sheriff.name} は自責の念で自害した!");
+                }
                 if (MissFire)
                 {
                     FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, sheriff.name + "は誤爆した！");
@@ -839,7 +843,20 @@ namespace SuperNewRoles.Modules
                     FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, sheriff.name + "は成功した！");
                 }
             }
-            if (MissFire)
+            if (AlwaysKill)
+            {
+                sheriff.Exiled();
+                if (PlayerControl.LocalPlayer == sheriff)
+                {
+                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, sheriff.Data);
+                }
+                target.Exiled();
+                if (PlayerControl.LocalPlayer == target)
+                {
+                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, target.Data);
+                }
+            }
+            else if (MissFire)
             {
                 sheriff.Exiled();
                 if (PlayerControl.LocalPlayer == sheriff)
@@ -852,7 +869,7 @@ namespace SuperNewRoles.Modules
                 target.Exiled();
                 if (PlayerControl.LocalPlayer == target)
                 {
-                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(target.Data, sheriff.Data);
+                    FastDestroyableSingleton<HudManager>.Instance.KillOverlay.ShowKillAnimation(sheriff.Data, target.Data);
                 }
             }
             if (MeetingHud.Instance)
@@ -1258,7 +1275,7 @@ namespace SuperNewRoles.Modules
                             SheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean(), reader.ReadBoolean());
                             break;
                         case CustomRPC.MeetingSheriffKill:
-                            MeetingSheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean());
+                            MeetingSheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean(), reader.ReadBoolean());
                             break;
                         case CustomRPC.CustomRPCKill:
                             CustomRPCKill(reader.ReadByte(), reader.ReadByte());

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -787,6 +787,13 @@ namespace SuperNewRoles.Modules
         public static void SetLovers(byte playerid1, byte playerid2)
             => RoleHelpers.SetLovers(ModHelpers.PlayerById(playerid1), ModHelpers.PlayerById(playerid2));
 
+        /// <summary>
+        /// Sheriffのキルを制御
+        /// </summary>
+        /// <param name="SheriffId">SheriffのPlayerId</param>
+        /// <param name="TargetId">Sheriffのターゲットにされた人のPlayerId</param>
+        /// <param name="MissFire">誤爆したか</param>
+        /// <param name="alwaysKill">誤爆していて尚且つ誤爆時も対象を殺す設定が有効か</param>
         public static void SheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool alwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);
@@ -821,6 +828,14 @@ namespace SuperNewRoles.Modules
                 }
             }
         }
+
+        /// <summary>
+        /// MeetingSheriffのキルを制御
+        /// </summary>
+        /// <param name="SheriffId">SheriffのPlayerId</param>
+        /// <param name="TargetId">Sheriffのターゲットにされた人のPlayerId</param>
+        /// <param name="MissFire">誤爆したか</param>
+        /// <param name="alwaysKill">誤爆していて尚且つ誤爆時も対象を殺す設定が有効か</param>
         public static void MeetingSheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool alwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -795,8 +795,8 @@ namespace SuperNewRoles.Modules
 
             if (MissFire)
             {
-                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
-                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
+                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCommitsSuicideWhenHeMisfires.GetBool()) target.MurderPlayer(target);
+                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCommitsSuicideWhenHeMisfires.GetBool()) target.MurderPlayer(target);
                 sheriff.MurderPlayer(sheriff);
             }
             else

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -881,6 +881,11 @@ namespace SuperNewRoles.Modules
                         pva.SetDead(pva.DidReport, true);
                         pva.Overlay.gameObject.SetActive(true);
                     }
+                    else if (pva.TargetPlayerId == TargetId && AlwaysKill)
+                    {
+                        pva.SetDead(pva.DidReport, true);
+                        pva.Overlay.gameObject.SetActive(true);
+                    }
                     else if (pva.TargetPlayerId == TargetId && !MissFire)
                     {
                         pva.SetDead(pva.DidReport, true);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -795,9 +795,9 @@ namespace SuperNewRoles.Modules
 
             if (MissFire)
             {
+                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
+                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
                 sheriff.MurderPlayer(sheriff);
-                if(sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
-                else if(sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCanKillCrewmate.GetBool()) target.MurderPlayer(target);
             }
             else
             {

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -787,13 +787,13 @@ namespace SuperNewRoles.Modules
         public static void SetLovers(byte playerid1, byte playerid2)
             => RoleHelpers.SetLovers(ModHelpers.PlayerById(playerid1), ModHelpers.PlayerById(playerid2));
 
-        public static void SheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool AlwaysKill)
+        public static void SheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool alwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);
             PlayerControl target = ModHelpers.PlayerById(TargetId);
             if (sheriff == null || target == null) return;
 
-            if (AlwaysKill)
+            if (alwaysKill)
             {
                 sheriff.MurderPlayer(target);
                 sheriff.MurderPlayer(sheriff);
@@ -821,7 +821,7 @@ namespace SuperNewRoles.Modules
                 }
             }
         }
-        public static void MeetingSheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool AlwaysKill)
+        public static void MeetingSheriffKill(byte SheriffId, byte TargetId, bool MissFire, bool alwaysKill)
         {
             PlayerControl sheriff = ModHelpers.PlayerById(SheriffId);
             PlayerControl target = ModHelpers.PlayerById(TargetId);
@@ -830,7 +830,7 @@ namespace SuperNewRoles.Modules
             if (!PlayerControl.LocalPlayer.IsAlive())
             {
                 FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat1"), target.name, sheriff.name));
-                if (AlwaysKill)
+                if (alwaysKill)
                 {
                     FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat2"), target.name, sheriff.name));
                 }
@@ -843,7 +843,7 @@ namespace SuperNewRoles.Modules
                     FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat4"), sheriff.name));
                 }
             }
-            if (AlwaysKill)
+            if (alwaysKill)
             {
                 target.Exiled();
                 if (PlayerControl.LocalPlayer == target)
@@ -881,7 +881,7 @@ namespace SuperNewRoles.Modules
                         pva.SetDead(pva.DidReport, true);
                         pva.Overlay.gameObject.SetActive(true);
                     }
-                    else if (pva.TargetPlayerId == TargetId && AlwaysKill)
+                    else if (pva.TargetPlayerId == TargetId && alwaysKill)
                     {
                         pva.SetDead(pva.DidReport, true);
                         pva.Overlay.gameObject.SetActive(true);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -829,18 +829,18 @@ namespace SuperNewRoles.Modules
             if (sheriff == null || target == null) return;
             if (!PlayerControl.LocalPlayer.IsAlive())
             {
-                FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, $"{sheriff.name} は {target.name} をシェリフキルした！");
+                FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat1"), target.name, sheriff.name));
                 if (AlwaysKill)
                 {
-                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, $"{target.name} をキルしたが誤射だった! {sheriff.name} は自責の念で自害した!");
+                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat2"), target.name, sheriff.name));
                 }
                 if (MissFire)
                 {
-                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, sheriff.name + "は誤爆した！");
+                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat3"), sheriff.name));
                 }
                 else
                 {
-                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, sheriff.name + "は成功した！");
+                    FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(sheriff, string.Format(ModTranslation.GetString("MeetingSheriffkillChat4"), sheriff.name));
                 }
             }
             if (AlwaysKill)

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -795,8 +795,8 @@ namespace SuperNewRoles.Modules
 
             if (MissFire)
             {
-                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffCommitsSuicideWhenHeMisfires.GetBool()) target.MurderPlayer(target);
-                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffCommitsSuicideWhenHeMisfires.GetBool()) target.MurderPlayer(target);
+                if (sheriff.IsRole(RoleId.Sheriff) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool()) target.MurderPlayer(target);
+                else if (sheriff.IsRole(RoleId.RemoteSheriff) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool()) target.MurderPlayer(target);
                 sheriff.MurderPlayer(sheriff);
             }
             else

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -309,16 +309,18 @@ namespace SuperNewRoles.Patches
                         {
                             var Target = player;
                             var misfire = !Sheriff.IsRemoteSheriffKill(Target);
+                            var AlwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool();
                             var TargetID = Target.PlayerId;
                             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
                             PlayerControl.LocalPlayer.RpcShapeshift(PlayerControl.LocalPlayer, true);
 
-                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire);
+                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, AlwaysKill);
                             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SheriffKill, SendOption.Reliable, -1);
                             killWriter.Write(LocalID);
                             killWriter.Write(TargetID);
                             killWriter.Write(misfire);
+                            killWriter.Write(AlwaysKill);
                             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.RemoteSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill));
                             RoleClass.RemoteSheriff.KillMaxCount--;

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -93,7 +93,7 @@ namespace SuperNewRoles.Patches
                         if (target.IsDead()) return true;
                         if (!RoleClass.RemoteSheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.RemoteSheriff.KillCount[__instance.PlayerId] >= 1)
                         {
-                            if ((!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool())
+                            if ((!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool())
                             {
                                 FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
                                 __instance.RpcMurderPlayerCheck(target);
@@ -316,7 +316,7 @@ namespace SuperNewRoles.Patches
                         {
                             var Target = player;
                             var misfire = !Sheriff.IsRemoteSheriffKill(Target);
-                            var alwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool();
+                            var alwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool();
                             var TargetID = Target.PlayerId;
                             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
@@ -525,7 +525,7 @@ namespace SuperNewRoles.Patches
                         case RoleId.Sheriff:
                             if (!RoleClass.Sheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.Sheriff.KillCount[__instance.PlayerId] >= 1)
                             {
-                                if (!Sheriff.IsSheriffKill(target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool())
+                                if (!Sheriff.IsSheriffKill(target) && CustomOptionHolder.SheriffAlwaysKills.GetBool())
                                 {
                                     FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
                                     __instance.RpcMurderPlayerCheck(target);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -93,7 +93,17 @@ namespace SuperNewRoles.Patches
                         if (target.IsDead()) return true;
                         if (!RoleClass.RemoteSheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.RemoteSheriff.KillCount[__instance.PlayerId] >= 1)
                         {
-                            if (!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff))
+                            if ((!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool())
+                            {
+                                FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
+                                __instance.RpcMurderPlayerCheck(target);
+                                FinalStatusClass.RpcSetFinalStatus(target, target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill);
+                                FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
+                                __instance.RpcMurderPlayer(__instance);
+                                FinalStatusClass.RpcSetFinalStatus(__instance, FinalStatus.RemoteSheriffMisFire);
+                                return true;
+                            }
+                            else if (!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff))
                             {
                                 FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                                 __instance.RpcMurderPlayer(__instance);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -316,18 +316,18 @@ namespace SuperNewRoles.Patches
                         {
                             var Target = player;
                             var misfire = !Sheriff.IsRemoteSheriffKill(Target);
-                            var AlwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool();
+                            var alwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffKillOpponentWhenMisfiring.GetBool();
                             var TargetID = Target.PlayerId;
                             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
                             PlayerControl.LocalPlayer.RpcShapeshift(PlayerControl.LocalPlayer, true);
 
-                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, AlwaysKill);
+                            RPCProcedure.SheriffKill(LocalID, TargetID, misfire, alwaysKill);
                             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.SheriffKill, SendOption.Reliable, -1);
                             killWriter.Write(LocalID);
                             killWriter.Write(TargetID);
                             killWriter.Write(misfire);
-                            killWriter.Write(AlwaysKill);
+                            killWriter.Write(alwaysKill);
                             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.RemoteSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill));
                             RoleClass.RemoteSheriff.KillMaxCount--;

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -95,31 +95,28 @@ namespace SuperNewRoles.Patches
                         {
                             if (!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff))
                             {
-                                if (!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff))
-                                {
-                                    FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
-                                    __instance.RpcMurderPlayer(__instance);
-                                    FinalStatusClass.RpcSetFinalStatus(__instance, FinalStatus.RemoteSheriffMisFire);
-                                    return true;
-                                }
+                                FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
+                                __instance.RpcMurderPlayer(__instance);
+                                FinalStatusClass.RpcSetFinalStatus(__instance, FinalStatus.RemoteSheriffMisFire);
+                                return true;
+                            }
+                            else
+                            {
+                                FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
+                                if (RoleClass.RemoteSheriff.KillCount.ContainsKey(__instance.PlayerId))
+                                    RoleClass.RemoteSheriff.KillCount[__instance.PlayerId]--;
+                                else
+                                    RoleClass.RemoteSheriff.KillCount[__instance.PlayerId] = CustomOptionHolder.RemoteSheriffKillMaxCount.GetInt() - 1;
+                                if (RoleClass.RemoteSheriff.IsKillTeleport)
+                                    __instance.RpcMurderPlayerCheck(target);
                                 else
                                 {
-                                    FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
-                                    if (RoleClass.RemoteSheriff.KillCount.ContainsKey(__instance.PlayerId))
-                                        RoleClass.RemoteSheriff.KillCount[__instance.PlayerId]--;
-                                    else
-                                        RoleClass.RemoteSheriff.KillCount[__instance.PlayerId] = CustomOptionHolder.RemoteSheriffKillMaxCount.GetInt() - 1;
-                                    if (RoleClass.RemoteSheriff.IsKillTeleport)
-                                        __instance.RpcMurderPlayerCheck(target);
-                                    else
-                                    {
-                                        target.RpcMurderPlayer(target);
-                                        __instance.RpcShowGuardEffect(__instance);
-                                    }
-                                    FinalStatusClass.RpcSetFinalStatus(target, target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill);
-                                    Mode.SuperHostRoles.FixedUpdate.SetRoleName(__instance);
-                                    return true;
+                                    target.RpcMurderPlayer(target);
+                                    __instance.RpcShowGuardEffect(__instance);
                                 }
+                                FinalStatusClass.RpcSetFinalStatus(target, target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill);
+                                Mode.SuperHostRoles.FixedUpdate.SetRoleName(__instance);
+                                return true;
                             }
                         }
                         return true;

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -518,7 +518,17 @@ namespace SuperNewRoles.Patches
                         case RoleId.Sheriff:
                             if (!RoleClass.Sheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.Sheriff.KillCount[__instance.PlayerId] >= 1)
                             {
-                                if (!Sheriff.IsSheriffKill(target))
+                                if (!Sheriff.IsSheriffKill(target) && CustomOptionHolder.SheriffKillOpponentWhenMisfiring.GetBool())
+                                {
+                                    FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
+                                    __instance.RpcMurderPlayerCheck(target);
+                                    if (target.IsRole(RoleId.HauntedWolf)) __instance.RpcSetFinalStatus(FinalStatus.SheriffHauntedWolfKill);
+                                    else __instance.RpcSetFinalStatus(FinalStatus.SheriffKill);
+                                    FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
+                                    __instance.RpcMurderPlayer(__instance);
+                                    __instance.RpcSetFinalStatus(FinalStatus.SheriffMisFire);
+                                }
+                                else if (!Sheriff.IsSheriffKill(target))
                                 {
                                     FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                                     __instance.RpcMurderPlayer(__instance);

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -357,7 +357,7 @@ SheriffIsKillNeutralSetting,Can kill neutrala,第三陣営をキルできる,可
 SheriffIsKillLoversSetting,Can kill lovers,ラバーズをキルできる,可以击杀恋人
 SheriffIsKillMadRoleSetting,Can kill mad roles,マッド系をキルできる,可以击杀叛徒系职业
 SheriffIsKillImpostorSetting,Can kill impostors,インポスターをキルできる,可以击杀内鬼
-SheriffCanKillCrewmateSetting,,クルーメイトをキルして自殺する
+SheriffCommitsSuicideWhenHeMisfires,Suicide when misfiring.,誤射した時自殺する
 SheriffIsKillFriendsRoleSetting,Can kill jackal friend roles,ジャッカルフレンズ系をキルできる,可以击杀狈系职业
 SheriffIsKillQuarreledSetting,Can kill quarreleds,クラードをキルできる,可以击杀福音天使
 SheriffYes,Yes,できる,是

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -357,7 +357,7 @@ SheriffIsKillNeutralSetting,Can kill neutrala,第三陣営をキルできる,可
 SheriffIsKillLoversSetting,Can kill lovers,ラバーズをキルできる,可以击杀恋人
 SheriffIsKillMadRoleSetting,Can kill mad roles,マッド系をキルできる,可以击杀叛徒系职业
 SheriffIsKillImpostorSetting,Can kill impostors,インポスターをキルできる,可以击杀内鬼
-SheriffKillOpponentWhenMisfiring,Killing a target even when it is misfiring.,誤射した時も対象を殺す
+SheriffAlwaysKills,Killing a target even when it is misfiring.,誤射した時も対象を殺す
 SheriffIsKillFriendsRoleSetting,Can kill jackal friend roles,ジャッカルフレンズ系をキルできる,可以击杀狈系职业
 SheriffIsKillQuarreledSetting,Can kill quarreleds,クラードをキルできる,可以击杀福音天使
 SheriffYes,Yes,できる,是

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -357,6 +357,7 @@ SheriffIsKillNeutralSetting,Can kill neutrala,第三陣営をキルできる,可
 SheriffIsKillLoversSetting,Can kill lovers,ラバーズをキルできる,可以击杀恋人
 SheriffIsKillMadRoleSetting,Can kill mad roles,マッド系をキルできる,可以击杀叛徒系职业
 SheriffIsKillImpostorSetting,Can kill impostors,インポスターをキルできる,可以击杀内鬼
+SheriffCanKillCrewmateSetting,,クルーメイトをキルして自殺する
 SheriffIsKillFriendsRoleSetting,Can kill jackal friend roles,ジャッカルフレンズ系をキルできる,可以击杀狈系职业
 SheriffIsKillQuarreledSetting,Can kill quarreleds,クラードをキルできる,可以击杀福音天使
 SheriffYes,Yes,できる,是

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -357,7 +357,7 @@ SheriffIsKillNeutralSetting,Can kill neutrala,第三陣営をキルできる,可
 SheriffIsKillLoversSetting,Can kill lovers,ラバーズをキルできる,可以击杀恋人
 SheriffIsKillMadRoleSetting,Can kill mad roles,マッド系をキルできる,可以击杀叛徒系职业
 SheriffIsKillImpostorSetting,Can kill impostors,インポスターをキルできる,可以击杀内鬼
-SheriffCommitsSuicideWhenHeMisfires,Suicide when misfiring.,誤射した時自殺する
+SheriffKillOpponentWhenMisfiring,Killing a target even when it is misfiring.,誤射した時も対象を殺す
 SheriffIsKillFriendsRoleSetting,Can kill jackal friend roles,ジャッカルフレンズ系をキルできる,可以击杀狈系职业
 SheriffIsKillQuarreledSetting,Can kill quarreleds,クラードをキルできる,可以击杀福音天使
 SheriffYes,Yes,できる,是

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -376,6 +376,10 @@ MeetingSheriffYes,Yes,できる,是
 MeetingSheriffNo,No,できない,否
 MeetingSheriffMaxKillCountSetting,Maximum number of Meeting Sheriff kills,ミーティングシェリフの最大キル数,执法官最大可击杀次数
 MeetingSheriffMeetingmultipleKillSetting,Can you get multiple kills in one meeting?,一会議中に複数キルできるか,执法官可以在一次会议中多次击杀
+MeetingSheriffkillChat1,{0} has sheriffkilled {1}!,{0} は {1} をシェリフキルした！
+MeetingSheriffkillChat2,{0} was killed，but it was a misfire! {1} killed himself in remorse!,{0} をキルしたが誤射だった! {1} は自責の念で自害した!
+MeetingSheriffkillChat3,{0} was a misfire!,{0} は誤爆した！
+MeetingSheriffkillChat4,{0} succeeded!,{0} は成功した！
 JackalName,Jackal,ジャッカル,豺狼
 JackalTitle1,Try to kill Impostors and Crewmates,インポスターとクルーメイトをキルしよう,杀死所有船员和内鬼
 JackalTitle2,Kill the other team to win!,他陣営をキルして勝利しよう,把其他人全部杀死获得胜利

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -105,17 +105,17 @@ namespace SuperNewRoles.Roles
         {
             var Target = ModHelpers.PlayerById(__instance.playerStates[Index].TargetPlayerId);
             var misfire = !IsMeetingSheriffKill(Target);
-            var AlwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffKillOpponentWhenMisfiring.GetBool();
+            var alwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffKillOpponentWhenMisfiring.GetBool();
             var TargetID = Target.PlayerId;
             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
-            RPCProcedure.MeetingSheriffKill(LocalID, TargetID, misfire, AlwaysKill);
+            RPCProcedure.MeetingSheriffKill(LocalID, TargetID, misfire, alwaysKill);
 
             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.MeetingSheriffKill, SendOption.Reliable, -1);
             killWriter.Write(LocalID);
             killWriter.Write(TargetID);
             killWriter.Write(misfire);
-            killWriter.Write(AlwaysKill);
+            killWriter.Write(alwaysKill);
             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.MeetingSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.MeetingSheriffHauntedWolfKill : FinalStatus.MeetingSheriffKill));
             RoleClass.MeetingSheriff.KillMaxCount--;

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -105,7 +105,7 @@ namespace SuperNewRoles.Roles
         {
             var Target = ModHelpers.PlayerById(__instance.playerStates[Index].TargetPlayerId);
             var misfire = !IsMeetingSheriffKill(Target);
-            var alwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffKillOpponentWhenMisfiring.GetBool();
+            var alwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffAlwaysKills.GetBool();
             var TargetID = Target.PlayerId;
             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -105,15 +105,17 @@ namespace SuperNewRoles.Roles
         {
             var Target = ModHelpers.PlayerById(__instance.playerStates[Index].TargetPlayerId);
             var misfire = !IsMeetingSheriffKill(Target);
+            var AlwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffKillOpponentWhenMisfiring.GetBool();
             var TargetID = Target.PlayerId;
             var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
-            RPCProcedure.MeetingSheriffKill(LocalID, TargetID, misfire);
+            RPCProcedure.MeetingSheriffKill(LocalID, TargetID, misfire, AlwaysKill);
 
             MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.MeetingSheriffKill, SendOption.Reliable, -1);
             killWriter.Write(LocalID);
             killWriter.Write(TargetID);
             killWriter.Write(misfire);
+            killWriter.Write(AlwaysKill);
             AmongUsClient.Instance.FinishRpcImmediately(killWriter);
             FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.MeetingSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.MeetingSheriffHauntedWolfKill : FinalStatus.MeetingSheriffKill));
             RoleClass.MeetingSheriff.KillMaxCount--;

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -1899,10 +1899,10 @@ namespace SuperNewRoles.Roles
                 NoTaskSheriffPlayer = new();
                 IsCreateSheriff = false;
                 CoolTime = CustomOptionHolder.ChiefSheriffCoolTime.GetFloat();
-                IsNeutralKill = CustomOptionHolder.ChiefIsNeutralKill.GetBool();
-                IsLoversKill = CustomOptionHolder.ChiefIsLoversKill.GetBool();
-                IsMadRoleKill = CustomOptionHolder.ChiefIsMadRoleKill.GetBool();
-                KillLimit = CustomOptionHolder.ChiefKillLimit.GetInt();
+                IsNeutralKill = CustomOptionHolder.ChiefSheriffCanKillNeutral.GetBool();
+                IsLoversKill = CustomOptionHolder.ChiefSheriffCanKillLovers.GetBool();
+                IsMadRoleKill = CustomOptionHolder.ChiefSheriffCanKillMadRole.GetBool();
+                KillLimit = CustomOptionHolder.ChiefSheriffKillLimit.GetInt();
             }
         }
         public static class Cleaner


### PR DESCRIPTION
# [追加点]
- シェリフ系役職が誤爆時対象を殺す設定を追加


# [修正点]
- ChiefIs～KillをChiefSheriffCanKill～に変更
- ミィーティングシェリフの修正
    - キルアニメーションが、対象を殺すのではなく、対象にシェリフが殺されていた問題を修正
- リモートシェリフの修正
    - 対象がキル可能陣営だった場合ワープが発生するorその場でシェイプシフトするだけで対象をキルできなかった問題を修正