### PR TITLE
フリーターバグ修正

### DIFF
--- a/SuperNewRoles/Roles/Neutral/PartTimer.cs
+++ b/SuperNewRoles/Roles/Neutral/PartTimer.cs
@@ -11,7 +11,11 @@ namespace SuperNewRoles.Roles.Neutral
         {
             foreach (var data in RoleClass.PartTimer.PlayerData)
             {
-                if (data.Value.IsDead())
+                if (!data.Key.IsRole(RoleId.PartTimer))
+                {
+                    RoleClass.PartTimer.Data.Remove(data.Key.PlayerId);
+                }
+                else if (data.Value.IsDead())
                 {
                     if (data.Key.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
                     {


### PR DESCRIPTION
フリーターの役職が変更された際、就職先のプレイヤーが元フリーターの役職を視認できてしまう問題を修正