### PR TITLE
廃村のlogのコードに無駄があった問題を修正&廃村処理を選べるように変更

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -53,6 +53,8 @@ namespace SuperNewRoles.Modules
 
         public static CustomOption IsChangeTheWinCondition;
 
+        public static CustomOption IsChangeHaisonReason;
+
         public static CustomOption DetectiveRate;
         public static CustomOption DetectivePlayerCount;
 
@@ -1023,6 +1025,8 @@ namespace SuperNewRoles.Modules
             IsAlwaysReduceCooldownExceptOnTask = Create(684, false, CustomOptionType.Generic, "IsAlwaysReduceCooldownExceptOnTask", true, IsAlwaysReduceCooldown);
 
             IsChangeTheWinCondition = Create(1005, true, CustomOptionType.Generic, "IsChangeTheWinCondition", true, null, isHeader: true);
+
+            IsChangeHaisonReason = Create(1005, true, CustomOptionType.Generic, "IsChangeHaisonReason", false, null, isHeader: true);
 
             MadRolesCanFixComms = Create(984, true, CustomOptionType.Crewmate, "MadRolesCanFixComms", false, null);
             MadRolesCanFixElectrical = Create(985, true, CustomOptionType.Crewmate, "MadRolesCanFixElectrical", false, null);

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -49,13 +49,13 @@ namespace SuperNewRoles.Patches
                     RPCProcedure.SetHaison();
                     if (ModeHandler.IsMode(ModeId.SuperHostRoles))
                     {
-                        if (CustomOptionHolder.IsChangeHaisonReason.GetBool()) EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.HumansByTask, false);
-                        else  EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
+                        if (!CustomOptionHolder.IsChangeHaisonReason.GetBool()) EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
+                        else  EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.HumansByTask, false);
                     }
                     else
                     {
-                        if (CustomOptionHolder.IsChangeHaisonReason.GetBool()) ShipStatus.RpcEndGame(GameOverReason.HumansByTask, false);
-                        else ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
+                        if (!CustomOptionHolder.IsChangeHaisonReason.GetBool()) ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
+                        else ShipStatus.RpcEndGame(GameOverReason.HumansByTask, false);
                         MapUtilities.CachedShipStatus.enabled = false;
                     }
                     Logger.Info("===================== 廃村 ======================", "End Game");

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -49,11 +49,13 @@ namespace SuperNewRoles.Patches
                     RPCProcedure.SetHaison();
                     if (ModeHandler.IsMode(ModeId.SuperHostRoles))
                     {
-                        EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
+                        if (CustomOptionHolder.IsChangeHaisonReason.GetBool()) EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.HumansByTask, false);
+                        else  EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
                     }
                     else
                     {
-                        ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
+                        if (CustomOptionHolder.IsChangeHaisonReason.GetBool()) ShipStatus.RpcEndGame(GameOverReason.HumansByTask, false);
+                        else ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
                         MapUtilities.CachedShipStatus.enabled = false;
                     }
                     Logger.Info("===================== 廃村 ======================", "End Game");

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -49,13 +49,13 @@ namespace SuperNewRoles.Patches
                     RPCProcedure.SetHaison();
                     if (ModeHandler.IsMode(ModeId.SuperHostRoles))
                     {
-                        Logger.Info("===================== Haison =====================", "End Game");
+                        Logger.Info("===================== 廃村 ======================", "End Game");
                         EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
 
                     }
                     else
                     {
-                        Logger.Info("===================== Haison =====================", "End Game");
+                        Logger.Info("===================== 廃村 =====================", "End Game");
                         ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
                         MapUtilities.CachedShipStatus.enabled = false;
                     }

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -49,16 +49,14 @@ namespace SuperNewRoles.Patches
                     RPCProcedure.SetHaison();
                     if (ModeHandler.IsMode(ModeId.SuperHostRoles))
                     {
-                        Logger.Info("===================== 廃村 ======================", "End Game");
                         EndGameCheck.CustomEndGame(ShipStatus.Instance, GameOverReason.ImpostorDisconnect, false);
-
                     }
                     else
                     {
-                        Logger.Info("===================== 廃村 =====================", "End Game");
                         ShipStatus.RpcEndGame(GameOverReason.ImpostorDisconnect, false);
                         MapUtilities.CachedShipStatus.enabled = false;
                     }
+                    Logger.Info("===================== 廃村 ======================", "End Game");
                 }
             }
 

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -32,7 +32,7 @@ vanillaOptionsText,VanillaOptions,バニラの設定,原版设置
 creditsUpdateOk,There is updated data. Please reboot. Latest Version:v{0},更新データがあります。再起動してください。最新バージョン:v{0},发现新版本。 请重新启动。 最新版本:v{0}
 modOptionsText,Options,設定,设置
 moreOptionsText,Normal Setting&<color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color> Settings,通常設定&<color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color>の設定,一般设置与&<color=#ffa500>Super</color><color=#ff0000>New</color><color=#00ff00>Roles</color>设置
-HaisonName,Haison,廃村,解散游戏
+HaisonName,Called Game,廃村,解散游戏
 Developer,Developer,開発者,开发者
 Sponsor,Sponsor,スポンサー,支持者
 Translator,Translator,翻訳,翻译

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -185,6 +185,7 @@ IsAlwaysReduceCooldown,Reduce Cooldown,常にキルクールタイムが進む,�
 IsAlwaysReduceCooldownExceptInVent,Reduce Cooldown Except InVent,ベント内でも進む,击杀冷却会在进入管道期间停止计算
 IsAlwaysReduceCooldownExceptOnTask,Reduce Cooldown Except OnTask,停電修理中でも進む,击杀冷却会在修理紧急任务时停止计算
 IsChangeTheWinCondition,Change the win condition,勝利条件を変更する,胜利条件变更
+IsChangeHaisonReason,Change the sound and screen when a match called off the game.,廃村時の音及び非導入社視点の画面を変更する
 DisconnectNotPC,Kick non-PCs.,PC以外をキックする,踢出非电脑端玩家
 WireTaskIsRandom,Wire task random,配線タスクランダム,随机分配修复配线的任务地点
 WireTaskNum,Wire task num,配線タスク数,修复配线任务总数


### PR DESCRIPTION
# [メモ]
- ``GameOverReason.ImpostorDisconnect``不評で悲しい…('・ω・`)
- 音が良いだけでなく、バニラ目線で廃村と何らかの勝利条件が満たされている事の違いが分かりやすくていいと思うんですけどね…

# [変更点]
- 廃村log変更
    - 文面の変更
        - 探しにくい上に、見た目もあまり良くなかった為変更した。
        - 「= Haison =」を「= 廃村 =」に

    - logのコードが1つで良かったのにも関わらず2つあった為、{}から出して1つにした。

- 廃村の英訳変更
    - HaisonからCalled Gameに変更した
    - ただし変数名は変えていない

- 廃村の処理方法を変更する設定を追加
    - デフォルト設定は``ImpostorDisconnect``
    - 設定を有効にすると``HumansByTask``に変更される

