### PR TITLE
会議判定が正常に動作していない問題を修正

### DIFF
--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -109,6 +109,7 @@ namespace SuperNewRoles.Patches
             if (PlayerControl.LocalPlayer.IsRole(RoleId.Painter)) Roles.Crewmate.Painter.WrapUp();
             Roles.Neutral.Photographer.WrapUp();
             Roles.Impostor.Cracker.WrapUp();
+            RoleClass.IsMeeting = false;
             if (exiled == null) return;
             SoothSayer_Patch.WrapUp(exiled.Object);
             Seer.ExileControllerWrapUpPatch.WrapUpPostfix();
@@ -181,7 +182,6 @@ namespace SuperNewRoles.Patches
                 }
             }
             Mode.SuperHostRoles.Main.RealExiled = null;
-            RoleClass.IsMeeting = false;
         }
     }
 }


### PR DESCRIPTION
追放者がいないと会議判定が無効にならない問題を修正