### PR TITLE
JackalとJackalSeerのボタンリセットを分離した&SKCoolを個別設定にした

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -958,7 +958,6 @@ namespace SuperNewRoles.Buttons
                             RPCProcedure.CreateSidekick(target.PlayerId, isFakeSidekick);
                         }
                         RoleClass.Jackal.CanCreateSidekick = false;
-                        Jackal.ResetCooldown();
                     }
                 },
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Jackal && ModeHandler.IsMode(ModeId.Default) && RoleClass.Jackal.CanCreateSidekick && CustomOptionHolder.JackalCreateSidekick.GetBool(); },
@@ -996,7 +995,6 @@ namespace SuperNewRoles.Buttons
                         AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                         RPCProcedure.CreateSidekickSeer(target.PlayerId, IsFakeSidekickSeer);
                         RoleClass.JackalSeer.CanCreateSidekick = false;
-                        JackalSeer.ResetCooldown();
                     }
                 },
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.JackalSeer && ModeHandler.IsMode(ModeId.Default) && RoleClass.JackalSeer.CanCreateSidekick && CustomOptionHolder.JackalSeerCreateSidekick.GetBool(); },

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -140,6 +140,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption JackalIsImpostorLight;
         public static CustomOption JackalCreateFriend;
         public static CustomOption JackalCreateSidekick;
+        public static CustomOption JackalSKCooldown;
         public static CustomOption JackalNewJackalCreateSidekick;
 
         public static CustomRoleOption TeleporterOption;
@@ -612,6 +613,7 @@ namespace SuperNewRoles.Modules
         public static CustomOption JackalSeerUseSabo;
         public static CustomOption JackalSeerIsImpostorLight;
         public static CustomOption JackalSeerCreateSidekick;
+        public static CustomOption JackalSeerSKCooldown;
         public static CustomOption JackalSeerNewJackalCreateSidekick;
 
         public static CustomRoleOption AssassinAndMarineOption;
@@ -1104,6 +1106,7 @@ namespace SuperNewRoles.Modules
             JackalIsImpostorLight = Create(63, true, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, JackalOption);
             JackalCreateFriend = Create(666, true, CustomOptionType.Neutral, "JackalCreateFriendSetting", false, JackalOption);
             JackalCreateSidekick = Create(64, false, CustomOptionType.Neutral, "JackalCreateSidekickSetting", false, JackalOption);
+            JackalSKCooldown = Create(1108, true, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalCreateSidekick, format: "unitSeconds");
             JackalNewJackalCreateSidekick = Create(65, false, CustomOptionType.Neutral, "JackalNewJackalCreateSidekickSetting", false, JackalCreateSidekick);
 
             TeleporterOption = SetupCustomRoleOption(66, false, RoleId.Teleporter);
@@ -1503,6 +1506,7 @@ namespace SuperNewRoles.Modules
             JackalSeerUseSabo = Create(382, false, CustomOptionType.Neutral, "JackalUseSaboSetting", false, JackalSeerOption);
             JackalSeerIsImpostorLight = Create(383, false, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, JackalSeerOption);
             JackalSeerCreateSidekick = Create(384, false, CustomOptionType.Neutral, "JackalCreateSidekickSetting", false, JackalSeerOption);
+            JackalSeerSKCooldown = Create(1109, true, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalSeerCreateSidekick, format: "unitSeconds");
             JackalSeerNewJackalCreateSidekick = Create(385, false, CustomOptionType.Neutral, "JackalNewJackalCreateSidekickSetting", false, JackalSeerCreateSidekick);
 
             AssassinAndMarineOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarineName", Color.white, 1);

--- a/SuperNewRoles/Roles/Neutral/Jackal.cs
+++ b/SuperNewRoles/Roles/Neutral/Jackal.cs
@@ -13,10 +13,15 @@ namespace SuperNewRoles.Roles
         {
             HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.Jackal.KillCooldown;
             HudManagerStartPatch.JackalKillButton.Timer = RoleClass.Jackal.KillCooldown;
+        }
+        public static void EndMeetingResetCooldown()
+        {
+            HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.Jackal.KillCooldown;
+            HudManagerStartPatch.JackalKillButton.Timer = RoleClass.Jackal.KillCooldown;
             HudManagerStartPatch.JackalSidekickButton.MaxTimer = RoleClass.Jackal.KillCooldown;
             HudManagerStartPatch.JackalSidekickButton.Timer = RoleClass.Jackal.KillCooldown;
         }
-        public static void EndMeeting() => ResetCooldown();
+        public static void EndMeeting() => EndMeetingResetCooldown();
         public static void SetPlayerOutline(PlayerControl target, Color color)
         {
             if (target == null) return;

--- a/SuperNewRoles/Roles/Neutral/Jackal.cs
+++ b/SuperNewRoles/Roles/Neutral/Jackal.cs
@@ -18,8 +18,8 @@ namespace SuperNewRoles.Roles
         {
             HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.Jackal.KillCooldown;
             HudManagerStartPatch.JackalKillButton.Timer = RoleClass.Jackal.KillCooldown;
-            HudManagerStartPatch.JackalSidekickButton.MaxTimer = RoleClass.Jackal.KillCooldown;
-            HudManagerStartPatch.JackalSidekickButton.Timer = RoleClass.Jackal.KillCooldown;
+            HudManagerStartPatch.JackalSidekickButton.MaxTimer = CustomOptionHolder.JackalSKCooldown.GetFloat();
+            HudManagerStartPatch.JackalSidekickButton.Timer = CustomOptionHolder.JackalSKCooldown.GetFloat();
         }
         public static void EndMeeting() => EndMeetingResetCooldown();
         public static void SetPlayerOutline(PlayerControl target, Color color)

--- a/SuperNewRoles/Roles/Neutral/JackalSeer.cs
+++ b/SuperNewRoles/Roles/Neutral/JackalSeer.cs
@@ -11,10 +11,15 @@ namespace SuperNewRoles.Roles
         {
             HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.JackalSeer.KillCooldown;
             HudManagerStartPatch.JackalKillButton.Timer = RoleClass.JackalSeer.KillCooldown;
+        }
+        public static void EndMeetingResetCooldown()
+        {
+            HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.JackalSeer.KillCooldown;
+            HudManagerStartPatch.JackalKillButton.Timer = RoleClass.JackalSeer.KillCooldown;
             HudManagerStartPatch.JackalSeerSidekickButton.MaxTimer = RoleClass.JackalSeer.KillCooldown;
             HudManagerStartPatch.JackalSeerSidekickButton.Timer = RoleClass.JackalSeer.KillCooldown;
         }
-        public static void EndMeeting() => ResetCooldown();
+        public static void EndMeeting() => EndMeetingResetCooldown();
         public static void SetPlayerOutline(PlayerControl target, Color color)
         {
             if (target == null || target.MyRend() == null) return;

--- a/SuperNewRoles/Roles/Neutral/JackalSeer.cs
+++ b/SuperNewRoles/Roles/Neutral/JackalSeer.cs
@@ -16,8 +16,8 @@ namespace SuperNewRoles.Roles
         {
             HudManagerStartPatch.JackalKillButton.MaxTimer = RoleClass.JackalSeer.KillCooldown;
             HudManagerStartPatch.JackalKillButton.Timer = RoleClass.JackalSeer.KillCooldown;
-            HudManagerStartPatch.JackalSeerSidekickButton.MaxTimer = RoleClass.JackalSeer.KillCooldown;
-            HudManagerStartPatch.JackalSeerSidekickButton.Timer = RoleClass.JackalSeer.KillCooldown;
+            HudManagerStartPatch.JackalSeerSidekickButton.MaxTimer = CustomOptionHolder.JackalSeerSKCooldown.GetFloat();
+            HudManagerStartPatch.JackalSeerSidekickButton.Timer = CustomOptionHolder.JackalSeerSKCooldown.GetFloat();
         }
         public static void EndMeeting() => EndMeetingResetCooldown();
         public static void SetPlayerOutline(PlayerControl target, Color color)


### PR DESCRIPTION
[変更点]
- Jackal&JackalSeerがキルした時、SKボタンもリセットされていた仕様を変更。
    - Kill及びSKした時に使用したボタンのみクールタイムがリセットされるように変更しました。
    - SKボタンは会議時に個別クールにリセットする仕様に変更しました。

- SKのクールタイムをキルク同期ではなく個別クールに設定できる仕様に変更しました。