### PR TITLE
侍の修正_必殺技の回数制限を当初の仕様のはずの1回に修正&侍の必殺技対象にFinalStatusが出るよう修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1909,6 +1909,7 @@ namespace SuperNewRoles.Buttons
                     if (PlayerControl.LocalPlayer.CanMove)
                     {
                         Samurai.SamuraiKill();
+                        RoleClass.Samurai.Sword = true;
                     }
                 },
                 (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Samurai && ModeHandler.IsMode(ModeId.Default) && !RoleClass.Samurai.Sword; },

--- a/SuperNewRoles/Mode/SuperHostRoles/Roles/Samurai.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/Roles/Samurai.cs
@@ -19,9 +19,5 @@ namespace SuperNewRoles.Mode.SuperHostRoles.Roles
                 }
             }
         }
-        public static void IsSword()
-        {
-            RoleClass.Samurai.Sword = true;
-        }
     }
 }

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -154,7 +154,7 @@ namespace SuperNewRoles.Patches
                                 {
                                     if (SelfBomber.GetIsBomb(__instance, p, CustomOptionHolder.SamuraiScope.GetFloat()))
                                     {
-                                        __instance.RpcSetFinalStatus(FinalStatus.SamuraiKill);
+                                        p.RpcSetFinalStatus(FinalStatus.SamuraiKill);
                                         __instance.RpcMurderPlayerCheck(p);
                                     }
                                 }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -281,7 +281,7 @@ FinalStatusNekomataExiled,The Way of the Nekomata,猫又の道連れ,连带
 FinalStatusSluggerHarisen,Harisen,ハリセン,击飞
 FinalStatusLoversBomb,Lovers suicide,心中,殉情
 FinalStatusKunaiKill,Kunai,クナイ,苦无
-FinalStatusSamuraiKill,Special sword,必殺剣,拔刀斩
+FinalStatusSamuraiKill,Farewell.,切り捨て御免,
 FinalStatusChiefMisSet,Misnaming,指名誤爆,背刺
 FinalStatusFalseChargesFalseCharge,Self-determination for injustice,冤罪自決,冤案
 FinalStatusSelfBomberBomb,Bomb victim,自爆巻き添え,恐袭

--- a/SuperNewRoles/Roles/Impostor/Samurai.cs
+++ b/SuperNewRoles/Roles/Impostor/Samurai.cs
@@ -19,7 +19,7 @@ namespace SuperNewRoles.Roles
                     if (SelfBomber.GetIsBomb(PlayerControl.LocalPlayer, p, CustomOptionHolder.SamuraiScope.GetFloat()))
                     {
                         PlayerControl.LocalPlayer.UncheckedMurderPlayer(p, showAnimation: false);
-                        PlayerControl.LocalPlayer.RpcSetFinalStatus(FinalStatus.SamuraiKill);
+                        p.RpcSetFinalStatus(FinalStatus.SamuraiKill);
                     }
                 }
             }


### PR DESCRIPTION
# [変更点]
- 侍の修正
    - 必殺技の回数制限を当初の仕様のはずの1回に修正
        - 使われていないbool型変数があり、その変数がボタン表示の条件にあった事から、「必殺技の回数制限は[1回]である」と仕様を判断した。
            - 当初の仕様でなくても、下記の理由で強すぎる為変更する。
            > - 必殺技使用後クールリセットされない
            > - 何度も範囲キルを使える

    - 必殺技使用時、侍本人のFinalStatusが変わっていた問題を修正
        - 必殺技使用時に侍死んだことにすな()
        - 必殺技対象のFinalStatusを「キル」から「斬り捨て御免」に変更