### PR TITLE
シーアの霊魂が追放者がいないと表示されない問題の修正

### DIFF
--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -947,7 +947,7 @@ namespace SuperNewRoles.Patches
             }
 
             SerialKiller.MurderPlayer(__instance, target);
-            Seer.ExileControllerWrapUpPatch.MurderPlayerPatch.Postfix(target);
+            Seer.WrapUpPatch.MurderPlayerPatch.Postfix(target);
             if (IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())
             {
                 new CustomMessage("MurderPlayerが発生しました", 5f);

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -110,9 +110,9 @@ namespace SuperNewRoles.Patches
             Roles.Neutral.Photographer.WrapUp();
             Roles.Impostor.Cracker.WrapUp();
             RoleClass.IsMeeting = false;
+            Seer.ExileControllerWrapUpPatch.WrapUpPostfix();
             if (exiled == null) return;
             SoothSayer_Patch.WrapUp(exiled.Object);
-            Seer.ExileControllerWrapUpPatch.WrapUpPostfix();
             Nekomata.NekomataEnd(exiled);
             Roles.Impostor.NekoKabocha.OnWrapUp(exiled.Object);
 

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -110,7 +110,7 @@ namespace SuperNewRoles.Patches
             Roles.Neutral.Photographer.WrapUp();
             Roles.Impostor.Cracker.WrapUp();
             RoleClass.IsMeeting = false;
-            Seer.ExileControllerWrapUpPatch.WrapUpPostfix();
+            Seer.WrapUpPatch.WrapUpPostfix();
             if (exiled == null) return;
             SoothSayer_Patch.WrapUp(exiled.Object);
             Nekomata.NekomataEnd(exiled);

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -70,7 +70,7 @@ namespace SuperNewRoles.Roles
             return SoulSprite;
         }
 
-        public static class ExileControllerWrapUpPatch
+        public static class WrapUpPatch
         {
             public static void WrapUpPostfix()
             {


### PR DESCRIPTION
# [連絡]
- ヴァンパイアのWrapUpでnullが出て進まない場所にコードを移動したので未テストです。
- 元々のコードでは追放が起きた会議の後で霊魂が表示されていたことを確認済み

# [変更点]
- 追放が起きないと霊魂が表示されなかった問題を修正。
    - ``if (exiled == null) return;``の下にコードがあった。

- ``ExileControllerWrapUpPatch``だったクラス名を``WrapUpPatch``に変更した。
    - 追放は関係ない為