### PR TITLE
ヴァンパイアのWarpUpで追放者がいない場合ぬるぬるになっていた問題を修正

### DIFF
--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -91,7 +91,6 @@ class WrapUpPatch
         Roles.Neutral.Revolutionist.WrapUp();
         Roles.Neutral.Spelunker.WrapUp();
         Roles.Neutral.Hitman.WrapUp();
-        Vampire.WrapUp(exiled.Object);
         Roles.Impostor.Matryoshka.WrapUp();
         Roles.Neutral.PartTimer.WrapUp();
         Roles.Crewmate.KnightProtected_Patch.WrapUp();
@@ -112,6 +111,7 @@ class WrapUpPatch
         RoleClass.IsMeeting = false;
         Seer.WrapUpPatch.WrapUpPostfix();
         if (exiled == null) return;
+        Vampire.WrapUp(exiled.Object);
         SoothSayer_Patch.WrapUp(exiled.Object);
         Nekomata.NekomataEnd(exiled);
         Roles.Impostor.NekoKabocha.OnWrapUp(exiled.Object);


### PR DESCRIPTION
# 変更点
- ヴァンパイアのWarpUp処理を[if (exiled == null) return;]の下に移動

# 説明
- [if (exiled == null) return;]の上に処理があった為、引数[exiled.Object]でnullが生じていた。

    - …これSeerのWrapUpPatch直した時に一緒に直せたやんけ(・ω・)

- 追放無しの会議時nullを起こさず、他のWarpUp処理が正常に働くことを確認しました。

- 追放ありの会議時nullを起こさず、他のWarpUp処理が正常に働くことを確認しました。

- (テスト方法の詳細はCommitMessageに記載)