### PR TITLE
ヴァンパイアのWrapUp処理を血痕と追放で分割した

### DIFF
--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -110,8 +110,9 @@ class WrapUpPatch
         Roles.Impostor.Cracker.WrapUp();
         RoleClass.IsMeeting = false;
         Seer.WrapUpPatch.WrapUpPostfix();
+        Vampire.WrapUp();
         if (exiled == null) return;
-        Vampire.WrapUp(exiled.Object);
+        Vampire.ExileControllerWrapUpPatch(exiled.Object);
         SoothSayer_Patch.WrapUp(exiled.Object);
         Nekomata.NekomataEnd(exiled);
         Roles.Impostor.NekoKabocha.OnWrapUp(exiled.Object);

--- a/SuperNewRoles/Roles/Impostor/Vampire.cs
+++ b/SuperNewRoles/Roles/Impostor/Vampire.cs
@@ -10,15 +10,8 @@ namespace SuperNewRoles.Roles;
 
 class Vampire
 {
-    public static void WrapUp(PlayerControl exiled)
+    public static void WrapUp()
     {
-        if (PlayerControl.LocalPlayer.IsRole(RoleId.Dependents) && PlayerControl.LocalPlayer.IsAlive())
-        {
-            bool Is = true;
-            foreach (PlayerControl p in RoleClass.Vampire.VampirePlayer) if (p.IsAlive() && (exiled == null || exiled.PlayerId != p.PlayerId)) Is = false;
-            if (Is)
-                PlayerControl.LocalPlayer.RpcExiledUnchecked();
-        }
         foreach (var data in RoleClass.Vampire.NoActiveTurnWait.ToArray())
         {
             RoleClass.Vampire.NoActiveTurnWait[data.Key]--;
@@ -32,6 +25,17 @@ class Vampire
             data.BloodStainObject.SetActive(true);
         RoleClass.Vampire.NoActiveTurnWait.Add(RoleClass.Vampire.WaitActiveBloodStains, CustomOptionHolder.VampireViewBloodStainsTurn.GetInt());
         RoleClass.Vampire.WaitActiveBloodStains = new();
+    }
+
+    public static void ExileControllerWrapUpPatch(PlayerControl exiled)
+    {
+        if (PlayerControl.LocalPlayer.IsRole(RoleId.Dependents) && PlayerControl.LocalPlayer.IsAlive())
+        {
+            bool Is = true;
+            foreach (PlayerControl p in RoleClass.Vampire.VampirePlayer) if (p.IsAlive() && (exiled == null || exiled.PlayerId != p.PlayerId)) Is = false;
+            if (Is)
+                PlayerControl.LocalPlayer.RpcExiledUnchecked();
+        }
     }
     [HarmonyPatch(typeof(VitalsPanel), nameof(VitalsPanel.SetDead))]
     class VitalsPanelSetDeadPatch

--- a/SuperNewRoles/Roles/Impostor/Vampire.cs
+++ b/SuperNewRoles/Roles/Impostor/Vampire.cs
@@ -10,6 +10,9 @@ namespace SuperNewRoles.Roles;
 
 class Vampire
 {
+    /// <summary>
+    /// ヴァンパイアの血痕処理
+    /// </summary>
     public static void WrapUp()
     {
         foreach (var data in RoleClass.Vampire.NoActiveTurnWait.ToArray())
@@ -27,6 +30,9 @@ class Vampire
         RoleClass.Vampire.WaitActiveBloodStains = new();
     }
 
+    /// <summary>
+    /// 眷属の心中処理
+    /// </summary>
     public static void ExileControllerWrapUpPatch(PlayerControl exiled)
     {
         if (PlayerControl.LocalPlayer.IsRole(RoleId.Dependents) && PlayerControl.LocalPlayer.IsAlive())


### PR DESCRIPTION
Seerで使われていた関数名を流用しました
[ExileControllerWrapUpPatch]