### PR TITLE
会議後にエアーシップの電気室のドアをシャッフルする設定を追加

### DIFF
--- a/SuperNewRoles/MapCustoms/MapCustom.cs
+++ b/SuperNewRoles/MapCustoms/MapCustom.cs
@@ -26,6 +26,7 @@ class MapCustom
     public static CustomOption MoveElecPad;
     public static CustomOption AddWireTask;
     public static CustomOption AntiTaskOverWall;
+    internal static CustomOption ShuffleElectricalDoors;
 
     public static void CreateOption()
     {
@@ -54,5 +55,6 @@ class MapCustom
         MoveElecPad = CustomOption.Create(645, false, CustomOptionType.Generic, "MoveElecPadSetting", false, AirshipSetting);
         AddWireTask = CustomOption.Create(646, false, CustomOptionType.Generic, "AddWireTaskSetting", false, AirshipSetting);
         AntiTaskOverWall = CustomOption.Create(1106, false, CustomOptionType.Generic, "AntiTaskOverWallSetting", false, AirshipSetting);
+        ShuffleElectricalDoors = CustomOption.Create(1110, false, CustomOptionType.Generic, "ShuffleElectricalDoorsSetting", false, AirshipSetting);
     }
 }

--- a/SuperNewRoles/MapCustoms/main.cs
+++ b/SuperNewRoles/MapCustoms/main.cs
@@ -87,3 +87,14 @@ public static class Extensions
         return self.Count > 0 ? self[UnityEngine.Random.Range(0, self.Count)] : default;
     }
 }
+[HarmonyPatch(typeof(AirshipExileController), nameof(AirshipExileController.WrapUpAndSpawn))]
+class AirshipExileControllerWrapUpAndSpawnPatch
+{
+    static void Prefix()
+    { // エアーシップ電気室のドアをシャッフルする
+        if (MapCustoms.MapCustomHandler.IsMapCustom(MapCustomHandler.MapCustomId.Airship)
+            && MapCustom.ShuffleElectricalDoors.GetBool()
+            && AmongUsClient.Instance.AmHost)
+            AirshipStatus.Instance.Systems[SystemTypes.Decontamination].Cast<ElectricalDoors>().Initialize();
+    }
+}

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -207,6 +207,7 @@ RestrictCamera,Restrict Camera,カメラの時間制限,监控使用时间限制
 CanGhostSeeRole,,死亡者が全員の役職を確認できる,死亡玩家能确认所有玩家的职业
 OnlyImpostorGhostSeeRole,,死亡しているインポスターのみが全員の役職を確認できる,只有死亡的内鬼阵营玩家可以确认所有玩家的职业
 AntiTaskOverWallSetting,Cannot tasks over the wall.,壁越しにタスクをできない,禁止隔墙做任务
+ShuffleElectricalDoorsSetting,Shuffle electrical doors after meeting,会議後に電気室のドアをシャッフルする
 
 # Modes
 ModeSetting,Mode Setting,モード設定,模式设置


### PR DESCRIPTION
 - エアーシップの電気室のドアを会議後にシャッフルします。
 - AirshipExileController.WrapUpAndSpawnをPrefixでパッチしています