### PR TITLE
殺し屋がキルできない問題を修正&殺し屋のFinalStatus追加

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2534,6 +2534,8 @@ static class HudManagerStartPatch
                 {
                     Roles.Neutral.Hitman.KillSuc();
                 }
+                ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
+                target.RpcSetFinalStatus(FinalStatus.HitmanKill);
                 RoleClass.Hitman.UpdateTime = CustomOptionHolder.HitmanChangeTargetTime.GetFloat();
                 RoleClass.Hitman.ArrowUpdateTime = 0;
                 Roles.Neutral.Hitman.SetTarget();

--- a/SuperNewRoles/Modules/FinalStatus.cs
+++ b/SuperNewRoles/Modules/FinalStatus.cs
@@ -55,4 +55,6 @@ public enum FinalStatus
     SuicideWisherSelfDeath,
     MadmakerMisSet,
     Revenge,//猫カボチャの道連れ
+    HitmanKill,
+    HitmanDead
 }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -305,6 +305,8 @@ FinalStatusOverKillerOverKill,Over Kill!,オーバーキル!,肢解
 FinalStatusSuicideWisherSelfDeath,Suicide,自殺,自杀
 FinalStatusMadmakerMisSet,Misnaming,指名誤爆,背刺
 FinalStatusRevenge,Revenge,復讐,仇杀
+FinalStatusHitmanKill,Mission accomplished.,任務遂行
+FinalStatusHitmanDead,Disposition.,処分
 
 # Sabotages
 SabotageSetting,Sabotage Setting,サボタージュの設定,破坏设置

--- a/SuperNewRoles/Roles/Neutral/Hitman.cs
+++ b/SuperNewRoles/Roles/Neutral/Hitman.cs
@@ -127,6 +127,7 @@ public static class Hitman
         if (RoleClass.Hitman.OutMissionLimit <= 0)
         {
             PlayerControl.LocalPlayer.RpcMurderPlayer(PlayerControl.LocalPlayer);
+            PlayerControl.LocalPlayer.RpcSetFinalStatus(FinalStatus.HitmanDead);
         }
     }
     public static void DestroyIntroHandle(IntroCutscene __instance)


### PR DESCRIPTION
# [メモ]
- [殺し屋のターゲット表示がairshipにおいて(会議を挟んでも)表示されない問題]は未修正です。

# [変更点]
- 殺し屋がキルできない問題を修正いたしました。
- 殺し屋が任務失敗時の死因が「キル」なのはおかしいと思ったため「処分」に変更しました。
- ついでに殺し屋に殺された人の死因も変更しました。