### PR TITLE
警告を修正

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/BlockTool.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/BlockTool.cs
@@ -40,9 +40,9 @@ namespace SuperNewRoles.Mode.SuperHostRoles
         private static readonly float UsableDistance = 1.5f;
         private static int Count = 0;
         public static bool IsCom;
-        public static float CameraTime;
-        public static float AdminTime;
-        public static float VitalTime;
+        public static float CameraTime = 0;
+        public static float AdminTime = 0;
+        public static float VitalTime = 0;
         public static void FixedUpdate()
         {
             Count--;


### PR DESCRIPTION
 - フィールド 'BlockTool.CameraTime' は割り当てられません。常に 既定値 0 を使用します
 - フィールド 'BlockTool.AdminTime' は割り当てられません。常に 既定値 0 を使用します
 - フィールド 'BlockTool.VitalTime' は割り当てられません。常に 既定値 0 を使用します