### PR TITLE
コマンド「/ar」と「/gr」の仕様変更

### DIFF
--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -282,6 +282,11 @@ class AddChatPatch
     static void RoleCommand(PlayerControl target = null, float SendTime = 1.5f)
     {
         if (!AmongUsClient.Instance.AmHost) return;
+        if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.SuperHostRoles, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
+        {
+            SendCommand(target, ModTranslation.GetString("Notassign"));
+            return;
+        }
         List<CustomRoleOption> EnableOptions = new();
         foreach (CustomRoleOption option in CustomRoleOption.RoleOptions)
         {
@@ -302,6 +307,11 @@ class AddChatPatch
     static void GetInRoleCommand(PlayerControl target = null)
     {
         if (!AmongUsClient.Instance.AmHost) return;
+        if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.SuperHostRoles, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
+        {
+            SendCommand(target, ModTranslation.GetString("Notassign"));
+            return;
+        }
         List<CustomRoleOption> EnableOptions = new();
         foreach (CustomRoleOption option in CustomRoleOption.RoleOptions)
         {

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -309,6 +309,7 @@ class AddChatPatch
             if (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && !option.isSHROn) continue;
             EnableOptions.Add(option);
         }
+        SendCommand(target, GetInRole(EnableOptions));
     }
     static void Send(PlayerControl target, string rolename, string text, float time = 0)
     {

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using BepInEx.IL2CPP.Utils;
 using HarmonyLib;
+using SuperNewRoles.Mode;
 using SuperNewRoles.Mode.SuperHostRoles;
 using SuperNewRoles.Roles;
 using UnityEngine;
@@ -305,12 +306,10 @@ class AddChatPatch
         List<CustomRoleOption> EnableOptions = new();
         foreach (CustomRoleOption option in CustomRoleOption.RoleOptions)
         {
-            if (option.IsRoleEnable && option.isSHROn)
-            {
+            if (!option.IsRoleEnable) continue;
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && !option.isSHROn) continue;
                 EnableOptions.Add(option);
-            }
         }
-        SendCommand(target, GetInRole(EnableOptions));
     }
     static void Send(PlayerControl target, string rolename, string text, float time = 0)
     {

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -285,10 +285,9 @@ class AddChatPatch
         List<CustomRoleOption> EnableOptions = new();
         foreach (CustomRoleOption option in CustomRoleOption.RoleOptions)
         {
-            if (option.IsRoleEnable && option.isSHROn)
-            {
-                EnableOptions.Add(option);
-            }
+            if (!option.IsRoleEnable) continue;
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && !option.isSHROn) continue;
+            EnableOptions.Add(option);
         }
         float time = 0;
         foreach (CustomRoleOption option in EnableOptions)
@@ -308,7 +307,7 @@ class AddChatPatch
         {
             if (!option.IsRoleEnable) continue;
             if (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && !option.isSHROn) continue;
-                EnableOptions.Add(option);
+            EnableOptions.Add(option);
         }
     }
     static void Send(PlayerControl target, string rolename, string text, float time = 0)

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1172,6 +1172,7 @@ TwitterDevLink,Development Information Account : https://twitter.com/SNRDevs,開
 Team,Team,陣営,阵营
 MessageSettings,Settings,設定,设置
 NowRolesMessage,Activate Roles,現在入っている役職,当前激活的职业
+Notassign,This is the mode in which no roles are assigned.,役職が選出されないモードに設定されています。
 TeamMessage,【Team:{0}】,【{0}陣営】,【{0}阵营】
 NameIncludeMod,You cannot make a room public contains mod in your name.,modが名前に含まれている状態では公開部屋にすることはできません。,不能在昵称里有“mod”时将房间状态设置为公开。
 CannotUseRenameMessage,Cannot rename.\nThe /rename command can only be used on\navailable only when hosted.,名前を変更することができません。\n/renameコマンドは\nホスト時のみ使用可能です。,无法重命名。\n/rename命令仅房主可用。


### PR DESCRIPTION
# [変更点]
- デフォルトモード, SHRモード, 人狼モード等、役職を導入できるモード以外では「役職が選出されないモードです。」と返すように変更。
  - かくれんぼモードを条件に入れない理由
    - 大幅改修する事が予測される為。
    - HostかくれんぼモードとSNR役職が使用可能なかくれんぼモードのわけかたの仕様が分からなかったた為。

- デフォルトモードでも、コマンド[/ar][/gr]を対応可能に変更
  - 「SHR対応役職以外表示しない」という仕様を変更。
    - 「SHRモードの時、SHR対応していないような役職は表示しない」仕様に変更
    - 「省かれなかった役職を表示する」仕様に変更

# [メモ]
- ``continue;``便利っすね(・ω・)