### PR TITLE
反転マップ修正

### DIFF
--- a/SuperNewRoles/Patches/ShipStatusPatch.cs
+++ b/SuperNewRoles/Patches/ShipStatusPatch.cs
@@ -148,7 +148,7 @@ class LightPatch
         return Mathf.Lerp(shipStatus.MinLightRadius, shipStatus.MaxLightRadius, lerpValue) * GameManager.Instance.LogicOptions.currentGameOptions.GetFloat(FloatOptionNames.CrewLightMod);
     }
 }
-[HarmonyPatch(typeof(ShipStatus), nameof(GameStartManager.Start))]
+[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Start))]
 public class Inversion
 { // マップ反転
     public static GameObject skeld;


### PR DESCRIPTION
[HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Start))]であるべき場所が[HarmonyPatch(typeof(ShipStatus), nameof(GameStartManager.Start))]だった。

何が問題なのかは一目瞭然。
逆になぜ今まで正常に動いていたのやら。