### PR TITLE
バグ#ticket-0089 /wコマンドの勝利陣営

### DIFF
--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -1069,7 +1069,7 @@ public static class OnGameEndPatch
             if (player.Object != null && player.Object.IsBot()) continue;
             CustomPlayerData data = new(player, gameOverReason)
             {
-                IsWin = TempData.winners.TrueForAll((Il2CppSystem.Predicate<WinningPlayerData>)(x => x.PlayerName == player.PlayerName))
+                IsWin = TempData.winners.ToArray().Any(x => x.PlayerName == player.PlayerName)
             };
             PlayerData.Add(data);
         }


### PR DESCRIPTION
バグ#ticket-0089
[Mode]SHR
[Ver]1.5.1.1で確認
[内容]
/wコマンドで勝利陣営の★マークが付かない

[ログ]
再現性があるため省略

[原因]
　OnGameEndPatch.Postfix()で勝利陣営のCustomPlayerData.IsWinにTrueが入っていない。