### PR TITLE
バグ#ticket-0093、0094、他 SHRスパイの不具合対応

### DIFF
--- a/SuperNewRoles/Mode/SuperHostRoles/Intro.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/Intro.cs
@@ -27,6 +27,7 @@ class Intro
                 {
                     if ((p.IsImpostor() || p.IsRole(RoleId.Spy)) && p.PlayerId != CachedPlayer.LocalPlayer.PlayerId && !p.IsBot())
                     {
+                        if (p.IsRole(RoleId.Spy)) p.Data.Role.NameColor = RoleClass.ImpostorRed;
                         Teams.Add(p);
                     }
                 }

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -182,12 +182,19 @@ public static class RoleSelectHandler
                     if (pc.PlayerId == Player.PlayerId) continue;
                     sender.RpcSetRole(pc, RoleTypes.Scientist, PlayerCID);
                 }
+            }
+            else
+            {
+                if (Player.PlayerId != 0) sender.RpcSetRole(Player, RoleTypes.Crewmate, Player.GetClientId());
+                else Player.SetRole(RoleTypes.Crewmate);
+            }
+            if (ModeHandler.GetMode() == ModeId.SuperHostRoles)
+            {
                 //他視点で科学者にするループ
                 foreach (var pc in PlayerControl.AllPlayerControls)
                 {
                     if (pc.PlayerId == Player.PlayerId) continue;
-                    if (pc.IsMod()) Player.SetRole(RoleTypes.Scientist); //ホスト視点用
-                    else
+                    if (!pc.IsMod()) 
                     {
                         if (pc.IsImpostor() || pc.IsRole(RoleId.Spy))
                         {
@@ -199,11 +206,6 @@ public static class RoleSelectHandler
                         }
                     }
                 }
-            }
-            else
-            {
-                if (Player.PlayerId != 0) sender.RpcSetRole(Player, RoleTypes.Crewmate, Player.GetClientId());
-                else Player.SetRole(RoleTypes.Crewmate);
             }
         }
         return;

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -241,6 +241,11 @@ public class FixedUpdate
                 }
                 SerialKiller.SHRFixedUpdate(PlayerControl.LocalPlayer.GetRole());
                 Roles.Impostor.Camouflager.SHRFixedUpdate();
+                if (PlayerControl.LocalPlayer.IsAlive())
+                {
+                    if (PlayerControl.LocalPlayer.IsImpostor()) { SetTarget.ImpostorSetTarget(); }
+                }
+
                 break;
             case ModeId.NotImpostorCheck:
                 if (AmongUsClient.Instance.AmHost)


### PR DESCRIPTION
SHRモード スパイの不具合対応

[バグ#ticket-0093]
　ホスト（MODクライアント）がスパイの場合に、インポスターから通常のクルーに見えてしまう
　キルも可能
[バグ#ticket-0094]
　ホスト（MODクライアント）がインポスターの場合に、スパイをキルすることができる
[バグ#ticket-未]
　ホスト（MODクライアント）がインポスターの場合に、イントロ画面でスパイの名前が白くみえてしまう