### PR TITLE
試合終了画面を整理

### DIFF
--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -102,7 +102,7 @@ public static class ShipStatusPatch
     [HarmonyPatch(typeof(LogicGameFlowNormal), nameof(LogicGameFlowNormal.IsGameOverDueToDeath))]
     public static void Postfix2(ref bool __result)
     {
-        
+
         __result = false;
     }
 }
@@ -374,7 +374,7 @@ public class EndGameManagerSetUpPatch
                 {
                     roleText += $" → {CustomOptionHolder.Cs(data.GhostIntroData.color, data.GhostIntroData.NameKey + "Name")}";
                 }
-                string result = $"{ModHelpers.Cs(Palette.PlayerColors[data.ColorId], data.PlayerName)}{data.NameSuffix}{taskInfo} - {FinalStatusPatch.GetStatusText(data.Status)} - {roleText}";
+                string result = $"{ModHelpers.Cs(Palette.PlayerColors[data.ColorId], data.PlayerName)}{data.NameSuffix}<pos=17%>{taskInfo} - <pos=27%>{FinalStatusPatch.GetStatusText(data.Status)} - <pos=34%>{roleText}";
                 if (ModeHandler.IsMode(ModeId.Zombie))
                 {
                     roleText = data.ColorId == 1 ? CustomOptionHolder.Cs(Mode.Zombie.Main.Policecolor, "ZombiePoliceName") : CustomOptionHolder.Cs(Mode.Zombie.Main.Zombiecolor, "ZombieZombieName");

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -375,7 +375,7 @@ public class EndGameManagerSetUpPatch
                     roleText += $" → {CustomOptionHolder.Cs(data.GhostIntroData.color, data.GhostIntroData.NameKey + "Name")}";
                 }
                 //位置調整:ExR参考  by 漢方
-                string result = $"{ModHelpers.Cs(Palette.PlayerColors[data.ColorId], data.PlayerName)}{data.NameSuffix}<pos=17%>{taskInfo} - <pos=27%>{FinalStatusPatch.GetStatusText(data.Status)} - <pos=34%>{roleText}";
+                string result = $"{ModHelpers.Cs(Palette.PlayerColors[data.ColorId], data.PlayerName)}{data.NameSuffix}<pos=17%>{taskInfo} - <pos=27%>{FinalStatusPatch.GetStatusText(data.Status)} - {roleText}";
                 if (ModeHandler.IsMode(ModeId.Zombie))
                 {
                     roleText = data.ColorId == 1 ? CustomOptionHolder.Cs(Mode.Zombie.Main.Policecolor, "ZombiePoliceName") : CustomOptionHolder.Cs(Mode.Zombie.Main.Zombiecolor, "ZombieZombieName");

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -374,6 +374,7 @@ public class EndGameManagerSetUpPatch
                 {
                     roleText += $" → {CustomOptionHolder.Cs(data.GhostIntroData.color, data.GhostIntroData.NameKey + "Name")}";
                 }
+                //位置調整:ExR参考  by 漢方
                 string result = $"{ModHelpers.Cs(Palette.PlayerColors[data.ColorId], data.PlayerName)}{data.NameSuffix}<pos=17%>{taskInfo} - <pos=27%>{FinalStatusPatch.GetStatusText(data.Status)} - <pos=34%>{roleText}";
                 if (ModeHandler.IsMode(ModeId.Zombie))
                 {


### PR DESCRIPTION
ごちゃごちゃになっていて見にくかったので修正しました。一部ExR参考です。
修正前：

![びふぉー](https://user-images.githubusercontent.com/102277752/209468448-b4239873-0504-4d5e-b85b-c048cd312bfd.png)

修正後：

![あふたー](https://user-images.githubusercontent.com/102277752/209468453-125cf262-3ede-45ee-8a57-2f50e7e8e0f6.png)

役職をリスト型にして矢印で表示しようか迷いましたが結局やめました