### PR TITLE
ファストメーカーとリモートシェリフのボタンを修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2529,21 +2529,29 @@ static class HudManagerStartPatch
                     PlayerControl.LocalPlayer.RpcShowGuardEffect(target); // 守護エフェクトの表示
                     Madmate.CreateMadmate(target);//くるぅにして、マッドにする
                     RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことに
-                    SuperNewRolesPlugin.Logger.LogInfo("[FastMakerButton]マッドを作ったから普通のキルボタンに戻すよ!");
+                    Logger.Info($"マッドを作成しました。IsCreatedMadmate == {RoleClass.FastMaker.IsCreatedMadmate}", "FastMakerButton");
+                }
+                else
+                {
+                    //作ってたらキル
+                    ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
+                    Logger.Info("Madを作成した為キル", "FastMakerButton");
                 }
             },
-            //マッドを作った後はカスタムキルボタンを消去する
-            (bool isAlive, RoleId role) => { return isAlive && role == RoleId.FastMaker && !RoleClass.FastMaker.IsCreatedMadmate && ModeHandler.IsMode(ModeId.Default); },
+            (bool isAlive, RoleId role) => { return isAlive && role == RoleId.FastMaker && !ModeHandler.IsMode(ModeId.SuperHostRoles); },
             () =>
             {
                 return SetTarget() && PlayerControl.LocalPlayer.CanMove;
             },
-            () => { },
+            () =>
+            {
+                FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown;
+                FastMakerButton.Timer = RoleClass.DefaultKillCoolDown;
+            },
             __instance.KillButton.graphic.sprite,
-            new Vector3(0, 1, 0),
+            new Vector3(-1, 1, 0),
             __instance,
             __instance.KillButton,
-            //マッドを作る前はキルボタンに擬態する
             KeyCode.Q,
             8,
             () => { return false; }

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2533,6 +2533,7 @@ static class HudManagerStartPatch
                 if (target && PlayerControl.LocalPlayer.CanMove && !RoleClass.FastMaker.IsCreatedMadmate)
                 {
                     PlayerControl.LocalPlayer.RpcShowGuardEffect(target); // 守護エフェクトの表示
+                    RoleClass.FastMaker.CreatePlayers.Add(PlayerControl.LocalPlayer.PlayerId);
                     Madmate.CreateMadmate(target);//くるぅにして、マッドにする
                     RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことに
                     FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown > 0 ? RoleClass.DefaultKillCoolDown / 2f : 0.00001f;

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2529,8 +2529,9 @@ static class HudManagerStartPatch
                     PlayerControl.LocalPlayer.RpcShowGuardEffect(target); // 守護エフェクトの表示
                     Madmate.CreateMadmate(target);//くるぅにして、マッドにする
                     RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことに
-                    FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown - 15f > 0 ? RoleClass.DefaultKillCoolDown - 15f : 0.00001f;
+                    FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown > 0 ? RoleClass.DefaultKillCoolDown / 2f : 0.00001f;
                     FastMakerButton.Timer = FastMakerButton.MaxTimer;
+                    Logger.Info($"守護を発動させている為、設定キルクールの半分の値である<{FastMakerButton.MaxTimer}s>にリセットしました。", "FastMakerButton");
                     Logger.Info($"マッドを作成しました。IsCreatedMadmate == {RoleClass.FastMaker.IsCreatedMadmate}", "FastMakerButton");
                 }
                 else
@@ -2539,7 +2540,7 @@ static class HudManagerStartPatch
                     ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
                     FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown;
                     FastMakerButton.Timer = FastMakerButton.MaxTimer;
-                    Logger.Info("Madを作成した為キル", "FastMakerButton");
+                    Logger.Info($"Mad作成済みの為キルしました。デフォルトキルクールである<{FastMakerButton.MaxTimer}s>にリセットしました。", "FastMakerButton");
                 }
             },
             (bool isAlive, RoleId role) => { return isAlive && role == RoleId.FastMaker && !ModeHandler.IsMode(ModeId.SuperHostRoles); },

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1400,7 +1400,7 @@ static class HudManagerStartPatch
                     }
                 }
             },
-            (bool isAlive, RoleId role) => { return isAlive && (role == RoleId.Sheriff || role == RoleId.RemoteSheriff) && ModeHandler.IsMode(ModeId.Default); },
+            (bool isAlive, RoleId role) => { return isAlive && (role == RoleId.RemoteSheriff || (role == RoleId.Sheriff && ModeHandler.IsMode(ModeId.Default))); },
             () =>
             {
                 float killCount = 0f;

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -123,16 +123,17 @@ static class HudManagerStartPatch
             () =>
             {
                 float killTimer = PlayerControl.LocalPlayer.killTimer;
-                ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, SetTarget(Crewmateonly:true));
+                ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, SetTarget(Crewmateonly: true));
                 RoleClass.Jumbo.Killed = true;
                 PlayerControl.LocalPlayer.killTimer = killTimer;
             },
             (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Jumbo && PlayerControl.LocalPlayer.IsImpostor() && !RoleClass.Jumbo.Killed && RoleClass.Jumbo.JumboSize.ContainsKey(PlayerControl.LocalPlayer.PlayerId) && RoleClass.Jumbo.JumboSize[PlayerControl.LocalPlayer.PlayerId] >= (CustomOptionHolder.JumboMaxSize.GetFloat() / 10); },
             () =>
             {
-                return SetTarget(Crewmateonly:true) && PlayerControl.LocalPlayer.CanMove;
+                return SetTarget(Crewmateonly: true) && PlayerControl.LocalPlayer.CanMove;
             },
-            () => {
+            () =>
+            {
                 JumboKillButton.MaxTimer = GameManager.Instance.LogicOptions.currentGameOptions.GetFloat(FloatOptionNames.KillCooldown);
                 JumboKillButton.Timer = JumboKillButton.MaxTimer;
             },
@@ -188,7 +189,8 @@ static class HudManagerStartPatch
                                 writer.Write(false);
                                 AmongUsClient.Instance.FinishRpcImmediately(writer);
                             }
-                        } else
+                        }
+                        else
                         {
                             MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetLoversBreakerWinner);
                             writer.Write(PlayerControl.LocalPlayer.PlayerId);
@@ -1398,7 +1400,7 @@ static class HudManagerStartPatch
                     }
                 }
             },
-            (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Sheriff && ModeHandler.IsMode(ModeId.Default); },
+            (bool isAlive, RoleId role) => { return isAlive && (role == RoleId.Sheriff || role == RoleId.RemoteSheriff) && ModeHandler.IsMode(ModeId.Default); },
             () =>
             {
                 float killCount = 0f;

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2529,12 +2529,16 @@ static class HudManagerStartPatch
                     PlayerControl.LocalPlayer.RpcShowGuardEffect(target); // 守護エフェクトの表示
                     Madmate.CreateMadmate(target);//くるぅにして、マッドにする
                     RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことに
+                    FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown - 15f > 0 ? RoleClass.DefaultKillCoolDown - 15f : 0.00001f;
+                    FastMakerButton.Timer = FastMakerButton.MaxTimer;
                     Logger.Info($"マッドを作成しました。IsCreatedMadmate == {RoleClass.FastMaker.IsCreatedMadmate}", "FastMakerButton");
                 }
                 else
                 {
                     //作ってたらキル
                     ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
+                    FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown;
+                    FastMakerButton.Timer = RoleClass.DefaultKillCoolDown;
                     Logger.Info("Madを作成した為キル", "FastMakerButton");
                 }
             },

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -2538,7 +2538,7 @@ static class HudManagerStartPatch
                     //作ってたらキル
                     ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
                     FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown;
-                    FastMakerButton.Timer = RoleClass.DefaultKillCoolDown;
+                    FastMakerButton.Timer = FastMakerButton.MaxTimer;
                     Logger.Info("Madを作成した為キル", "FastMakerButton");
                 }
             },
@@ -2549,8 +2549,8 @@ static class HudManagerStartPatch
             },
             () =>
             {
-                FastMakerButton.MaxTimer = RoleClass.DefaultKillCoolDown;
-                FastMakerButton.Timer = RoleClass.DefaultKillCoolDown;
+                FastMakerButton.MaxTimer = RoleClass.Tuna.IsMeetingEnd ? RoleClass.DefaultKillCoolDown : 10f;
+                FastMakerButton.Timer = FastMakerButton.MaxTimer;
             },
             __instance.KillButton.graphic.sprite,
             new Vector3(-1, 1, 0),

--- a/SuperNewRoles/Buttons/NormalButtonDestroy.cs
+++ b/SuperNewRoles/Buttons/NormalButtonDestroy.cs
@@ -13,7 +13,7 @@ public class NormalButtonDestroy
         UseButton
     }
     private static readonly Dictionary<RoleId, (NormalButton, bool)> SetActiveDictionary = new() {
-            //{ RoleId.FastMaker, (NormalButton.KillButton, !ModeHandler.IsMode(ModeId.SuperHostRoles) && !RoleClass.FastMaker.IsCreatedMadmate) }, 試合中に変動する必要がある為辞書に入れず直接パッチ
+            { RoleId.FastMaker, (NormalButton.KillButton, !ModeHandler.IsMode(ModeId.SuperHostRoles))},
             { RoleId.SecretlyKiller, (NormalButton.KillButton, true) },
             { RoleId.DoubleKiller, (NormalButton.KillButton, true) },
             { RoleId.Smasher, (NormalButton.KillButton, true) },
@@ -29,10 +29,6 @@ public class NormalButtonDestroy
     public static void SetActiveState()
     {
         var hm = FastDestroyableSingleton<HudManager>.Instance;
-
-        // ファストメーカーのキルボタン
-        if (PlayerControl.LocalPlayer.IsRole(RoleId.FastMaker) && !ModeHandler.IsMode(ModeId.SuperHostRoles) && !RoleClass.FastMaker.IsCreatedMadmate && hm.KillButton.gameObject.active)
-            hm.KillButton.gameObject.SetActive(false);// キルボタンを無効化
 
         // ニートの使用ボタン
         if (PlayerControl.LocalPlayer.IsRole(RoleId.Neet) && hm.UseButton.gameObject.active)

--- a/SuperNewRoles/Buttons/NormalButtonDestroy.cs
+++ b/SuperNewRoles/Buttons/NormalButtonDestroy.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using SuperNewRoles.Roles;
+using SuperNewRoles.Mode;
 
 namespace SuperNewRoles.Buttons;
 
@@ -12,7 +13,7 @@ public class NormalButtonDestroy
         UseButton
     }
     private static readonly Dictionary<RoleId, (NormalButton, bool)> SetActiveDictionary = new() {
-            //{ RoleId.FastMaker, (NormalButton.KillButton, !RoleClass.FastMaker.IsCreatedMadmate) }, 試合中に変動する必要がある為辞書に入れず直接パッチ
+            //{ RoleId.FastMaker, (NormalButton.KillButton, !ModeHandler.IsMode(ModeId.SuperHostRoles) && !RoleClass.FastMaker.IsCreatedMadmate) }, 試合中に変動する必要がある為辞書に入れず直接パッチ
             { RoleId.SecretlyKiller, (NormalButton.KillButton, true) },
             { RoleId.DoubleKiller, (NormalButton.KillButton, true) },
             { RoleId.Smasher, (NormalButton.KillButton, true) },
@@ -30,8 +31,8 @@ public class NormalButtonDestroy
         var hm = FastDestroyableSingleton<HudManager>.Instance;
 
         // ファストメーカーのキルボタン
-        if (PlayerControl.LocalPlayer.IsRole(RoleId.FastMaker) && !RoleClass.FastMaker.IsCreatedMadmate && hm.KillButton.gameObject.active)
-            hm.UseButton.gameObject.SetActive(false);// 使用ボタンを無効化
+        if (PlayerControl.LocalPlayer.IsRole(RoleId.FastMaker) && !ModeHandler.IsMode(ModeId.SuperHostRoles) && !RoleClass.FastMaker.IsCreatedMadmate && hm.KillButton.gameObject.active)
+            hm.KillButton.gameObject.SetActive(false);// キルボタンを無効化
 
         // ニートの使用ボタン
         if (PlayerControl.LocalPlayer.IsRole(RoleId.Neet) && hm.UseButton.gameObject.active)

--- a/SuperNewRoles/Buttons/NormalButtonDestroy.cs
+++ b/SuperNewRoles/Buttons/NormalButtonDestroy.cs
@@ -12,7 +12,7 @@ public class NormalButtonDestroy
         UseButton
     }
     private static readonly Dictionary<RoleId, (NormalButton, bool)> SetActiveDictionary = new() {
-            { RoleId.FastMaker, (NormalButton.KillButton, !RoleClass.FastMaker.IsCreatedMadmate) },
+            //{ RoleId.FastMaker, (NormalButton.KillButton, !RoleClass.FastMaker.IsCreatedMadmate) }, 試合中に変動する必要がある為辞書に入れず直接パッチ
             { RoleId.SecretlyKiller, (NormalButton.KillButton, true) },
             { RoleId.DoubleKiller, (NormalButton.KillButton, true) },
             { RoleId.Smasher, (NormalButton.KillButton, true) },
@@ -27,33 +27,39 @@ public class NormalButtonDestroy
         };
     public static void SetActiveState()
     {
+        var hm = FastDestroyableSingleton<HudManager>.Instance;
+
+        // ファストメーカーのキルボタン
+        if (PlayerControl.LocalPlayer.IsRole(RoleId.FastMaker) && !RoleClass.FastMaker.IsCreatedMadmate && hm.KillButton.gameObject.active)
+            hm.UseButton.gameObject.SetActive(false);// 使用ボタンを無効化
+
         // ニートの使用ボタン
-        if (PlayerControl.LocalPlayer.IsRole(RoleId.Neet) && FastDestroyableSingleton<HudManager>.Instance.UseButton.gameObject.active)
-            FastDestroyableSingleton<HudManager>.Instance.UseButton.gameObject.SetActive(false);// 使用ボタンを無効化
+        if (PlayerControl.LocalPlayer.IsRole(RoleId.Neet) && hm.UseButton.gameObject.active)
+            hm.UseButton.gameObject.SetActive(false);// 使用ボタンを無効化
 
         if (!SetActiveDictionary.ContainsKey(PlayerControl.LocalPlayer.GetRole())) return;
         if (!SetActiveDictionary[PlayerControl.LocalPlayer.GetRole()].Item2) return;
         switch (SetActiveDictionary[PlayerControl.LocalPlayer.GetRole()].Item1)
         {
             case NormalButton.KillButton: // キルボタン
-                if (FastDestroyableSingleton<HudManager>.Instance.KillButton.gameObject.active)
-                    FastDestroyableSingleton<HudManager>.Instance.KillButton.gameObject.SetActive(false);
+                if (hm.KillButton.gameObject.active)
+                    hm.KillButton.gameObject.SetActive(false);
                 break;
             case NormalButton.ReportButton: // 通報ボタン
-                if (FastDestroyableSingleton<HudManager>.Instance.ReportButton.gameObject.active)
+                if (hm.ReportButton.gameObject.active)
                 {
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.SetActive(false);//通報
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.gameObject.SetActiveRecursively(false);
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.graphic.enabled = false;
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.enabled = false;
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.graphic.sprite = null;
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.buttonLabelText.enabled = false;
-                    FastDestroyableSingleton<HudManager>.Instance.ReportButton.buttonLabelText.SetText("");
+                    hm.ReportButton.SetActive(false);//通報
+                    hm.ReportButton.gameObject.SetActiveRecursively(false);
+                    hm.ReportButton.graphic.enabled = false;
+                    hm.ReportButton.enabled = false;
+                    hm.ReportButton.graphic.sprite = null;
+                    hm.ReportButton.buttonLabelText.enabled = false;
+                    hm.ReportButton.buttonLabelText.SetText("");
                 }
                 break;
             case NormalButton.UseButton: // 使用ボタン
-                if (FastDestroyableSingleton<HudManager>.Instance.UseButton.gameObject.active)
-                    FastDestroyableSingleton<HudManager>.Instance.UseButton.gameObject.SetActive(false);
+                if (hm.UseButton.gameObject.active)
+                    hm.UseButton.gameObject.SetActive(false);
                 break;
         }
     }

--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -389,8 +389,15 @@ public static class FixedUpdate
                 FastDestroyableSingleton<HudManager>.Instance.KillButton.SetTarget(null);
             }
         }
-        else if (PlayerControl.LocalPlayer.IsRole(RoleId.Jackal, RoleId.MadMaker, RoleId.Egoist, RoleId.RemoteSheriff,
-            RoleId.Demon, RoleId.Arsonist)
+        else if
+            (PlayerControl.LocalPlayer.IsRole
+                (
+                    RoleId.Jackal,
+                    RoleId.MadMaker,
+                    RoleId.Egoist,
+                    RoleId.Demon,
+                    RoleId.Arsonist
+                )
             )
         {
             FastDestroyableSingleton<HudManager>.Instance.KillButton.gameObject.SetActive(true);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1103,7 +1103,7 @@ public class CustomOptionHolder
 
         RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
         RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
-        RemoteSheriffCoolTime = Create(46, true, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
+        RemoteSheriffCoolTime = Create(46, false, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
         RemoteSheriffAlwaysKills = Create(733, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, RemoteSheriffOption);
         RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, RemoteSheriffOption);
         RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -643,13 +643,13 @@ static class CheckMurderPatch
                             target.SetRoleRPC(RoleId.Madmate);//マッドにする
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                             RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことにする
-                            SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSHR]マッドを作ったよ");
+                            Logger.Info("マッドメイトを作成しました","FastMakerSHR");
                             return false;
                         }
                         else
                         {
                             //作ってたら普通のキル(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
-                            SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSHR]作ったので普通のキル");
+                            Logger.Info("マッドメイトを作成済みの為 普通のキル","FastMakerSHR");
                         }
                         break;
                     case RoleId.Jackal:

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -83,6 +83,7 @@ class WrapUpPatch
         SerialKiller.WrapUp();
         Assassin.WrapUp();
         CountChanger.CountChangerPatch.WrapUpPatch();
+        RoleClass.Tuna.IsMeetingEnd = true;
         CustomButton.MeetingEndedUpdate();
 
         PlayerControlHepler.RefreshRoleDescription(PlayerControl.LocalPlayer);
@@ -95,7 +96,6 @@ class WrapUpPatch
         Roles.Impostor.Matryoshka.WrapUp();
         Roles.Neutral.PartTimer.WrapUp();
         Roles.Crewmate.KnightProtected_Patch.WrapUp();
-        RoleClass.Tuna.IsMeetingEnd = true;
         Bestfalsecharge.WrapUp();
         if (AmongUsClient.Instance.AmHost)
         {

--- a/SuperNewRoles/Roles/CrewMate/Sheriff.cs
+++ b/SuperNewRoles/Roles/CrewMate/Sheriff.cs
@@ -1,4 +1,5 @@
 using System;
+using SuperNewRoles.Mode;
 using SuperNewRoles.Buttons;
 
 namespace SuperNewRoles.Roles;
@@ -11,8 +12,8 @@ class Sheriff
         {
             if (PlayerControl.LocalPlayer.IsRole(RoleId.RemoteSheriff))
             {
-                HudManagerStartPatch.SheriffKillButton.MaxTimer = RoleClass.RemoteSheriff.CoolTime;
-                HudManagerStartPatch.SheriffKillButton.Timer = RoleClass.RemoteSheriff.CoolTime;
+                HudManagerStartPatch.SheriffKillButton.MaxTimer = ModeHandler.IsMode(ModeId.SuperHostRoles) ? 0f : RoleClass.RemoteSheriff.CoolTime;
+                HudManagerStartPatch.SheriffKillButton.Timer = ModeHandler.IsMode(ModeId.SuperHostRoles) ? 0f : RoleClass.RemoteSheriff.CoolTime;
                 RoleClass.Sheriff.ButtonTimer = DateTime.Now;
             }
             else

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -23,6 +23,7 @@ public static class RoleClass
     public static Color FoxPurple = Palette.Purple;
     public static bool IsStart;
     public static List<byte> BlockPlayers;
+    public static float DefaultKillCoolDown;
 
     public static void ClearAndReloadRoles()
     {
@@ -36,6 +37,7 @@ public static class RoleClass
         LateTask.AddTasks = new();
         BotManager.AllBots = new();
         IsCoolTimeSetted = false;
+        DefaultKillCoolDown = GameOptionsManager.Instance.CurrentGameOptions.GetFloat(FloatOptionNames.KillCooldown);
         IsStart = false;
         Agartha.MapData.ClearAndReloads();
         LadderDead.Reset();
@@ -198,8 +200,8 @@ public static class RoleClass
         Penguin.ClearAndReload();
         Dependents.ClearAndReload();
         LoversBreaker.ClearAndReload();
-            Jumbo.ClearAndReload();
-            //ロールクリア
+        Jumbo.ClearAndReload();
+        //ロールクリア
         Quarreled.ClearAndReload();
         Lovers.ClearAndReload();
         MapOption.MapOption.ClearAndReload();


### PR DESCRIPTION
# [連絡]
- #913 を先に
  - **はよmergeしてくれ()draftはこっちで解除したで**

# [変更点]
- SHR時、リモートシェリフのキルクールを0sに固定し、設定を不可能にした。
  - SHR時リモートシェリフのキルクールが、導入者と非導入者で違いがあり問題があった。
  - 非導入者ではシェイプボタンを導入者ではキルボタンを使用している為差異が生じていた。
  - SHR時、リモートシェリフのクールを0sに固定することで差異をなくした。<br><br>
- SHR時、導入者リモートシェリフのボタンをキルボタンからカスタムボタンに変更
  - キルボタン=シェイプボタンが分かりにくかった為変更。
  - 近くに人がいないとボタンが光らないが、実際は押せるという仕様が分かりにくかった為変更。
- RoleClassにバニラのキルク設定を保存する変数``DefaultKillCoolDown``を作成。
# [修正点]
- 導入者ファストメーカー(SHR,SNR共に)のボタンが表示されていない問題の修正。
  - SHR時は導入者も純正キルボタンとPLCを使用するように変更。
    - これにより導入者と非導入者で変動していた以下の問題を修正。
      - 初手キルクール
        - 導入者 : バニラキルク
        - 非導入者 : 10s
      - マッド作成時のキルクリセット
        - 導入者 : バニラキルク
        - 非導入者 : (バニラキルク/2)s
  - SNR時は純正キルボタンを消去しカスタムキルボタンを使用するように変更。
    - 初手キルクはTunaの初回会議判定を利用し10sに設定。
    - マッド作成時バニラキルクの半分にキルクリセットされるように修正
- SNR時、リモートシェリフのキルボタンがなかった問題の修正。
  - シェリフとボタン共通なのに、なぜか表示条件がSheriffしかなかった。
  - なんでやねん()