### PR TITLE
SHRでジャッカルフレンズを作成時守護天使になって死んでしまう問題を修正(ResetAndSetRoleからSHR時守護天使にするコードを削除)

### DIFF
--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -228,11 +228,6 @@ public static class RPCHelper
     public static void ResetAndSetRole(this PlayerControl target, RoleId Id)
     {
         target.RPCSetRoleUnchecked(RoleTypes.Crewmate);
-        if (ModeHandler.IsMode(ModeId.SuperHostRoles))
-        {
-            target.RpcSetRoleDesync(RoleTypes.GuardianAngel);//守護天使にする
-            Logger.Info($"[{target.GetDefaultName()}] の役職を [守護天使] に変更しました。");
-        }
         target.SetRoleRPC(Id);
         Logger.Info($"[{target.GetDefaultName()}] の役職を [{Id}] に変更しました。");
     }

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -661,18 +661,18 @@ static class CheckMurderPatch
                             RoleClass.Jackal.CreatePlayers.Add(__instance.PlayerId);
                             if (!target.IsImpostor())
                             {
-                                Jackal.CreateJackalFriends(target);//守護天使にして クルーにして フレンズにする
+                                Jackal.CreateJackalFriends(target);//クルーにして フレンズにする
                             }
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
-                            SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR]フレンズを作ったよ");
+                            Logger.Info("ジャッカルフレンズを作成しました。","JackalSHR");
                             return false;
                         }
                         else
                         {
                             // キルができた理由のログを表示する(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
-                            if (!RoleClass.Jackal.CanCreateFriend) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] フレンズを作る設定ではない為 普通のキル");
-                            else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.CreatePlayers.Contains(__instance.PlayerId)) SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 作ったので 普通のキル");
-                            else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
+                            if (!RoleClass.Jackal.CanCreateFriend) Logger.Info("ジャッカルフレンズを作る設定ではない為 普通のキル","JackalSHR");
+                            else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.CreatePlayers.Contains(__instance.PlayerId)) Logger.Info("ジャッカルフレンズ作成済みの為 普通のキル","JackalSHR");
+                            else Logger.Info("不正なキル","JackalSHR");
                         }
                         break;
                     case RoleId.DarkKiller:

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -521,7 +521,6 @@ static class CheckMurderPatch
                             RoleClass.Truelover.CreatePlayers.Add(__instance.PlayerId);
                             RoleHelpers.SetLovers(__instance, target);
                             RoleHelpers.SetLoversRPC(__instance, target);
-                            //__instance.RpcSetRoleDesync(RoleTypes.GuardianAngel);
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(__instance);
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);
                         }
@@ -569,9 +568,7 @@ static class CheckMurderPatch
                             if (target == null || RoleClass.MadMaker.CreatePlayers.Contains(__instance.PlayerId)) return false;
                             __instance.RpcShowGuardEffect(target);
                             RoleClass.MadMaker.CreatePlayers.Add(__instance.PlayerId);
-                            target.RpcSetRoleDesync(RoleTypes.GuardianAngel);
-                            target.SetRoleRPC(RoleId.Madmate);
-                            //__instance.RpcSetRoleDesync(RoleTypes.GuardianAngel);
+                            Madmate.CreateMadmate(target);
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);
                         }
                         else

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -640,7 +640,7 @@ static class CheckMurderPatch
                             if (target == null || RoleClass.FastMaker.CreatePlayers.Contains(__instance.PlayerId)) return false;
                             __instance.RpcShowGuardEffect(target);
                             RoleClass.FastMaker.CreatePlayers.Add(__instance.PlayerId);
-                            target.SetRoleRPC(RoleId.Madmate);//マッドにする
+                            Madmate.CreateMadmate(target);//クルーにして、マッドにする
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                             RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことにする
                             SuperNewRolesPlugin.Logger.LogInfo("[FastMakerSHR]マッドを作ったよ");


### PR DESCRIPTION
# [修正点]
- SHRでジャッカルフレンズを作成時、作成したジャッカルフレンズが守護天使になって死んでしまう問題を修正
  - ResetAndSetRoleからSHR時守護天使にするコードを削除)
- SHRでマッドメイカーがマッドを作成時、作成したマッドが守護天使になって死んでしまう問題を修正
  - 作成するコードをResetAndSetRoleに変更