### PR TITLE
役職カラー一部修正

### DIFF
--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -245,7 +245,7 @@ public static class RoleClass
     public static class Lighter
     {
         public static List<PlayerControl> LighterPlayer;
-        public static Color32 color = new(255, 255, 0, byte.MaxValue);
+        public static Color32 color = new(255, 236, 71, byte.MaxValue);
         public static float CoolTime;
         public static float DurationTime;
         public static bool IsLightOn;
@@ -583,7 +583,7 @@ public static class RoleClass
     public static class NiceScientist
     {
         public static List<PlayerControl> NiceScientistPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = Palette.CrewmateBlue;
         public static float CoolTime;
         public static float DurationTime;
         public static DateTime ButtonTimer;
@@ -2020,7 +2020,7 @@ public static class RoleClass
     public static class GhostMechanic
     {
         public static List<PlayerControl> GhostMechanicPlayer;
-        public static Color32 color = Color.blue;
+        public static Color32 color = new(25, 68, 142, byte.MaxValue);
         public static int LimitCount;
         public static Sprite GetButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.GhostMechanicRepairButton.png", 115f);
 
@@ -2649,7 +2649,7 @@ public static class RoleClass
     public static class Photographer
     {
         public static List<PlayerControl> PhotographerPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = new(141, 160, 182, byte.MaxValue);
         public static int BonusCount;
         public static List<byte> PhotedPlayerIds;
         public static bool IsPhotographerShared;

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -21,6 +21,8 @@ public static class RoleClass
     public static Color ImpostorRed = Palette.ImpostorRed;
     public static Color CrewmateWhite = Color.white;
     public static Color FoxPurple = Palette.Purple;
+    private static Color32 SheriffYellow = new(250, 191, 20, byte.MaxValue);
+    private static Color32 JackalBlue = new(0, 180, 235, byte.MaxValue);
     public static bool IsStart;
     public static List<byte> BlockPlayers;
 
@@ -198,8 +200,8 @@ public static class RoleClass
         Penguin.ClearAndReload();
         Dependents.ClearAndReload();
         LoversBreaker.ClearAndReload();
-            Jumbo.ClearAndReload();
-            //ロールクリア
+        Jumbo.ClearAndReload();
+        //ロールクリア
         Quarreled.ClearAndReload();
         Lovers.ClearAndReload();
         MapOption.MapOption.ClearAndReload();
@@ -292,7 +294,7 @@ public static class RoleClass
     public static class Sheriff
     {
         public static List<PlayerControl> SheriffPlayer;
-        public static Color32 color = new(255, 255, 0, byte.MaxValue);
+        public static Color32 color = SheriffYellow;
         public static PlayerControl currentTarget;
         public static float CoolTime;
         public static bool IsNeutralKill;
@@ -320,7 +322,7 @@ public static class RoleClass
     public static class MeetingSheriff
     {
         public static List<PlayerControl> MeetingSheriffPlayer;
-        public static Color32 color = new(255, 255, 0, byte.MaxValue);
+        public static Color32 color = SheriffYellow;
         public static bool NeutralKill;
         public static bool MadRoleKill;
         public static float KillMaxCount;
@@ -341,7 +343,7 @@ public static class RoleClass
         public static List<PlayerControl> JackalPlayer;
         public static List<PlayerControl> SidekickPlayer;
         public static List<PlayerControl> FakeSidekickPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
         public static float KillCooldown;
         public static bool IsUseVent;
         public static bool IsUseSabo;
@@ -858,7 +860,7 @@ public static class RoleClass
     public static class JackalFriends
     {
         public static List<PlayerControl> JackalFriendsPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
         public static bool IsUseVent;
         public static bool IsImpostorLight;
         public static bool IsJackalCheck;
@@ -1645,7 +1647,7 @@ public static class RoleClass
     public static class RemoteSheriff
     {
         public static List<PlayerControl> RemoteSheriffPlayer;
-        public static Color32 color = new(255, 255, 0, byte.MaxValue);
+        public static Color32 color = SheriffYellow;
         public static float CoolTime;
         public static bool IsNeutralKill;
         public static bool IsLoversKill;
@@ -1672,7 +1674,7 @@ public static class RoleClass
     public static class TeleportingJackal
     {
         public static List<PlayerControl> TeleportingJackalPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
         public static float KillCooldown;
         public static bool IsUseVent;
         public static bool IsUseSabo;
@@ -1753,7 +1755,7 @@ public static class RoleClass
     public static class SeerFriends
     {
         public static List<PlayerControl> SeerFriendsPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
 
         public static List<Vector3> deadBodyPositions;
 
@@ -1795,7 +1797,7 @@ public static class RoleClass
         public static List<PlayerControl> JackalSeerPlayer;
         public static List<PlayerControl> SidekickSeerPlayer;
         public static List<PlayerControl> FakeSidekickSeerPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
 
         public static List<Vector3> deadBodyPositions;
         public static float soulDuration;
@@ -1889,7 +1891,7 @@ public static class RoleClass
         public static List<PlayerControl> ChiefPlayer;
         public static List<byte> SheriffPlayer;
         public static List<byte> NoTaskSheriffPlayer;
-        public static Color32 color = new(255, 255, 0, byte.MaxValue);
+        public static Color32 color = SheriffYellow;
         public static bool IsCreateSheriff;
         public static float CoolTime;
         public static bool IsNeutralKill;
@@ -1972,7 +1974,7 @@ public static class RoleClass
     public static class MayorFriends
     {
         public static List<PlayerControl> MayorFriendsPlayer;
-        public static Color32 color = new(0, 255, 255, byte.MaxValue);
+        public static Color32 color = JackalBlue;
         public static bool IsUseVent;
         public static bool IsImpostorLight;
         public static bool IsJackalCheck;
@@ -2793,7 +2795,7 @@ public static class RoleClass
     public static class WaveCannonJackal
     {
         public static List<PlayerControl> WaveCannonJackalPlayer;
-        public static Color32 color = Jackal.color;
+        public static Color32 color = JackalBlue;
         public static void ClearAndReload()
         {
             WaveCannonJackalPlayer = new();


### PR DESCRIPTION
# [変更点]
- ジャッカル&フレンズ系、シェリフ系、ライター、亡霊整備士、ナイスサイエンティスト、写真家の役職の色を変更しました。<br><br>
- ジャッカル&フレンズ系はTORジャッカルの色に揃えました。
  - RoleClass.ImpostorRedのように、RoleClass.JackalBlueで色を制御するように変更しました。
    - privateで宣言しているので必要な場合はpublicに変えて下さい。
- シェリフ系の色はSheriffYellowで制御するようにしました。(同じくprivate宣言)

## ジャッカル系
![image](https://user-images.githubusercontent.com/104145991/210492097-4b917f14-ef66-4ec8-a0a3-a5b83b82da6a.png)

## シェリフ系
![image](https://user-images.githubusercontent.com/104145991/210492858-91f5bff8-465d-42b9-8573-8e2bb8f2abf3.png)

## ライター
![image](https://user-images.githubusercontent.com/104145991/210492947-0ccfaf2b-e297-46e6-9023-77a8c408514c.png)

## 亡霊整備士
![image](https://user-images.githubusercontent.com/104145991/210492990-03bb1033-2ac5-4b15-952f-8335c6d086fa.png)

## ナイスサイエンティスト
![image](https://user-images.githubusercontent.com/104145991/210492968-b8aa2fcc-eacd-449b-aca3-b495a7935d4a.png)
(科学者の色=クルーメイトの色に変更)

## 写真家
![image](https://user-images.githubusercontent.com/104145991/210493932-e8dc4702-76d2-43f0-84cd-bca52e150a2a.png)
