### PR TITLE
SHRのシーアズをいろいろ修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -123,16 +123,17 @@ static class HudManagerStartPatch
             () =>
             {
                 float killTimer = PlayerControl.LocalPlayer.killTimer;
-                ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, SetTarget(Crewmateonly:true));
+                ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, SetTarget(Crewmateonly: true));
                 RoleClass.Jumbo.Killed = true;
                 PlayerControl.LocalPlayer.killTimer = killTimer;
             },
             (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Jumbo && PlayerControl.LocalPlayer.IsImpostor() && !RoleClass.Jumbo.Killed && RoleClass.Jumbo.JumboSize.ContainsKey(PlayerControl.LocalPlayer.PlayerId) && RoleClass.Jumbo.JumboSize[PlayerControl.LocalPlayer.PlayerId] >= (CustomOptionHolder.JumboMaxSize.GetFloat() / 10); },
             () =>
             {
-                return SetTarget(Crewmateonly:true) && PlayerControl.LocalPlayer.CanMove;
+                return SetTarget(Crewmateonly: true) && PlayerControl.LocalPlayer.CanMove;
             },
-            () => {
+            () =>
+            {
                 JumboKillButton.MaxTimer = GameManager.Instance.LogicOptions.currentGameOptions.GetFloat(FloatOptionNames.KillCooldown);
                 JumboKillButton.Timer = JumboKillButton.MaxTimer;
             },
@@ -188,7 +189,8 @@ static class HudManagerStartPatch
                                 writer.Write(false);
                                 AmongUsClient.Instance.FinishRpcImmediately(writer);
                             }
-                        } else
+                        }
+                        else
                         {
                             MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetLoversBreakerWinner);
                             writer.Write(PlayerControl.LocalPlayer.PlayerId);
@@ -1132,12 +1134,19 @@ static class HudManagerStartPatch
                             }
                         }
                     }
-                    bool IsFakeSidekickSeer = EvilEraser.IsBlockAndTryUse(EvilEraser.BlockTypes.JackalSeerSidekick, target);
-                    MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.CreateSidekickSeer, SendOption.Reliable, -1);
-                    killWriter.Write(target.PlayerId);
-                    killWriter.Write(IsFakeSidekickSeer);
-                    AmongUsClient.Instance.FinishRpcImmediately(killWriter);
-                    RPCProcedure.CreateSidekickSeer(target.PlayerId, IsFakeSidekickSeer);
+                    if (RoleClass.JackalSeer.CanCreateFriend)
+                    {
+                        Jackal.CreateJackalFriends(target); //クルーにして フレンズにする
+                    }
+                    else
+                    {
+                        bool IsFakeSidekickSeer = EvilEraser.IsBlockAndTryUse(EvilEraser.BlockTypes.JackalSeerSidekick, target);
+                        MessageWriter killWriter = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.CreateSidekickSeer, SendOption.Reliable, -1);
+                        killWriter.Write(target.PlayerId);
+                        killWriter.Write(IsFakeSidekickSeer);
+                        AmongUsClient.Instance.FinishRpcImmediately(killWriter);
+                        RPCProcedure.CreateSidekickSeer(target.PlayerId, IsFakeSidekickSeer);
+                    }
                     RoleClass.JackalSeer.CanCreateSidekick = false;
                 }
             },

--- a/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/CoEnterVent.cs
@@ -26,6 +26,9 @@ class CoEnterVent
             case RoleId.Jackal:
                 if (RoleClass.Jackal.IsUseVent) return true;
                 break;
+            case RoleId.JackalSeer:
+                if (RoleClass.JackalSeer.IsUseVent) return true;
+                break;
             case RoleId.MadMaker:
                 if (RoleClass.MadMaker.IsUseVent) return true;
                 break;

--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -389,8 +389,17 @@ public static class FixedUpdate
                 FastDestroyableSingleton<HudManager>.Instance.KillButton.SetTarget(null);
             }
         }
-        else if (PlayerControl.LocalPlayer.IsRole(RoleId.Jackal, RoleId.MadMaker, RoleId.Egoist, RoleId.RemoteSheriff,
-            RoleId.Demon, RoleId.Arsonist)
+        else if
+            (PlayerControl.LocalPlayer.IsRole
+                (
+                    RoleId.Jackal,
+                    RoleId.JackalSeer,
+                    RoleId.MadMaker,
+                    RoleId.Egoist,
+                    RoleId.Demon,
+                    RoleId.Arsonist,
+                    RoleId.RemoteSheriff
+                )
             )
         {
             FastDestroyableSingleton<HudManager>.Instance.KillButton.gameObject.SetActive(true);

--- a/SuperNewRoles/Mode/SuperHostRoles/MurderPlayer.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/MurderPlayer.cs
@@ -61,5 +61,6 @@ class MurderPlayer
         }
         Roles.Bait.MurderPostfix(__instance, target);
         FixedUpdate.SetRoleName(target);
+        Seer.WrapUpPatch.MurderPlayerPatch.ShowFlash_SHR(target);
     }
 }

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -139,6 +139,7 @@ public static class RoleSelectHandler
         SetVanillaRole(RoleClass.SuicideWisher.SuicideWisherPlayer, RoleTypes.Shapeshifter, false);
         SetVanillaRole(RoleClass.Doppelganger.DoppelggerPlayer, RoleTypes.Shapeshifter, false);
         SetVanillaRole(RoleClass.Camouflager.CamouflagerPlayer, RoleTypes.Shapeshifter, false);
+        SetVanillaRole(RoleClass.EvilSeer.EvilSeerPlayer, RoleTypes.Shapeshifter, false);
         /*============シェイプシフター役職設定============*/
 
         foreach (PlayerControl Player in RoleClass.Egoist.EgoistPlayer)

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -145,6 +145,27 @@ public static class SyncSetting
                 }
                 optdata.SetFloat(FloatOptionNames.KillCooldown, KillCoolSet(RoleClass.Jackal.KillCooldown));
                 break;
+            case RoleId.JackalSeer:
+                if (!player.IsMod())
+                {
+                    if (!RoleClass.JackalSeer.IsImpostorLight)
+                    {
+                        optdata.SetFloat(FloatOptionNames.ImpostorLightMod, optdata.GetFloat(FloatOptionNames.CrewLightMod));
+                        var switchSystemJackal = MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>();
+                        if (switchSystemJackal != null && switchSystemJackal.IsActive) optdata.SetFloat(FloatOptionNames.ImpostorLightMod, optdata.GetFloat(FloatOptionNames.ImpostorLightMod) / 5);
+                    }
+                }
+                else
+                {
+                    if (RoleClass.JackalSeer.IsImpostorLight)
+                    {
+                        optdata.SetFloat(FloatOptionNames.CrewLightMod, optdata.GetFloat(FloatOptionNames.ImpostorLightMod));
+                        var switchSystem2 = MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>();
+                        if (switchSystem2 != null && switchSystem2.IsActive) optdata.SetFloat(FloatOptionNames.CrewLightMod, optdata.GetFloat(FloatOptionNames.ImpostorLightMod) * 15);
+                    }
+                }
+                optdata.SetFloat(FloatOptionNames.KillCooldown, KillCoolSet(RoleClass.JackalSeer.KillCooldown));
+                break;
             case RoleId.Demon:
                 optdata.SetFloat(FloatOptionNames.KillCooldown, KillCoolSet(RoleClass.Demon.CoolTime));
                 break;

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -186,6 +186,10 @@ public static class SyncSetting
                                                                  : (3f + RoleClass.Camouflager.DurationTime));
                 }
                 break;
+            case RoleId.EvilSeer:
+                optdata.SetFloat(FloatOptionNames.ShapeshifterCooldown, 0f);
+                optdata.SetFloat(FloatOptionNames.ShapeshifterDuration, 1f);
+                break;
         }
         if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
         optdata.SetBool(BoolOptionNames.ShapeshifterLeaveSkin, false);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -622,6 +622,7 @@ public class CustomOptionHolder
     public static CustomOption JackalSeerUseSabo;
     public static CustomOption JackalSeerIsImpostorLight;
     public static CustomOption JackalSeerCreateSidekick;
+    public static CustomOption JackalSeerCreateFriend;
     public static CustomOption JackalSeerSKCooldown;
     public static CustomOption JackalSeerNewJackalCreateSidekick;
 
@@ -1518,17 +1519,18 @@ public class CustomOptionHolder
         SeerFriendsLongTask = SeerFriendsoption.Item3;
         SeerFriendsCheckJackalTask = Create(374, true, CustomOptionType.Crewmate, "MadmateCheckImpostorTaskSetting", rates4, SeerFriendsIsCheckJackal);
 
-        JackalSeerOption = SetupCustomRoleOption(375, false, RoleId.JackalSeer);
-        JackalSeerPlayerCount = Create(376, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], JackalSeerOption);
+        JackalSeerOption = SetupCustomRoleOption(375, true, RoleId.JackalSeer);
+        JackalSeerPlayerCount = Create(376, true, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], JackalSeerOption);
         JackalSeerMode = Create(377, false, CustomOptionType.Neutral, "SeerMode", new string[] { "SeerModeBoth", "SeerModeFlash", "SeerModeSouls" }, JackalSeerOption);
         JackalSeerLimitSoulDuration = Create(378, false, CustomOptionType.Neutral, "SeerLimitSoulDuration", false, JackalSeerOption);
         JackalSeerSoulDuration = Create(379, false, CustomOptionType.Neutral, "SeerSoulDuration", 15f, 0f, 120f, 5f, JackalSeerLimitSoulDuration, format: "unitCouples");
         JackalSeerKillCooldown = Create(380, false, CustomOptionType.Neutral, "JackalCooldownSetting", 30f, 2.5f, 60f, 2.5f, JackalSeerOption, format: "unitSeconds");
-        JackalSeerUseVent = Create(381, false, CustomOptionType.Neutral, "JackalUseVentSetting", true, JackalSeerOption);
-        JackalSeerUseSabo = Create(382, false, CustomOptionType.Neutral, "JackalUseSaboSetting", false, JackalSeerOption);
-        JackalSeerIsImpostorLight = Create(383, false, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, JackalSeerOption);
+        JackalSeerUseVent = Create(381, true, CustomOptionType.Neutral, "JackalUseVentSetting", true, JackalSeerOption);
+        JackalSeerUseSabo = Create(382, true, CustomOptionType.Neutral, "JackalUseSaboSetting", false, JackalSeerOption);
+        JackalSeerIsImpostorLight = Create(383, true, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, JackalSeerOption);
         JackalSeerCreateSidekick = Create(384, false, CustomOptionType.Neutral, "JackalCreateSidekickSetting", false, JackalSeerOption);
-        JackalSeerSKCooldown = Create(1109, true, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalSeerCreateSidekick, format: "unitSeconds");
+        JackalSeerCreateFriend = Create(1143, true, CustomOptionType.Neutral, "JackalCreateFriendSetting", false, JackalSeerOption);
+        JackalSeerSKCooldown = Create(1109, false, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalSeerCreateSidekick, format: "unitSeconds");
         JackalSeerNewJackalCreateSidekick = Create(385, false, CustomOptionType.Neutral, "JackalNewJackalCreateSidekickSetting", false, JackalSeerCreateSidekick);
 
         AssassinAndMarineOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarineName", Color.white, 1);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1128,7 +1128,7 @@ public class CustomOptionHolder
         JackalIsImpostorLight = Create(63, true, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, JackalOption);
         JackalCreateFriend = Create(666, true, CustomOptionType.Neutral, "JackalCreateFriendSetting", false, JackalOption);
         JackalCreateSidekick = Create(64, false, CustomOptionType.Neutral, "JackalCreateSidekickSetting", false, JackalOption);
-        JackalSKCooldown = Create(1108, true, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalCreateSidekick, format: "unitSeconds");
+        JackalSKCooldown = Create(1108, false, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalCreateSidekick, format: "unitSeconds");
         JackalNewJackalCreateSidekick = Create(65, false, CustomOptionType.Neutral, "JackalNewJackalCreateSidekickSetting", false, JackalCreateSidekick);
 
         TeleporterOption = SetupCustomRoleOption(66, false, RoleId.Teleporter);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -486,16 +486,6 @@ static class CheckMurderPatch
                 Logger.Info("SHR", "CheckMurder");
                 if (RoleClass.Assassin.TriggerPlayer != null) return false;
                 Logger.Info("SHR-Assassin.TriggerPlayerを通過", "CheckMurder");
-                foreach (var p in Seer.Seers)
-                {
-                    if (p == null) continue;
-                    foreach (var p2 in p)
-                    {
-                        if (p2 == null) continue;
-                        if (!p2.IsMod())
-                            p2.ShowReactorFlash(1.5f);
-                    }
-                }
                 switch (__instance.GetRole())
                 {
                     case RoleId.RemoteSheriff:

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -217,6 +217,8 @@ class RpcShapeshiftPatch
                         SyncSetting.CustomSyncSettings(__instance);
                     }
                     return true;
+                case RoleId.EvilSeer:
+                    return false;//shapeとしての能力は持たせない為、誤爆封じで導入者のみ使用不可にする。
             }
         }
         return true;

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -667,6 +667,29 @@ static class CheckMurderPatch
                             else SuperNewRolesPlugin.Logger.LogInfo("[JackalSHR] 不正なキル");
                         }
                         break;
+                    case RoleId.JackalSeer:
+                        if (!RoleClass.JackalSeer.CreatePlayers.Contains(__instance.PlayerId) && RoleClass.JackalSeer.CanCreateFriend)//まだ作ってなくて、設定が有効の時
+                        {
+                            Logger.Info("未作成 且つ 設定が有効である為 フレンズを作成", "JackalSeerSHR");
+                            if (target == null || RoleClass.JackalSeer.CreatePlayers.Contains(__instance.PlayerId)) return false;
+                            __instance.RpcShowGuardEffect(target);
+                            RoleClass.JackalSeer.CreatePlayers.Add(__instance.PlayerId);
+                            if (!target.IsImpostor())
+                            {
+                                Jackal.CreateJackalFriends(target);//クルーにして フレンズにする
+                            }
+                            Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
+                            Logger.Info("ジャッカルフレンズを作成しました。", "JackalSeerSHR");
+                            return false;
+                        }
+                        else
+                        {
+                            // キルができた理由のログを表示する(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
+                            if (!RoleClass.JackalSeer.CanCreateFriend) Logger.Info("ジャッカルフレンズを作る設定ではない為 普通のキル", "JackalSeerSHR");
+                            else if (RoleClass.JackalSeer.CanCreateFriend && RoleClass.JackalSeer.CreatePlayers.Contains(__instance.PlayerId)) Logger.Info("ジャッカルフレンズ作成済みの為 普通のキル", "JackalSeerSHR");
+                            else Logger.Info("不正なキル", "JackalSeerSHR");
+                        }
+                        break;
                     case RoleId.DarkKiller:
                         var ma = MapUtilities.CachedShipStatus.Systems[SystemTypes.Electrical].CastFast<SwitchSystem>();
                         if (ma != null && !ma.IsActive) return false;

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -795,6 +795,7 @@ DarkKillerKillCoolSetting,Dark Killer's Kill Cool Time,ダークキラーのキ�
 FoxName,Fox,妖狐,妖狐
 FoxTitle1,I am Fox!,私は狐です!,我是一只小狐狸！
 SeerName,Seer,シーア,灵媒
+SeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いてインポスターを特定しましょう。
 SeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡
 SeerMode,Mode,モード,灵媒模式
 SeerModeBoth,Show Death Flash + Souls,死の点滅＆幽霊が見える,显示死亡闪光和灵魂
@@ -803,8 +804,10 @@ SeerModeSouls,Show Souls,幽霊が見える,显示灵魂
 SeerLimitSoulDuration,Limit Soul Duration,時間経過で幽霊が消える,灵魂随时间的推移消失
 SeerSoulDuration,Soul Duration,幽霊が見える時間,灵魂从出现到消失经过的时间
 MadSeerName,MadSeer,マッドシーア,叛变的灵媒
+MadSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いて村を陽動しましょう。
 MadSeerTitle1,Feel the success of your husband,ご主人の活躍を感じ取ろう,感知内鬼的行动
 EvilSeerName,EvilSeer,イビルシーア,邪恶的灵媒
+EvilSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n相方の行動を把握しサポートに回りましょう。
 EvilSeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡
 RemoteSheriffName,Remote Sheriff,リモートシェリフ,超能警长
 RemoteSheriffTitle1,Let's do a Remote Sheriff kill!,遠隔でシェリフキルをしよう,远距离进行执法
@@ -821,10 +824,13 @@ TaskManagerName,TaskManager,タスクマネージャー,代理人
 TaskManagerTitle1,Finish the task and mount up!,タスクを終わらせ、マウントを取ろう,帮助他人完成所有任务
 SeerFriendsName,SeerFriends,シーアフレンズ,狈族灵媒
 SeerFriendsTitle1,Let's feel the activity of Jackal,ジャッカルの活躍を感じ取ろう,感知豺狼的行动
+SeerFriendsDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いて村を陽動しましょう。
 JackalSeerName,SeerJackal,ジャッカルシーア,狼族灵媒
 JackalSeerTitle1,Detect the dead and bring victory to your camp!,死者を感知し自陣営に勝利をもたらせ!,感知死亡，为豺狼带来胜利
+JackalSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\nインポスターの行動を把握し、利用しましょう。
 SidekickSeerName,Sidekick(Seer),サイドキック(シーア),狼族灵媒学徒
 SidekickSeerTitle1,Let's help Jackal with the dead detection ability that we got,貰った死者感知能力でジャッカルを助けよう,用死亡感知能力来帮助豺狼
+SidekickSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いて、親ジャッカルを守り、時には切り、貢献しましょう。
 AssassinAndMarineName,<color=#ff0000>Assassin</color> and <color=#AFDFE4>Merine</color>,<color=#ff0000>アサシン</color>と<color=#AFDFE4>マーリン</color>,<color=#ff0000>阿</color>瓦<color=#AFDFE4>隆</color>
 AssassinSettingPlayerCountName,Number of <color=#ff0000>Assassin</color>,<color=#ff0000>アサシン</color>の人数,<color=#ff0000>刺客</color>的人数
 MarineSettingPlayerCountName,Number of <color=#AFDFE4>Merine</color>,<color=#AFDFE4>マーリン</color>の人数,<color=#AFDFE4>梅林</color>的人数

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -191,7 +191,7 @@ class Seer
                         if (!p2.IsMod())
                         {
                             p2.ShowReactorFlash(1.5f);
-                            Logger.Info($"{p2.GetRole()}である{p2.GetDefaultName()}に死の点滅を発生させました。", "MurderPlayer");
+                            Logger.Info($"非導入者で尚且つ[ {p2.GetRole()} ]である{p2.GetDefaultName()}に死の点滅を発生させました。", "MurderPlayer");
                         }
                     }
                 }

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -1,3 +1,5 @@
+using SuperNewRoles.Mode;
+using SuperNewRoles.Mode.SuperHostRoles;
 using System;
 using System.Collections.Generic;
 using HarmonyLib;
@@ -176,6 +178,22 @@ class Seer
                     if (PlayerControl.LocalPlayer.IsAlive() && CachedPlayer.LocalPlayer.PlayerId != target.PlayerId && ModeFlag)
                     {
                         ShowFlash(new Color(42f / 255f, 187f / 255f, 245f / 255f));
+                    }
+                }
+            }
+            public static void ShowFlash_SHR(PlayerControl target)
+            {
+                Logger.Info($"1", "ShowFlash");
+                foreach (var p in Seers)
+                {
+                    if (p == null) continue;
+                    foreach (var p2 in p)
+                    {
+                        if (p2 == null) continue;
+                        if (!p2.IsMod())
+                        {
+                            p2.ShowReactorFlash(1.5f);
+                        }
                     }
                 }
             }

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -183,7 +183,6 @@ class Seer
             }
             public static void ShowFlash_SHR(PlayerControl target)
             {
-                Logger.Info($"1", "ShowFlash");
                 foreach (var p in Seers)
                 {
                     if (p == null) continue;

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -10,14 +10,6 @@ namespace SuperNewRoles.Roles;
 class Seer
 //マッド・イビル・フレンズ・ジャッカル・サイドキック　シーア
 {
-    public static List<List<PlayerControl>> Seers = new() {
-            RoleClass.Seer.SeerPlayer,
-            RoleClass.EvilSeer.EvilSeerPlayer,
-            RoleClass.MadSeer.MadSeerPlayer,
-            RoleClass.JackalSeer.JackalSeerPlayer,
-            RoleClass.SeerFriends.SeerFriendsPlayer
-        };
-
     public static SpriteRenderer FullScreenRenderer;
 
     /** <summary>
@@ -183,7 +175,14 @@ class Seer
             }
             public static void ShowFlash_SHR(PlayerControl target)
             {
-                foreach (var p in Seers)
+                List<List<PlayerControl>> seers = new() {
+                    RoleClass.Seer.SeerPlayer,
+                    RoleClass.EvilSeer.EvilSeerPlayer,
+                    RoleClass.MadSeer.MadSeerPlayer,
+                    RoleClass.JackalSeer.JackalSeerPlayer,
+                    RoleClass.SeerFriends.SeerFriendsPlayer
+                };
+                foreach (var p in seers)
                 {
                     if (p == null) continue;
                     foreach (var p2 in p)
@@ -192,6 +191,7 @@ class Seer
                         if (!p2.IsMod())
                         {
                             p2.ShowReactorFlash(1.5f);
+                            Logger.Info($"{p2.GetRole()}である{p2.GetDefaultName()}に死の点滅を発生させました。", "MurderPlayer");
                         }
                     }
                 }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -198,8 +198,8 @@ public static class RoleClass
         Penguin.ClearAndReload();
         Dependents.ClearAndReload();
         LoversBreaker.ClearAndReload();
-            Jumbo.ClearAndReload();
-            //ロールクリア
+        Jumbo.ClearAndReload();
+        //ロールクリア
         Quarreled.ClearAndReload();
         Lovers.ClearAndReload();
         MapOption.MapOption.ClearAndReload();
@@ -1577,7 +1577,7 @@ public static class RoleClass
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.SeerLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.SeerSoulDuration.GetFloat();
-            mode = CustomOptionHolder.SeerMode.GetSelection();
+            mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.SeerMode.GetSelection();
 
             Roles.Seer.FullScreenRenderer = GameObject.Instantiate(FastDestroyableSingleton<HudManager>.Instance.FullScreen, FastDestroyableSingleton<HudManager>.Instance.transform);
         }
@@ -1603,7 +1603,7 @@ public static class RoleClass
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.MadSeerLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.MadSeerSoulDuration.GetFloat();
-            mode = CustomOptionHolder.MadSeerMode.GetSelection();
+            mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.MadSeerMode.GetSelection();
 
             IsImpostorCheck = CustomOptionHolder.MadSeerIsCheckImpostor.GetBool();
             IsUseVent = CustomOptionHolder.MadSeerIsUseVent.GetBool();
@@ -1638,7 +1638,7 @@ public static class RoleClass
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.EvilSeerLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.EvilSeerSoulDuration.GetFloat();
-            mode = CustomOptionHolder.EvilSeerMode.GetSelection();
+            mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.EvilSeerMode.GetSelection();
             IsCreateMadmate = CustomOptionHolder.EvilSeerMadmateSetting.GetBool();
         }
     }
@@ -1772,7 +1772,7 @@ public static class RoleClass
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.SeerFriendsLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.SeerFriendsSoulDuration.GetFloat();
-            mode = CustomOptionHolder.SeerFriendsMode.GetSelection();
+            mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.SeerFriendsMode.GetSelection();
 
             IsJackalCheck = CustomOptionHolder.SeerFriendsIsCheckJackal.GetBool();
             IsUseVent = CustomOptionHolder.SeerFriendsIsUseVent.GetBool();
@@ -1820,7 +1820,7 @@ public static class RoleClass
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.JackalSeerLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.JackalSeerSoulDuration.GetFloat();
-            mode = CustomOptionHolder.JackalSeerMode.GetSelection();
+            mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.JackalSeerMode.GetSelection();
 
             KillCooldown = CustomOptionHolder.JackalSeerKillCooldown.GetFloat();
             IsUseVent = CustomOptionHolder.JackalSeerUseVent.GetBool();

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -1795,6 +1795,7 @@ public static class RoleClass
         public static List<PlayerControl> JackalSeerPlayer;
         public static List<PlayerControl> SidekickSeerPlayer;
         public static List<PlayerControl> FakeSidekickSeerPlayer;
+        public static List<int> CreatePlayers;
         public static Color32 color = new(0, 255, 255, byte.MaxValue);
 
         public static List<Vector3> deadBodyPositions;
@@ -1809,6 +1810,7 @@ public static class RoleClass
         public static bool CreateSidekick;
         public static bool NewJackalCreateSidekick;
         public static bool CanCreateSidekick;
+        public static bool CanCreateFriend;
         public static Sprite GetButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.JackalSeerSidekickButton.png", 115f);
 
         public static void ClearAndReload()
@@ -1816,6 +1818,7 @@ public static class RoleClass
             JackalSeerPlayer = new();
             SidekickSeerPlayer = new();
             FakeSidekickSeerPlayer = new();
+            CreatePlayers = new();
 
             deadBodyPositions = new();
             limitSoulDuration = CustomOptionHolder.JackalSeerLimitSoulDuration.GetBool();
@@ -1828,6 +1831,7 @@ public static class RoleClass
             IsImpostorLight = CustomOptionHolder.JackalSeerIsImpostorLight.GetBool();
             CreateSidekick = CustomOptionHolder.JackalSeerCreateSidekick.GetBool();
             CanCreateSidekick = CustomOptionHolder.JackalSeerCreateSidekick.GetBool();
+            CanCreateFriend = CustomOptionHolder.JackalSeerCreateFriend.GetBool();
             NewJackalCreateSidekick = CustomOptionHolder.JackalSeerNewJackalCreateSidekick.GetBool();
         }
     }


### PR DESCRIPTION
# [修正点]
- 非導入者Seersのキルフラッシュが発動しない問題を修正
  - Seersのリストが初期化タイミングに問題があった為、常に「Seersがいない」扱いになっていた。
  - flash発動時にlocalでリストを作成するように変更。

- SHR時においてSeersが「死の点滅が見える」以外のモードを使用できた(内部設定影響で)問題を修正。

# [変更点]
- SeersのDescription追加

- イビルシーアをSHR時は「シェイプシフター」に変更。
  - イビル科学者要員
    - シェイプシフト画面で死亡者スキン表示になっている場合、死亡している事が分かる為この仕様(かバグかは知らない)を利用してインポスター版 科学者能力として扱う
    - ![image](https://user-images.githubusercontent.com/104145991/211502004-0a86ea37-e15a-4c8d-834f-20c16862a503.png)
  - SNRでこの仕様(というよりバイタルを持たせる仕様)にしないのは別口の能力追加を考えているからです。
    - (EvilSeerにこの能力を持たせるのは、「本来持たせたい能力」のHostMode制限版扱い)

- ジャッカルシーアSHR対応
  - SeersSHR対応時に、ジャッカルシーアの挙動に問題がありジャッカルシーアのみ未対応にしていた為、新規SHR対応役扱いに。
    - 導入者がキルできなかった問題を修正
      - 純正キルボタンを使用するように変更
    - 非導入者のベント設定が取得されていなかった問題の修正。
    - 導入者、非導入者共に視界設定が取得されていなかった問題の修正。
  
  - ジャッカルシーアのSHR対応でSKJFの機能を追加した為、SNRでもSKJFが使えるように変更した。
    - SNRもSHRもシーアフレンズではなくジャッカルフレンズを作成します。
   