### PR TITLE
SHRにおいてマッドがベント移動できない設定およびベントアニメーション無効化設定が反映されている問題を修正

### DIFF
--- a/SuperNewRoles/Buttons/VentAndSabo.cs
+++ b/SuperNewRoles/Buttons/VentAndSabo.cs
@@ -94,7 +94,7 @@ public static class VentAndSabo
     {
         public static bool Prefix([HarmonyArgument(0)] PlayerControl pc)
         {
-            return !MapOption.MapOption.VentAnimation.GetBool() || pc.AmOwner;
+            return !MapOption.MapOption.CanNotVentAnimation || pc.AmOwner;
         }
     }
     [HarmonyPatch(typeof(Vent), nameof(Vent.ExitVent))]
@@ -102,7 +102,7 @@ public static class VentAndSabo
     {
         public static bool Prefix([HarmonyArgument(0)] PlayerControl pc)
         {
-            return !MapOption.MapOption.VentAnimation.GetBool() || pc.AmOwner;
+            return !MapOption.MapOption.CanNotVentAnimation || pc.AmOwner;
         }
     }
     [HarmonyPatch(typeof(Vent), nameof(Vent.CanUse))]

--- a/SuperNewRoles/Buttons/VentAndSabo.cs
+++ b/SuperNewRoles/Buttons/VentAndSabo.cs
@@ -178,7 +178,7 @@ public static class VentAndSabo
     {
         public static void Prefix(Vent __instance, ref bool enabled)
         {
-            if (PlayerControl.LocalPlayer.IsMadRoles() && !CustomOptionHolder.MadRolesCanVentMove.GetBool()) enabled = false;
+            if (!Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) && PlayerControl.LocalPlayer.IsMadRoles() && !CustomOptionHolder.MadRolesCanVentMove.GetBool()) enabled = false;
         }
     }
 

--- a/SuperNewRoles/MapOption/MapOption.cs
+++ b/SuperNewRoles/MapOption/MapOption.cs
@@ -188,7 +188,7 @@ public class MapOption
         MiraReactorTimeLimit = CustomOption.Create(470, true, CustomOptionType.Generic, "MiraReactorTime", 30f, 0f, 100f, 1f, ReactorDurationOption);
         AirshipReactorTimeLimit = CustomOption.Create(471, true, CustomOptionType.Generic, "AirshipReactorTime", 30f, 0f, 100f, 1f, ReactorDurationOption);
 
-        VentAnimation = CustomOption.Create(600, false, CustomOptionType.Generic, "VentAnimation", false, MapOptionSetting);
+        VentAnimation = CustomOption.Create(600, false, CustomOptionType.Generic, "VentAnimation", false, MapOptionSetting); //true時ベントアニメーション無効化
 
         WireTaskIsRandomOption = CustomOption.Create(956, false, CustomOptionType.Generic, "WireTaskIsRandom", false, MapOptionSetting);
         WireTaskNumOption = CustomOption.Create(957, false, CustomOptionType.Generic, "WireTaskNum", 5f, 1f, 8f, 1f, WireTaskIsRandomOption);

--- a/SuperNewRoles/MapOption/MapOption.cs
+++ b/SuperNewRoles/MapOption/MapOption.cs
@@ -39,6 +39,7 @@ public class MapOption
     //private static Sprite buttonSprite;
     public static float Default;
     public static float CameraDefault;
+    public static bool CanNotVentAnimation;
     public static void ClearAndReload()
     {
         if (MapOptionSetting.GetBool())
@@ -76,6 +77,7 @@ public class MapOption
             WireTaskNum = WireTaskNumOption.GetInt();
             UseDeadBodyReport = !NotUseReportDeadBody.GetBool();
             UseMeetingButton = !NotUseMeetingButton.GetBool();
+            CanNotVentAnimation = !ModeHandler.IsMode(ModeId.SuperHostRoles) && VentAnimation.GetBool();
             //SuperNewRoles.Patches.AdminPatch.ClearAndReload();
             //SuperNewRoles.Patches.CameraPatch.ClearAndReload();
             //SuperNewRoles.Patches.VitalsPatch.ClearAndReload();
@@ -94,6 +96,7 @@ public class MapOption
             ValidationPolus = false;
             ValidationAirship = false;
             WireTaskIsRandom = false;
+            CanNotVentAnimation = false;
         }
         BlockTool.OldDesyncCommsPlayers = new();
         BlockTool.CameraPlayers = new();


### PR DESCRIPTION
# [修正点]
- SHR時に導入者は「マッドロールがベント移動できない」内部設定を反映している問題を修正。 
  - SHR時は設定を無効にするようにした。

- ベントアニメ無効化がSHR時及びマップの設定がオフ時でも有効な問題を修正
  - ベントアニメーション無効化の条件を[CanNotVentAnimation]という変数に格納するように変更
    - VentAnimationでは翻訳文を確認しないと変数の意味が分からなかった為。
    - ベント無効化条件に「SHRでない」「マップの設定が有効化である」という条件も追加したことから、直接Getbool形式では分かりにくい為。
    - ベントに入る人がいるたび3つの条件をいちいち判断するのはどうかと思った為。