### PR TITLE
CustomHats.csのパスがInnerSlothフォルダに移動していた為buildできなかった問題を修正

### DIFF
--- a/SuperNewRoles/CustomCosmetics/CustomHats.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomHats.cs
@@ -551,6 +551,7 @@ public class CustomHatLoader
 
             { "https://raw.githubusercontent.com/hinakkyu/TheOtherHats/master", "mememurahat" },
             { "https://raw.githubusercontent.com/Ujet222/TOPHats/main", "YJ" },
+            { "https://raw.githubusercontent.com/catudon1276/Mememura-Hats/main", "MememuraByCatudon" },
         };
 
     public static List<string> CachedRepos = new();

--- a/SuperNewRoles/CustomCosmetics/CustomHats.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomHats.cs
@@ -551,7 +551,6 @@ public class CustomHatLoader
 
             { "https://raw.githubusercontent.com/hinakkyu/TheOtherHats/master", "mememurahat" },
             { "https://raw.githubusercontent.com/Ujet222/TOPHats/main", "YJ" },
-            { "https://raw.githubusercontent.com/catudon1276/Mememura-Hats/main", "MememuraByCatudon" },
         };
 
     public static List<string> CachedRepos = new();


### PR DESCRIPTION
~~Reverts ykundesu/SuperNewRoles#928~~
~~ちょっと動かなくなったんでいったん戻しましょう~~

変更
CustomHats.csのパスがInnerSlothフォルダに移動していた為、build不可になっていた問題を修正