### PR TITLE
ヴァルチャーが勝利できない問題及び能力使用後のクールリセットがない問題を修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1896,6 +1896,7 @@ static class HudManagerStartPatch
             () =>
             {
                 Vulture.RpcCleanDeadBody(RoleClass.Vulture.DeadBodyCount);
+                RoleClass.Vulture.DeadBodyCount--;
 
                 if (RoleClass.Vulture.DeadBodyCount < 0)
                 {

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1916,6 +1916,7 @@ static class HudManagerStartPatch
                         AmongUsClient.Instance.FinishRpcImmediately(writer2);
                     }
                 }
+                Vulture.ResetCoolDown();
             },
             (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Vulture; },
             () =>
@@ -1924,8 +1925,7 @@ static class HudManagerStartPatch
             },
             () =>
             {
-                VultureButton.MaxTimer = RoleClass.Vulture.CoolTime;
-                VultureButton.Timer = RoleClass.Vulture.CoolTime;
+                Vulture.EndMeeting();
             },
             RoleClass.Vulture.GetButtonSprite(),
             new Vector3(-2f, 1, 0),

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1898,7 +1898,7 @@ static class HudManagerStartPatch
                 Vulture.RpcCleanDeadBody(RoleClass.Vulture.DeadBodyCount);
                 RoleClass.Vulture.DeadBodyCount--;
 
-                if (RoleClass.Vulture.DeadBodyCount < 0)
+                if (RoleClass.Vulture.DeadBodyCount <= 0)
                 {
                     RPCProcedure.ShareWinner(CachedPlayer.LocalPlayer.PlayerId);
                     MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.ShareWinner, SendOption.Reliable, -1);

--- a/SuperNewRoles/Roles/Neutral/Vulture.cs
+++ b/SuperNewRoles/Roles/Neutral/Vulture.cs
@@ -1,4 +1,5 @@
 using SuperNewRoles.CustomObject;
+using SuperNewRoles.Buttons;
 using UnityEngine;
 using Hazel;
 
@@ -70,5 +71,16 @@ public class Vulture
                 }
             }
         }
+    }
+
+    public static void EndMeeting()
+    {
+        ResetCoolDown();
+    }
+
+    public static void ResetCoolDown()
+    {
+        HudManagerStartPatch.VultureButton.MaxTimer = RoleClass.Vulture.CoolTime;
+        HudManagerStartPatch.VultureButton.Timer = RoleClass.Vulture.CoolTime;
     }
 }


### PR DESCRIPTION
# [修正点]
- ヴァルチャーが勝利できない問題
  - ヴァルチャーが死体を喰らった際、死体数がカウント(デクリメント)されていなかった問題を修正。
  - ヴァルチャーの勝利判定に必要な死体数が「設定数+1」になっていた問題を修正。
    - 上のコードになるべき所が下のコードになっていた。
    ```cs
    RoleClass.Vulture.DeadBodyCount <= 0
    ```
    ```cs
    RoleClass.Vulture.DeadBodyCount < 0
    ```

- 能力使用後のクールリセットがない問題