### PR TITLE
SNRの公開投票修正&死亡後の公開投票の設定&アサシンとマーリンに公開投票の設定&Marlinの誤字を修正

### DIFF
--- a/READMEs/README_en.md
+++ b/READMEs/README_en.md
@@ -146,7 +146,7 @@ Please use the Discord server:[Discord server](https://discord.gg/Cqfwx82ynN)
 | [EvilSeer](#EvilSeer)                   | [Spirit Medium](#SpiritMedium)            |
 | [DarkKiller](#DarkKiller)               | [MadMayor](#MadMayor)                     |
 | [Vampire](#Vampire)                     | [NiceHawk](#NiceHawk)                     |
-| [AssassinAndMarine](#AssassinAndMarine) | [MadStuntman](#MadStuntman)               |
+| [AssassinAndMarlin](#AssassinAndMarlin) | [MadStuntman](#MadStuntman)               |
 | [Cleaner](#Cleaner)                     | [MadHawk](#MadHawk)                       |
 | [Samurai](#Samurai)                     | [Bakery](#Bakery)                         |
 | [VentMaker](#VentMaker)                 | [MadJester](#MadJester)                   |

--- a/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/FixedUpdate.cs
@@ -109,7 +109,7 @@ public static class FixedUpdate
 
         if (Madmate.CheckImpostor(player) ||
             MadMayor.CheckImpostor(player) ||
-            player.IsRole(RoleId.Marine) ||
+            player.IsRole(RoleId.Marlin) ||
             BlackCat.CheckImpostor(player))
         {
             foreach (PlayerControl Impostor in CachedPlayer.AllPlayers)

--- a/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/RoleSelectHandler.cs
@@ -69,7 +69,7 @@ public static class RoleSelectHandler
                 crewmate++;
                 crewmate++;
             }
-            else if (CustomOptionHolder.AssassinAndMarineOption.GetSelection() != 0)
+            else if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() != 0)
             {
                 PlayerControl bot1 = BotManager.Spawn("暗転対策BOT1");
                 bot1.RpcSetRole(RoleTypes.Crewmate);
@@ -88,9 +88,9 @@ public static class RoleSelectHandler
             {
                 BotManager.Spawn("パン屋BOT").Exiled();
             }
-            else if (CustomOptionHolder.AssassinAndMarineOption.GetSelection() != 0)
+            else if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() != 0)
             {
-                BotManager.Spawn(ModTranslation.GetString("AssassinAndMarineName") + "BOT").Exiled();
+                BotManager.Spawn(ModTranslation.GetString("AssassinAndMarlinName") + "BOT").Exiled();
             }
         }
     }
@@ -331,7 +331,7 @@ public static class RoleSelectHandler
             }
         }
 
-        var Assassinselection = CustomOptionHolder.AssassinAndMarineOption.GetSelection();
+        var Assassinselection = CustomOptionHolder.AssassinAndMarlinOption.GetSelection();
         SuperNewRolesPlugin.Logger.LogInfo("[SHR] アサイン情報:" + Assassinselection + "、" + AllRoleSetClass.CrewmatePlayerNum + "、" + AllRoleSetClass.CrewmatePlayers.Count);
         if (Assassinselection != 0 && AllRoleSetClass.CrewmatePlayerNum > 0 && AllRoleSetClass.CrewmatePlayers.Count > 0)
         {

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -52,12 +52,6 @@ public static class SyncSetting
                 optdata.SetFloat(FloatOptionNames.ShapeshifterCooldown, RoleClass.Samurai.SwordCoolTime);
                 optdata.SetFloat(FloatOptionNames.ShapeshifterDuration, RoleClass.Samurai.SwordCoolTime);
                 break;
-            case RoleId.God:
-                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.God.IsVoteView);
-                break;
-            case RoleId.Observer:
-                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
-                break;
             case RoleId.MadMaker:
                 if (!player.IsMod())
                 {
@@ -182,12 +176,29 @@ public static class SyncSetting
                 if (RoleClass.Camouflager.IsCamouflage)
                 {
                     optdata.SetFloat(FloatOptionNames.ShapeshifterCooldown,
-                            RoleClass.Camouflager.CoolTime >= 5f ? (RoleClass.Camouflager.CoolTime + RoleClass.Camouflager.DurationTime - 2f)
-                                                                 : (3f + RoleClass.Camouflager.DurationTime));
+                            RoleClass.Camouflager.CoolTime >= 5f ? (RoleClass.Camouflager.CoolTime + RoleClass.Camouflager.DurationTime - 2f) : (3f + RoleClass.Camouflager.DurationTime));
                 }
                 break;
         }
-        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
+        {
+            //投票開示処理
+
+            //var role = player.GetRole();
+            //var optdata = SyncSetting.OptionData.DeepCopy();
+
+            switch (role)
+            {
+                case RoleId.God:
+                    optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.God.IsVoteView);
+                    break;
+                case RoleId.Observer:
+                    optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
+                    break;
+            }
+            if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
+            Logger.Info("ぷぇ");
+        }
+        //AnonymousVotes.VoteSyncSetting(player);
         optdata.SetBool(BoolOptionNames.ShapeshifterLeaveSkin, false);
         if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
         optdata.RpcSyncOption(player.GetClientId());

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -180,25 +180,7 @@ public static class SyncSetting
                 }
                 break;
         }
-        {
-            //投票開示処理
-
-            //var role = player.GetRole();
-            //var optdata = SyncSetting.OptionData.DeepCopy();
-
-            switch (role)
-            {
-                case RoleId.God:
-                    optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.God.IsVoteView);
-                    break;
-                case RoleId.Observer:
-                    optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
-                    break;
-            }
-            if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
-            Logger.Info("ぷぇ");
-        }
-        //AnonymousVotes.VoteSyncSetting(player);
+        optdata.SetBool(BoolOptionNames.AnonymousVotes, OpenVotes.VoteSyncSetting(player));
         optdata.SetBool(BoolOptionNames.ShapeshifterLeaveSkin, false);
         if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
         optdata.RpcSyncOption(player.GetClientId());

--- a/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/SyncSetting.cs
@@ -205,7 +205,6 @@ public static class SyncSetting
                 optdata.SetFloat(FloatOptionNames.ShapeshifterDuration, 1f);
                 break;
         }
-        optdata.SetBool(BoolOptionNames.AnonymousVotes, OpenVotes.VoteSyncSetting(player));
         optdata.SetBool(BoolOptionNames.ShapeshifterLeaveSkin, false);
         if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
         optdata.RpcSyncOption(player.GetClientId());
@@ -234,8 +233,19 @@ public static class SyncSetting
             default:
                 return;
         }
-        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
         optdata.SetBool(BoolOptionNames.ShapeshifterLeaveSkin, false);
+        if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
+        optdata.RpcSyncOption(player.GetClientId());
+    }
+
+    public static void MeetingSyncSettings(this PlayerControl player)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        var role = player.GetRole();
+        var optdata = OptionData.DeepCopy();
+
+        optdata.SetBool(BoolOptionNames.AnonymousVotes, OpenVotes.VoteSyncSetting(player));
+        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
         if (player.AmOwner) GameManager.Instance.LogicOptions.SetGameOptions(optdata);
         optdata.RpcSyncOption(player.GetClientId());
     }
@@ -279,6 +289,21 @@ public static class SyncSetting
             }
         }
     }
+
+    /// <summary>
+    /// 開票処理をゲストに送信する準備
+    /// </summary>
+    public static void MeetingSyncSettings()
+    {
+        foreach (PlayerControl p in CachedPlayer.AllPlayers)
+        {
+            if (!p.Data.Disconnected && !p.IsBot())
+            {
+                MeetingSyncSettings(p);
+            }
+        }
+    }
+
     public static IGameOptions DeepCopy(this IGameOptions opt)
     {
         var optByte = GameOptionsManager.Instance.gameOptionsFactory.ToBytes(opt);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -630,11 +630,11 @@ public class CustomOptionHolder
     public static CustomOption JackalSeerSKCooldown;
     public static CustomOption JackalSeerNewJackalCreateSidekick;
 
-    public static CustomRoleOption AssassinAndMarineOption;
+    public static CustomRoleOption AssassinAndMarlinOption;
     public static CustomOption AssassinPlayerCount;
     public static CustomOption AssassinViewVote;
-    public static CustomOption MarinePlayerCount;
-    public static CustomOption MarineViewVote;
+    public static CustomOption MarlinPlayerCount;
+    public static CustomOption MarlinViewVote;
 
     public static CustomRoleOption ChiefOption;
     public static CustomOption ChiefPlayerCount;
@@ -1541,11 +1541,11 @@ public class CustomOptionHolder
         JackalSeerSKCooldown = Create(1109, false, CustomOptionType.Neutral, "PavlovsownerCreateDogCoolTime", 30f, 2.5f, 60f, 2.5f, JackalSeerCreateSidekick, format: "unitSeconds");
         JackalSeerNewJackalCreateSidekick = Create(385, false, CustomOptionType.Neutral, "JackalNewJackalCreateSidekickSetting", false, JackalSeerCreateSidekick);
 
-        AssassinAndMarineOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarineName", Color.white, 1);
-        AssassinPlayerCount = Create(387, true, CustomOptionType.Impostor, "AssassinSettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], AssassinAndMarineOption);
-        AssassinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarineOption);
-        MarinePlayerCount = Create(388, true, CustomOptionType.Impostor, "MarineSettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], AssassinAndMarineOption);
-        MarineViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarineOption);
+        AssassinAndMarlinOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarlinName", Color.white, 1);
+        AssassinPlayerCount = Create(387, true, CustomOptionType.Impostor, "AssassinSettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], AssassinAndMarlinOption);
+        AssassinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
+        MarlinPlayerCount = Create(388, true, CustomOptionType.Impostor, "MarlinSettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], AssassinAndMarlinOption);
+        MarlinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
 
         ArsonistOption = SetupCustomRoleOption(389, true, RoleId.Arsonist);
         ArsonistPlayerCount = Create(390, true, CustomOptionType.Neutral, "SettingPlayerCountName", AlonePlayers[0], AlonePlayers[1], AlonePlayers[2], AlonePlayers[3], ArsonistOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -46,6 +46,7 @@ public class CustomOptionHolder
 
     public static CustomOption CanGhostSeeRole;
     public static CustomOption OnlyImpostorGhostSeeRole;
+    public static CustomOption CanGhostSeeVote;
 
     public static CustomOption IsDebugMode;
     public static CustomOption DebugModeFastStart;
@@ -1024,6 +1025,8 @@ public class CustomOptionHolder
 
         CanGhostSeeRole = Create(1100, true, CustomOptionType.Generic, "CanGhostSeeRole", true, null, isHeader: true);
         OnlyImpostorGhostSeeRole = Create(1101, true, CustomOptionType.Generic, "OnlyImpostorGhostSeeRole", false, CanGhostSeeRole);
+
+        CanGhostSeeVote = Create(1144, true, CustomOptionType.Generic, "CanGhostSeeVote", true, null, isHeader: true);
 
         IsSNROnlySearch = Create(1083, false, CustomOptionType.Generic, "IsSNROnlySearch", false, null, isHeader: true);
 

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -632,7 +632,9 @@ public class CustomOptionHolder
 
     public static CustomRoleOption AssassinAndMarineOption;
     public static CustomOption AssassinPlayerCount;
+    public static CustomOption AssassinViewVote;
     public static CustomOption MarinePlayerCount;
+    public static CustomOption MarineViewVote;
 
     public static CustomRoleOption ChiefOption;
     public static CustomOption ChiefPlayerCount;
@@ -1541,7 +1543,9 @@ public class CustomOptionHolder
 
         AssassinAndMarineOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarineName", Color.white, 1);
         AssassinPlayerCount = Create(387, true, CustomOptionType.Impostor, "AssassinSettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], AssassinAndMarineOption);
+        AssassinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarineOption);
         MarinePlayerCount = Create(388, true, CustomOptionType.Impostor, "MarineSettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], AssassinAndMarineOption);
+        MarineViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarineOption);
 
         ArsonistOption = SetupCustomRoleOption(389, true, RoleId.Arsonist);
         ArsonistPlayerCount = Create(390, true, CustomOptionType.Neutral, "SettingPlayerCountName", AlonePlayers[0], AlonePlayers[1], AlonePlayers[2], AlonePlayers[3], ArsonistOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1543,9 +1543,9 @@ public class CustomOptionHolder
 
         AssassinAndMarlinOption = new(386, true, CustomOptionType.Impostor, "AssassinAndMarlinName", Color.white, 1);
         AssassinPlayerCount = Create(387, true, CustomOptionType.Impostor, "AssassinSettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], AssassinAndMarlinOption);
-        AssassinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
+        AssassinViewVote = Create(1145, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
         MarlinPlayerCount = Create(388, true, CustomOptionType.Impostor, "MarlinSettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], AssassinAndMarlinOption);
-        MarlinViewVote = Create(167, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
+        MarlinViewVote = Create(1146, true, CustomOptionType.Impostor, "GodViewVoteSetting", false, AssassinAndMarlinOption);
 
         ArsonistOption = SetupCustomRoleOption(389, true, RoleId.Arsonist);
         ArsonistPlayerCount = Create(390, true, CustomOptionType.Neutral, "SettingPlayerCountName", AlonePlayers[0], AlonePlayers[1], AlonePlayers[2], AlonePlayers[3], ArsonistOption);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -113,7 +113,7 @@ public enum RoleId
     JackalSeer,
     SidekickSeer,
     Assassin,
-    Marine,
+    Marlin,
     Arsonist,
     Chief,
     Cleaner,

--- a/SuperNewRoles/Modules/IntroData.cs
+++ b/SuperNewRoles/Modules/IntroData.cs
@@ -73,7 +73,8 @@ public class IntroData
         if (RoleId is RoleId.DefaultRole)
         {
             return p != null && p.IsImpostor() ? ImpostorIntro : CrewmateIntro;
-        } else if(RoleId is RoleId.Jumbo)
+        }
+        else if (RoleId is RoleId.Jumbo)
         {
             return p == null ? JumboIntro : p.IsImpostor() ? EvilJumboIntro : NiceJumboIntro;
         }
@@ -189,7 +190,7 @@ public class IntroData
     public static IntroData JackalSeerIntro = new("JackalSeer", RoleClass.JackalSeer.color, 1, RoleId.JackalSeer, TeamRoleType.Neutral);
     public static IntroData SidekickSeerIntro = new("SidekickSeer", RoleClass.JackalSeer.color, 1, RoleId.SidekickSeer, TeamRoleType.Neutral);
     public static IntroData AssassinIntro = new("Assassin", RoleClass.Assassin.color, 1, RoleId.Assassin);
-    public static IntroData MarineIntro = new("Marine", RoleClass.Marine.color, 1, RoleId.Marine);
+    public static IntroData MarlinIntro = new("Marlin", RoleClass.Marlin.color, 1, RoleId.Marlin);
     public static IntroData ArsonistIntro = new("Arsonist", RoleClass.Arsonist.color, 1, RoleId.Arsonist, TeamRoleType.Neutral);
     public static IntroData ChiefIntro = new("Chief", RoleClass.Chief.color, 1, RoleId.Chief);
     public static IntroData CleanerIntro = new("Cleaner", RoleClass.Cleaner.color, 1, RoleId.Cleaner, TeamRoleType.Impostor);

--- a/SuperNewRoles/Modules/SetNames.cs
+++ b/SuperNewRoles/Modules/SetNames.cs
@@ -223,7 +223,8 @@ public class SetNamesClass
     }
     public static void JumboSet()
     {
-        foreach (PlayerControl p in RoleClass.Jumbo.JumboPlayer) {
+        foreach (PlayerControl p in RoleClass.Jumbo.JumboPlayer)
+        {
             if (!RoleClass.Jumbo.JumboSize.ContainsKey(p.PlayerId)) continue;
             SetPlayerNameText(p, p.NameText().text + $"({(int)(RoleClass.Jumbo.JumboSize[p.PlayerId] * 15)})");
         }
@@ -364,7 +365,7 @@ public class SetNameUpdate
         {
             if (Madmate.CheckImpostor(PlayerControl.LocalPlayer) ||
                 LocalRole == RoleId.MadKiller ||
-                LocalRole == RoleId.Marine ||
+                LocalRole == RoleId.Marlin ||
                 (RoleClass.Demon.IsCheckImpostor && LocalRole == RoleId.Demon)
                 )
             {

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -570,7 +570,7 @@ public static class OpenVotes
                 optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
                 break;
         }
-        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
+        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, !CustomOptionHolder.CanGhostSeeVote.GetBool());
         Logger.Info("開票しました。", "OpenVotes");
         return optdata.GetBool(BoolOptionNames.AnonymousVotes);
     }

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -480,7 +480,15 @@ class MeetingHudStartPatch
             new LateTask(() =>
             {
                 SyncSetting.CustomSyncSettings();
+                SyncSetting.MeetingSyncSettings();
             }, 3f, "StartMeeting CustomSyncSetting");
+        }
+        if (ModeHandler.IsMode(ModeId.Default))
+        {
+            new LateTask(() =>
+            {
+                SyncSetting.MeetingSyncSettings();
+            }, 3f, "StartMeeting MeetingSyncSettings SNR");
         }
         Roles.Crewmate.Knight.ProtectedPlayer = null;
         Roles.Crewmate.Knight.GuardedPlayers = new();
@@ -545,8 +553,9 @@ public static class OpenVotes
 {
     /// <summary>
     /// 公開投票にします。
-    /// Anonymous votes(匿名投票)をfalseにする事で、Open votes(公開投票)にします。
     /// </summary>
+    /// <param name="player">設定送信先</param>
+    /// <returns>Anonymous votes(匿名投票)をfalseにする事で、Open votes(公開投票)にします。</returns>
     public static bool VoteSyncSetting(this PlayerControl player)
     {
         var role = player.GetRole();

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -541,9 +541,13 @@ class MeetingHudStartPatch
 }
 
 
-/*static class AnonymousVotes
+public static class OpenVotes
 {
-    public static void VoteSyncSetting(PlayerControl player)
+    /// <summary>
+    /// 公開投票にします。
+    /// Anonymous votes(匿名投票)をfalseにする事で、Open votes(公開投票)にします。
+    /// </summary>
+    public static bool VoteSyncSetting(this PlayerControl player)
     {
         var role = player.GetRole();
         var optdata = SyncSetting.OptionData.DeepCopy();
@@ -558,6 +562,7 @@ class MeetingHudStartPatch
                 break;
         }
         if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
-        Logger.Info("ぷぇ");
+        Logger.Info("開票しました。", "OpenVotes");
+        return optdata.GetBool(BoolOptionNames.AnonymousVotes);
     }
-}*/
+}

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -1,3 +1,4 @@
+using AmongUs.GameOptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -538,3 +539,25 @@ class MeetingHudStartPatch
         }
     }
 }
+
+
+/*static class AnonymousVotes
+{
+    public static void VoteSyncSetting(PlayerControl player)
+    {
+        var role = player.GetRole();
+        var optdata = SyncSetting.OptionData.DeepCopy();
+
+        switch (role)
+        {
+            case RoleId.God:
+                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.God.IsVoteView);
+                break;
+            case RoleId.Observer:
+                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
+                break;
+        }
+        if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, false);
+        Logger.Info("ぷぇ");
+    }
+}*/

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -569,6 +569,12 @@ public static class OpenVotes
             case RoleId.Observer:
                 optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
                 break;
+            case RoleId.Marine:
+                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Marine.IsVoteView);
+                break;
+            case RoleId.Assassin:
+                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Assassin.IsVoteView);
+                break;
         }
         if (player.IsDead()) optdata.SetBool(BoolOptionNames.AnonymousVotes, !CustomOptionHolder.CanGhostSeeVote.GetBool());
         Logger.Info("開票しました。", "OpenVotes");

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -131,7 +131,7 @@ class CheckForEndVotingPatch
                                     exile = p;
                                     p.RpcSetColor((byte)outfit.ColorId);
                                     p.RpcSetName(target.Object.GetDefaultName() +
-                                        ModTranslation.GetString(target.Object.IsRole(RoleId.Marine) ?
+                                        ModTranslation.GetString(target.Object.IsRole(RoleId.Marlin) ?
                                         "AssassinSucsess" :
                                         "AssassinFail")
                                         + "<size=0%>");
@@ -143,7 +143,7 @@ class CheckForEndVotingPatch
                             }
                         }
                         RoleClass.Assassin.MeetingEndPlayers.Add(RoleClass.Assassin.TriggerPlayer.PlayerId);
-                        if (target.Object.IsRole(RoleId.Marine))
+                        if (target.Object.IsRole(RoleId.Marlin))
                             RoleClass.Assassin.IsImpostorWin = true;
                         else
                             RoleClass.Assassin.DeadPlayer = RoleClass.Assassin.TriggerPlayer;
@@ -569,8 +569,8 @@ public static class OpenVotes
             case RoleId.Observer:
                 optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Observer.IsVoteView);
                 break;
-            case RoleId.Marine:
-                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Marine.IsVoteView);
+            case RoleId.Marlin:
+                optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Marlin.IsVoteView);
                 break;
             case RoleId.Assassin:
                 optdata.SetBool(BoolOptionNames.AnonymousVotes, !RoleClass.Assassin.IsVoteView);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -632,13 +632,13 @@ static class CheckMurderPatch
                             Madmate.CreateMadmate(target);//クルーにして、マッドにする
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
                             RoleClass.FastMaker.IsCreatedMadmate = true;//作ったことにする
-                            Logger.Info("マッドメイトを作成しました","FastMakerSHR");
+                            Logger.Info("マッドメイトを作成しました", "FastMakerSHR");
                             return false;
                         }
                         else
                         {
                             //作ってたら普通のキル(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
-                            Logger.Info("マッドメイトを作成済みの為 普通のキル","FastMakerSHR");
+                            Logger.Info("マッドメイトを作成済みの為 普通のキル", "FastMakerSHR");
                         }
                         break;
                     case RoleId.Jackal:
@@ -653,15 +653,15 @@ static class CheckMurderPatch
                                 Jackal.CreateJackalFriends(target);//クルーにして フレンズにする
                             }
                             Mode.SuperHostRoles.FixedUpdate.SetRoleName(target);//名前も変える
-                            Logger.Info("ジャッカルフレンズを作成しました。","JackalSHR");
+                            Logger.Info("ジャッカルフレンズを作成しました。", "JackalSHR");
                             return false;
                         }
                         else
                         {
                             // キルができた理由のログを表示する(此処にMurderPlayerを使用すると2回キルされる為ログのみ表示)
-                            if (!RoleClass.Jackal.CanCreateFriend) Logger.Info("ジャッカルフレンズを作る設定ではない為 普通のキル","JackalSHR");
-                            else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.CreatePlayers.Contains(__instance.PlayerId)) Logger.Info("ジャッカルフレンズ作成済みの為 普通のキル","JackalSHR");
-                            else Logger.Info("不正なキル","JackalSHR");
+                            if (!RoleClass.Jackal.CanCreateFriend) Logger.Info("ジャッカルフレンズを作る設定ではない為 普通のキル", "JackalSHR");
+                            else if (RoleClass.Jackal.CanCreateFriend && RoleClass.Jackal.CreatePlayers.Contains(__instance.PlayerId)) Logger.Info("ジャッカルフレンズ作成済みの為 普通のキル", "JackalSHR");
+                            else Logger.Info("不正なキル", "JackalSHR");
                         }
                         break;
                     case RoleId.JackalSeer:
@@ -785,12 +785,12 @@ static class CheckMurderPatch
             }, 0.5f, "RpcCheckExile Assassin Start Meeting");
             new LateTask(() =>
             {
-                __instance.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marine.color, IntroData.MarineIntro.NameKey + "Name")}は誰だ？</size>");
-            }, 2f, "RpcCheckExile Who Marine Name");
+                __instance.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marlin.color, IntroData.MarlinIntro.NameKey + "Name")}は誰だ？</size>");
+            }, 2f, "RpcCheckExile Who Marlin Name");
             new LateTask(() =>
             {
-                __instance.RpcSendChat($"\n{ModTranslation.GetString("MarineWhois")}");
-            }, 2.5f, "RpcCheckExile Who Marine Chat");
+                __instance.RpcSendChat($"\n{ModTranslation.GetString("MarlinWhois")}");
+            }, 2.5f, "RpcCheckExile Who Marlin Chat");
             new LateTask(() =>
             {
                 __instance.RpcSetName(__instance.GetDefaultName());
@@ -817,12 +817,12 @@ static class CheckMurderPatch
             }, 0.5f, "RpcMurderPlayerCheck Assassin Meeting");
             new LateTask(() =>
             {
-                target.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marine.color, IntroData.MarineIntro.NameKey + "Name")}は誰だ？</size>");
-            }, 2f, "RpcMurderPlayerCheck Who Marine Name");
+                target.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marlin.color, IntroData.MarlinIntro.NameKey + "Name")}は誰だ？</size>");
+            }, 2f, "RpcMurderPlayerCheck Who Marlin Name");
             new LateTask(() =>
             {
-                target.RpcSendChat($"\n{ModTranslation.GetString("MarineWhois")}");
-            }, 2.5f, "RpcMurderPlayerCheck Who Marine Chat");
+                target.RpcSendChat($"\n{ModTranslation.GetString("MarlinWhois")}");
+            }, 2.5f, "RpcMurderPlayerCheck Who Marlin Chat");
             new LateTask(() =>
             {
                 target.RpcSetName(target.GetDefaultName());

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -205,7 +205,8 @@ RestrictDevicesOption,Restrict Devices Option,機器の時間制限,飞船设备
 RestrictAdmin,Restrict Admin,アドミンの時間制限,管理师地图使用时间限制
 RestrictVital,Restrict Vital,バイタルの時間制限,生命监测装置使用时间限制
 RestrictCamera,Restrict Camera,カメラの時間制限,监控使用时间限制
-CanGhostSeeRole,,死亡者が全員の役職を確認できる,死亡玩家能确认所有玩家的职业
+CanGhostSeeRole,After death，everyone's role can be confirmed.,死亡者が全員の役職を確認できる,死亡玩家能确认所有玩家的职业
+CanGhostSeeVote,After death，everyone's voting address can be confirmed.,死亡者が全員の投票先を確認できる,死亡玩家能确认所有玩家的职业
 OnlyImpostorGhostSeeRole,,死亡しているインポスターのみが全員の役職を確認できる,只有死亡的内鬼阵营玩家可以确认所有玩家的职业
 AntiTaskOverWallSetting,Cannot tasks over the wall.,壁越しにタスクをできない,禁止隔墙做任务
 ShuffleElectricalDoorsSetting,Shuffle electrical doors after meeting,会議後に電気室のドアをシャッフルする,飞艇地图配电室门的开关在会议后重新分配

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -832,16 +832,16 @@ JackalSeerDescription,,死亡時刻や死亡場所を把握する事が可能な
 SidekickSeerName,Sidekick(Seer),サイドキック(シーア),狼族灵媒学徒
 SidekickSeerTitle1,Let's help Jackal with the dead detection ability that we got,貰った死者感知能力でジャッカルを助けよう,用死亡感知能力来帮助豺狼
 SidekickSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いて、親ジャッカルを守り、時には切り、貢献しましょう。
-AssassinAndMarineName,<color=#ff0000>Assassin</color> and <color=#AFDFE4>Merine</color>,<color=#ff0000>アサシン</color>と<color=#AFDFE4>マーリン</color>,<color=#ff0000>阿</color>瓦<color=#AFDFE4>隆</color>
+AssassinAndMarlinName,<color=#ff0000>Assassin</color> and <color=#AFDFE4>Merine</color>,<color=#ff0000>アサシン</color>と<color=#AFDFE4>マーリン</color>,<color=#ff0000>阿</color>瓦<color=#AFDFE4>隆</color>
 AssassinSettingPlayerCountName,Number of <color=#ff0000>Assassin</color>,<color=#ff0000>アサシン</color>の人数,<color=#ff0000>刺客</color>的人数
-MarineSettingPlayerCountName,Number of <color=#AFDFE4>Merine</color>,<color=#AFDFE4>マーリン</color>の人数,<color=#AFDFE4>梅林</color>的人数
+MarlinSettingPlayerCountName,Number of <color=#AFDFE4>Merine</color>,<color=#AFDFE4>マーリン</color>の人数,<color=#AFDFE4>梅林</color>的人数
 AssassinName,Assassin,アサシン,刺客
 AssassinTitle1,<color=#AFDFE4>Merine</color>Suppose you guessed it. let's turn the tables and win!,<color=#AFDFE4>マーリン</color>を当てて逆転勝利しよう,找出<color=#AFDFE4>梅林</color>来获得胜利
-AssassinSucsess,was marine.,はマーリンだった,是梅林
-AssassinFail,was not marine.,はマーリンではなかった,不是梅林
-MarineName,Merine,マーリン,梅林
-MarineTitle1,Let's not let <color=#ff0000>Assassin</color> find out.,<color=#ff0000>アサシン</color>にバレないようにしよう。,不要被<color=#ff0000>刺客</color>发现。
-MarineWhois,Who is Merine?,マーリンは誰だ？,谁是梅林？
+AssassinSucsess,was Marlin.,はマーリンだった,是梅林
+AssassinFail,was not Marlin.,はマーリンではなかった,不是梅林
+MarlinName,Merine,マーリン,梅林
+MarlinTitle1,Let's not let <color=#ff0000>Assassin</color> find out.,<color=#ff0000>アサシン</color>にバレないようにしよう。,不要被<color=#ff0000>刺客</color>发现。
+MarlinWhois,Who is Merine?,マーリンは誰だ？,谁是梅林？
 ArsonistName,Arsonist,アーソニスト,纵火犯
 ArsonistTitle1,Douse Douse burn,塗って塗って燃やせ,燃烧吧
 ArsonistDurationTimeSetting,Douse Duration,塗り時間,纵火犯涂油所需时间

--- a/SuperNewRoles/Roles/AllRoleSetClass.cs
+++ b/SuperNewRoles/Roles/AllRoleSetClass.cs
@@ -547,13 +547,13 @@ class AllRoleSetClass
         //マーリンを選ぶ
         if (IsAssassinAssigned)
         {
-            int PlayerCount = (int)GetPlayerCount(RoleId.Marine);
+            int PlayerCount = (int)GetPlayerCount(RoleId.Marlin);
             if (PlayerCount >= CrewmatePlayerNum)
             {
                 for (int i = 1; i <= CrewmatePlayerNum; i++)
                 {
                     PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
-                    p.SetRoleRPC(RoleId.Marine);
+                    p.SetRoleRPC(RoleId.Marlin);
                     CrewmatePlayers.Remove(p);
                 }
                 CrewmatePlayerNum = 0;
@@ -562,7 +562,7 @@ class AllRoleSetClass
             {
                 foreach (PlayerControl Player in CrewmatePlayers)
                 {
-                    Player.SetRoleRPC(RoleId.Marine);
+                    Player.SetRoleRPC(RoleId.Marlin);
                 }
                 CrewmatePlayerNum = 0;
             }
@@ -572,7 +572,7 @@ class AllRoleSetClass
                 {
                     CrewmatePlayerNum--;
                     PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
-                    p.SetRoleRPC(RoleId.Marine);
+                    p.SetRoleRPC(RoleId.Marlin);
                     CrewmatePlayers.Remove(p);
                 }
             }
@@ -911,7 +911,7 @@ class AllRoleSetClass
             RoleId.SeerFriends => CustomOptionHolder.SeerFriendsPlayerCount.GetFloat(),
             RoleId.JackalSeer => CustomOptionHolder.JackalSeerPlayerCount.GetFloat(),
             RoleId.Assassin => CustomOptionHolder.AssassinPlayerCount.GetFloat(),
-            RoleId.Marine => CustomOptionHolder.MarinePlayerCount.GetFloat(),
+            RoleId.Marlin => CustomOptionHolder.MarlinPlayerCount.GetFloat(),
             RoleId.Arsonist => CustomOptionHolder.ArsonistPlayerCount.GetFloat(),
             RoleId.Chief => CustomOptionHolder.ChiefPlayerCount.GetFloat(),
             RoleId.Cleaner => CustomOptionHolder.CleanerPlayerCount.GetFloat(),
@@ -1053,7 +1053,7 @@ class AllRoleSetClass
             }
         }
         SetJumboTicket();
-        var Assassinselection = CustomOptionHolder.AssassinAndMarineOption.GetSelection();
+        var Assassinselection = CustomOptionHolder.AssassinAndMarlinOption.GetSelection();
         if (Assassinselection != 0 && CrewmatePlayerNum > 0 && CrewmatePlayers.Count > 0)
         {
             if (Assassinselection == 10)

--- a/SuperNewRoles/Roles/Attribute/Guesser.cs
+++ b/SuperNewRoles/Roles/Attribute/Guesser.cs
@@ -182,7 +182,7 @@ class Guesser
         if (CustomOptionHolder.JackalSeerOption.GetSelection() is not 0 && CustomOptionHolder.JackalSeerCreateSidekick.GetBool()) CreateRole(IntroData.SidekickSeerIntro);
         if (CustomOptionHolder.PavlovsownerOption.GetSelection() is not 0) CreateRole(IntroData.PavlovsdogsIntro);
         if (CustomOptionHolder.RevolutionistAndDictatorOption.GetSelection() is not 0) { CreateRole(IntroData.DictatorIntro); CreateRole(IntroData.RevolutionistIntro); }
-        if (CustomOptionHolder.AssassinAndMarineOption.GetSelection() is not 0) { CreateRole(IntroData.AssassinIntro); CreateRole(IntroData.MarineIntro); }
+        if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() is not 0) { CreateRole(IntroData.AssassinIntro); CreateRole(IntroData.MarlinIntro); }
         void CreateRole(IntroData roleInfo)
         {
             if (40 <= i[(int)roleInfo.Team]) i[(int)roleInfo.Team] = 0;

--- a/SuperNewRoles/Roles/CrewMate/Bakery.cs
+++ b/SuperNewRoles/Roles/CrewMate/Bakery.cs
@@ -36,7 +36,7 @@ public class Bakery
             PlayerControl player = RoleClass.Assassin.TriggerPlayer;
 
             var exile = ModeHandler.IsMode(ModeId.SuperHostRoles) ? Mode.SuperHostRoles.Main.RealExiled : exiled.Object;
-            if (exile != null && exile.IsRole(RoleId.Marine))
+            if (exile != null && exile.IsRole(RoleId.Marlin))
             {
                 printStr = player.Data.PlayerName + ModTranslation.GetString("AssassinSucsess");
                 RoleClass.Assassin.IsImpostorWin = true;

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -16,7 +16,7 @@ class MeetingUpdatePatch
     {
         if (RoleClass.Assassin.TriggerPlayer != null)
         {
-            __instance.TitleText.text = ModTranslation.GetString("MarineWhois");
+            __instance.TitleText.text = ModTranslation.GetString("MarlinWhois");
         }
         if (!IsFlag) return;
         if (Input.GetKeyDown(KeyCode.RightArrow))

--- a/SuperNewRoles/Roles/Impostor/Assassin.cs
+++ b/SuperNewRoles/Roles/Impostor/Assassin.cs
@@ -59,7 +59,7 @@ public static class Assassin
                             exileplayer = p.Data;
                             exile = p;
                             p.RpcSetColor((byte)outfit.ColorId);
-                            p.RpcSetName(target.Object.GetDefaultName() + (target.Object.IsRole(RoleId.Marine) ? ModTranslation.GetString("AssassinSucsess") : ModTranslation.GetString("AssassinFail")) + "<size=0%>");
+                            p.RpcSetName(target.Object.GetDefaultName() + (target.Object.IsRole(RoleId.Marlin) ? ModTranslation.GetString("AssassinSucsess") : ModTranslation.GetString("AssassinFail")) + "<size=0%>");
                             p.RpcSetHat(outfit.HatId);
                             p.RpcSetVisor(outfit.VisorId);
                             p.RpcSetSkin(outfit.SkinId);
@@ -68,7 +68,7 @@ public static class Assassin
                     }
                 }
                 RoleClass.Assassin.MeetingEndPlayers.Add(RoleClass.Assassin.TriggerPlayer.PlayerId);
-                if (target.Object.IsRole(RoleId.Marine))
+                if (target.Object.IsRole(RoleId.Marlin))
                 {
                     RoleClass.Assassin.IsImpostorWin = true;
                 }
@@ -128,11 +128,11 @@ public static class Assassin
                 }, 10.5f, "Assassin Meet");
                 new LateTask(() =>
                 {
-                    exile.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marine.color, IntroData.MarineIntro.NameKey + "Name")}<color=white>は誰だ？</size>");
+                    exile.RpcSetName($"<size=200%>{CustomOptionHolder.Cs(RoleClass.Marlin.color, IntroData.MarlinIntro.NameKey + "Name")}<color=white>は誰だ？</size>");
                 }, 12f, "Assassin Name");
                 new LateTask(() =>
                 {
-                    exile.RpcSendChat($"\n{ModTranslation.GetString("MarineWhois")}");
+                    exile.RpcSendChat($"\n{ModTranslation.GetString("MarlinWhois")}");
                 }, 12.5f, "Assassin Chat");
                 new LateTask(() =>
                 {

--- a/SuperNewRoles/Roles/Impostor/ShiftActor.cs
+++ b/SuperNewRoles/Roles/Impostor/ShiftActor.cs
@@ -77,7 +77,7 @@ public static class ShiftActor
                     TargetRoleText = ModTranslation.GetString("CrewmateName");
                 }
             }
-            else if (target.IsRole(RoleId.Marine))
+            else if (target.IsRole(RoleId.Marlin))
             { // マーリンはクルーに
                 TargetRoleText = ModTranslation.GetString("CrewmateName");
             }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -1848,6 +1848,7 @@ public static class RoleClass
         public static List<byte> MeetingEndPlayers;
         public static PlayerControl TriggerPlayer;
         public static PlayerControl DeadPlayer;
+        public static bool IsVoteView;
         public static bool IsImpostorWin;
         public static void ClearAndReload()
         {
@@ -1856,15 +1857,18 @@ public static class RoleClass
             TriggerPlayer = null;
             DeadPlayer = null;
             IsImpostorWin = false;
+            IsVoteView = CustomOptionHolder.AssassinViewVote.GetBool();
         }
     }
     public static class Marine
     {
         public static List<PlayerControl> MarinePlayer;
         public static Color32 color = new(175, 223, 228, byte.MaxValue);
+        public static bool IsVoteView;
         public static void ClearAndReload()
         {
             MarinePlayer = new();
+            IsVoteView = CustomOptionHolder.MarineViewVote.GetBool();
         }
     }
     public static class Arsonist

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -143,7 +143,7 @@ public static class RoleClass
         SeerFriends.ClearAndReload();
         JackalSeer.ClearAndReload();
         Assassin.ClearAndReload();
-        Marine.ClearAndReload();
+        Marlin.ClearAndReload();
         Arsonist.ClearAndReload();
         Chief.ClearAndReload();
         Cleaner.ClearAndReload();
@@ -1860,15 +1860,15 @@ public static class RoleClass
             IsVoteView = CustomOptionHolder.AssassinViewVote.GetBool();
         }
     }
-    public static class Marine
+    public static class Marlin
     {
-        public static List<PlayerControl> MarinePlayer;
+        public static List<PlayerControl> MarlinPlayer;
         public static Color32 color = new(175, 223, 228, byte.MaxValue);
         public static bool IsVoteView;
         public static void ClearAndReload()
         {
-            MarinePlayer = new();
-            IsVoteView = CustomOptionHolder.MarineViewVote.GetBool();
+            MarlinPlayer = new();
+            IsVoteView = CustomOptionHolder.MarlinViewVote.GetBool();
         }
     }
     public static class Arsonist

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -48,7 +48,7 @@ public static class RoleHelpers
         RoleId.MadSeer or
         RoleId.BlackCat or
         RoleId.MadMaker;
-        // IsMads
+    // IsMads
 
     //We are JackalFriends!
     public static bool IsFriendRoles(this PlayerControl player) =>
@@ -56,7 +56,7 @@ public static class RoleHelpers
         RoleId.JackalFriends or
         RoleId.SeerFriends or
         RoleId.MayorFriends;
-        // IsFriends
+    // IsFriends
 
 
 
@@ -141,7 +141,8 @@ public static class RoleHelpers
     public static void SetLovers(PlayerControl player1, PlayerControl player2)
     {
         List<PlayerControl> sets = new() { player1, player2 };
-        if (player1.IsRole(RoleId.LoversBreaker) || player2.IsRole(RoleId.LoversBreaker)) {
+        if (player1.IsRole(RoleId.LoversBreaker) || player2.IsRole(RoleId.LoversBreaker))
+        {
             if (player1.IsRole(RoleId.LoversBreaker)) RoleClass.Lovers.FakeLovers.Add(player1.PlayerId);
             else RoleClass.Lovers.FakeLovers.Add(player2.PlayerId);
             RoleClass.Lovers.FakeLoverPlayers.Add(sets);
@@ -538,8 +539,8 @@ public static class RoleHelpers
             case RoleId.Assassin:
                 RoleClass.Assassin.AssassinPlayer.Add(player);
                 break;
-            case RoleId.Marine:
-                RoleClass.Marine.MarinePlayer.Add(player);
+            case RoleId.Marlin:
+                RoleClass.Marlin.MarlinPlayer.Add(player);
                 break;
             case RoleId.Arsonist:
                 RoleClass.Arsonist.ArsonistPlayer.Add(player);
@@ -1018,8 +1019,8 @@ public static class RoleHelpers
             case RoleId.Assassin:
                 RoleClass.Assassin.AssassinPlayer.RemoveAll(ClearRemove);
                 break;
-            case RoleId.Marine:
-                RoleClass.Marine.MarinePlayer.RemoveAll(ClearRemove);
+            case RoleId.Marlin:
+                RoleClass.Marlin.MarlinPlayer.RemoveAll(ClearRemove);
                 break;
             case RoleId.Arsonist:
                 RoleClass.Arsonist.ArsonistPlayer.RemoveAll(ClearRemove);
@@ -1198,7 +1199,7 @@ public static class RoleHelpers
             case RoleId.Jumbo:
                 RoleClass.Jumbo.JumboPlayer.RemoveAll(ClearRemove);
                 break;
-            // ロールリモベ
+                // ロールリモベ
         }
         ChacheManager.ResetMyRoleChache();
     }
@@ -1264,7 +1265,7 @@ public static class RoleHelpers
             case RoleId.Cupid:
             case RoleId.Dependents:
             case RoleId.LoversBreaker:
-            // タスククリアか
+                // タスククリアか
                 IsTaskClear = true;
                 break;
             case RoleId.Sheriff when RoleClass.Chief.NoTaskSheriffPlayer.Contains(player.PlayerId):
@@ -1445,7 +1446,7 @@ public static class RoleHelpers
         RoleId.Cupid or
         RoleId.Pavlovsowner or
         RoleId.LoversBreaker;
-        // 第三か
+    // 第三か
     public static bool IsRole(this PlayerControl p, RoleId role, bool IsChache = true)
     {
         RoleId MyRole;
@@ -1640,7 +1641,7 @@ public static class RoleHelpers
             else if (RoleClass.JackalSeer.JackalSeerPlayer.IsCheckListPlayerControl(player)) return RoleId.JackalSeer;
             else if (RoleClass.JackalSeer.SidekickSeerPlayer.IsCheckListPlayerControl(player)) return RoleId.SidekickSeer;
             else if (RoleClass.Assassin.AssassinPlayer.IsCheckListPlayerControl(player)) return RoleId.Assassin;
-            else if (RoleClass.Marine.MarinePlayer.IsCheckListPlayerControl(player)) return RoleId.Marine;
+            else if (RoleClass.Marlin.MarlinPlayer.IsCheckListPlayerControl(player)) return RoleId.Marlin;
             else if (RoleClass.SeerFriends.SeerFriendsPlayer.IsCheckListPlayerControl(player)) return RoleId.SeerFriends;
             else if (RoleClass.Arsonist.ArsonistPlayer.IsCheckListPlayerControl(player)) return RoleId.Arsonist;
             else if (RoleClass.Chief.ChiefPlayer.IsCheckListPlayerControl(player)) return RoleId.Chief;


### PR DESCRIPTION
# 要約
- SNRの公開投票を修正した。
- 死亡後の公開投票の有無を設定可能にした。
- アサシンとマーリンに公開投票の設定を持たせた。
- MarlinがMarineになっていた誤字を修正した。

# 詳細
- SNRの公開投票を修正した。
  - 公開投票をSyncSettingからMeetingSyncSettingsに独立させた。
  - 独立させることにより、SNRでもSHRと同様の開票処理を行えるようになった。
  - 公開投票系の役ができた時は1個所に追加するだけでSNRでもSHRでも機能する。

- 死亡後の公開投票の有無を設定可能にした。

- アサシンとマーリンに公開投票の設定を持たせた。
  - ExRのアサマリに近づけよう第一弾

- MarlinがMarineになっていた誤字を修正した。