### PR TITLE
logに記載したくないRPCを辞書型で判定し記載しないようにした

### DIFF
--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -1337,9 +1337,18 @@ public static class RPCProcedure
             }
             return true;
         }
+
+        /// <summary>
+        /// LOGに記載しないRPCを設定する
+        /// </summary>
+        /// <returns>falseで記載するとRPCをlogに記載しなくなる。</returns>
+        private static readonly Dictionary<CustomRPC, bool> IsWritingRPCLog = new() {
+            {CustomRPC.ShareSNRVersion,false},
+        };
+
         static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
         {
-            Logger.Info(ModHelpers.GetRPCNameFromByte(callId), "RPC");
+            if (!IsWritingRPCLog.ContainsKey((CustomRPC)callId)) Logger.Info(ModHelpers.GetRPCNameFromByte(callId), "RPC");
             try
             {
                 byte packetId = callId;

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -1348,7 +1348,8 @@ public static class RPCProcedure
 
         static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
         {
-            if (!IsWritingRPCLog.ContainsKey((CustomRPC)callId)) Logger.Info(ModHelpers.GetRPCNameFromByte(callId), "RPC");
+            if (!IsWritingRPCLog.ContainsKey((CustomRPC)callId))
+                Logger.Info(ModHelpers.GetRPCNameFromByte(callId), "RPC");
             try
             {
                 byte packetId = callId;


### PR DESCRIPTION
# [変更点]
- logに記載したくないRPCを辞書型で判定し記載しないようにした
  - 現在``ShareSNRVersion``のみ
  - 辞書型の理由
    - 記載したくないRPCを簡単に追記できるようにしたかった為。
    - フレーム処理でbool型の関数を読ませたくなかった為。

# [スクリーンショット]
- 旧ログ
  - ![image](https://user-images.githubusercontent.com/104145991/215277101-39fbf6f7-05c7-4bb3-a9c8-98a840a29248.png)
- 新ログ
  - ![image](https://user-images.githubusercontent.com/104145991/215277345-c0380e27-1602-4a1b-82e6-8992e1162ad8.png)

# [参考]
- https://github.com/ykundesu/SuperNewRoles/pull/692