### PR TITLE
シェイプシフター置き換え役職を死後Impostorghostにするようにした(シェイプ置き換え役職配役時のタスク勝利問題修正)

### DIFF
--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -232,6 +232,27 @@ public static class RPCHelper
         Logger.Info($"[{target.GetDefaultName()}] の役職を [{Id}] に変更しました。");
     }
 
+    /// <summary>
+    ///　役職をImpostorghostにリセットします。
+    /// </summary>
+    /// <param name="target">役職が変更される対象</param>
+    public static void ResetAndSetImpostorghost(this PlayerControl target)
+    {
+        var targetRole = target.GetRole();
+
+        if (AmongUsClient.Instance.AmHost)
+        {
+            target.RPCSetRoleUnchecked(RoleTypes.ImpostorGhost);
+            target.RpcSetRole(RoleTypes.ImpostorGhost);
+        }
+        else
+        {
+            target.RPCSetRoleUnchecked(RoleTypes.ImpostorGhost);
+            target.SetRole(RoleTypes.ImpostorGhost);
+        }
+        Logger.Info($"[{targetRole}] であった [{target.GetDefaultName()}] の役職を ImpostorGhost に変更しました。");
+    }
+
     public static void RpcResetAbilityCooldown(this PlayerControl target)
     {
         if (!AmongUsClient.Instance.AmHost) return;

--- a/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
@@ -85,5 +85,6 @@ class WrapUpClass
         }
         Roles.Jester.WrapUp(exiled);
         Roles.Nekomata.WrapUp(exiled);
+        if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
     }
 }

--- a/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
@@ -6,6 +6,7 @@ using SuperNewRoles.Helpers;
 using SuperNewRoles.Patches;
 using SuperNewRoles.Roles;
 using UnityEngine;
+using static SuperNewRoles.Helpers.RPCHelper;
 
 namespace SuperNewRoles.Mode.SuperHostRoles;
 
@@ -84,5 +85,6 @@ class WrapUpClass
         }
         Roles.Jester.WrapUp(exiled);
         Roles.Nekomata.WrapUp(exiled);
+        if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
     }
 }

--- a/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
@@ -85,6 +85,5 @@ class WrapUpClass
         }
         Roles.Jester.WrapUp(exiled);
         Roles.Nekomata.WrapUp(exiled);
-        if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
     }
 }

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -231,6 +231,9 @@ public class FixedUpdate
                             }
                             break;
                     }
+                    if (PlayerControl.LocalPlayer.IsShapeshifter())
+                        PlayerControl.LocalPlayer.ResetAndSetImpostorghost();
+                    break;
                 }
                 break;
             case ModeId.SuperHostRoles:

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -231,9 +231,6 @@ public class FixedUpdate
                             }
                             break;
                     }
-                    if (PlayerControl.LocalPlayer.IsShapeshifter())
-                        PlayerControl.LocalPlayer.ResetAndSetImpostorghost();
-                    break;
                 }
                 break;
             case ModeId.SuperHostRoles:

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -142,6 +142,7 @@ class RpcShapeshiftPatch
                         }
                     }
                     __instance.RpcMurderPlayer(__instance);
+                    __instance.ResetAndSetImpostorghost();
                     __instance.RpcSetFinalStatus(FinalStatus.SelfBomberBomb);
                     return false;
                 case RoleId.Samurai:
@@ -186,6 +187,7 @@ class RpcShapeshiftPatch
                     return false;
                 case RoleId.SuicideWisher:
                     __instance.RpcMurderPlayer(__instance);
+                    __instance.ResetAndSetImpostorghost();
                     __instance.RpcSetFinalStatus(FinalStatus.SuicideWisherSelfDeath);
                     return false;
                 case RoleId.ToiletFan:
@@ -763,6 +765,7 @@ static class CheckMurderPatch
                     }
                 }
             }
+            else if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
         }
         Logger.Info("全スタントマン系通過", "CheckMurder");
         __instance.RpcMurderPlayerCheck(target);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1089,6 +1089,7 @@ public static class MurderPlayerPatch
                 }
             }
             Minimalist.MurderPatch.Postfix(__instance);
+            if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
         }
         Vampire.OnMurderPlayer(__instance, target);
         if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && ModeHandler.IsMode(ModeId.Default))

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -192,6 +192,7 @@ class WrapUpPatch
                     CheckGameEndPatch.CustomEndGame((GameOverReason)CustomGameOverReason.MadJesterWin, false);
                 }
             }
+            if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
         }
         Mode.SuperHostRoles.Main.RealExiled = null;
     }

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -58,7 +58,23 @@ public static class RoleHelpers
         RoleId.MayorFriends;
     // IsFriends
 
-
+    /// <summary>
+    /// v2022.12.8で発生したシェイプシフターが死亡後クルーメイトゴーストになるバグの修正用。
+    /// We are Shapeshifter!
+    /// </summary>
+    /// <param name="player">シェイプシフターであるか判定されるプレイヤー</param>
+    /// <returns>プレイヤーがシェイプシフターである場合trueを返す</returns>
+    public static bool IsShapeshifter(this PlayerControl player) =>
+        player.GetRole() is
+        RoleId.SelfBomber or
+        RoleId.Samurai or
+        RoleId.EvilButtoner or
+        RoleId.SuicideWisher or
+        RoleId.Doppelganger or
+        RoleId.Camouflager or
+        RoleId.EvilSeer or
+        RoleId.ShiftActor;
+    // IsShapeshifter
 
     public static bool IsQuarreled(this PlayerControl player, bool IsChache = true)
     {

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -1231,6 +1231,7 @@ public static class RoleHelpers
     {
         var IsTaskClear = false;
         if (player.IsImpostor()) IsTaskClear = true;
+        if (player.IsShapeshifter()) IsTaskClear = true;
         switch (player.GetRole())
         {
             case RoleId.Jester:


### PR DESCRIPTION
# [メモ]
- **これはSNRのバグじゃなくて公式のバグなんだぜ()**

# [修正点]
- IsShapeshifter関数を作成。
  - シェイプシフター(シェイプシフターを含まない)が吊られた時、キルされた時にImpostorghostになるようにした。
    - SHR,SNRで処理は分かれているが、IsShapeshifterに追加するだけでどちらでも対応可能になる。
    - 死後サボタージュができない問題を修正(ただし非導入者は一度マップを出さないとサボタージュボタンが表示されない)。
    - 死後タスクが発生しそのタスクをやらないとクルーが勝利できない問題を修正。
      - 一応IsShapeshifterの場合タスククリアするようにもした。

# [テスト]
## [SNR]
- ホストがシフトアクター
  - 吊った時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
  - キルされた時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった

- ゲストがシフトアクター
  - 吊った時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
  - キルされた時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった

## [SHR]
### [導入者]
- ホストがスーサイドウィッシャー□
  - 吊った時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
  - キルされた時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
  - 自殺した時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった

- ゲストがスーサイドウィッシャー□
  - 吊った時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
 - キルされた時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった
  - 自殺した時
    - インポスターゴーストになった
    - ボタンは正常表示された。
    - サボタージュが正常に使用可能であった

### [非導入者]
- ゲストがスーサイドウィッシャー□
  - 吊った時
    - インポスターゴーストになった
    - ボタンは一度マップを開かないと正常表示されない。
    - サボタージュが正常に使用可能であった
  - キルされた時
    - インポスターゴーストになった
    - ボタンは一度マップを開かないと正常表示されない。
    - サボタージュが正常に使用可能であった
  - 自殺した時
    - インポスターゴーストになった
    - ボタンは一度マップを開かないと正常表示されない。
    - サボタージュが正常に使用可能であった