### PR TITLE
明暗表示がLogを荒らしてた問題を修正

### DIFF
--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -602,6 +602,7 @@ public static class OpenVotes
 [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Update))]
 public class MeetingHudUpdatePatch
 {
+    public static List<string> ErrorNames;
     public static void Postfix()
     {
         if (Instance)
@@ -624,7 +625,12 @@ public class MeetingHudUpdatePatch
                     }
                     else player.NameText.text = player.NameText.text.Replace(GetLightAndDarkerText(true), "").Replace(GetLightAndDarkerText(false), "");
                 }
-                else Logger.Error($"プレイヤーコントロールを取得できませんでした。 プレイヤー名 : {player.NameText.text}", "LightAndDarkerText");
+                else
+                {
+                    if (ErrorNames.Contains(player.NameText.text)) continue;
+                    Logger.Error($"プレイヤーコントロールを取得できませんでした。 プレイヤー名 : {player.NameText.text}", "LightAndDarkerText");
+                    ErrorNames.Add(player.NameText.text);
+                }
             }
         }
     }

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -58,6 +58,7 @@ public static class RoleClass
         MapCustoms.SpecimenVital.ClearAndReload();
         MapCustoms.MoveElecPad.ClearAndReload();
         Beacon.ClearBeacons();
+        MeetingHudUpdatePatch.ErrorNames = new();
 
         Debugger.ClearAndReload();
         SoothSayer.ClearAndReload();


### PR DESCRIPTION
プレイヤーが抜けたなどの要因で、プレイヤーコントロール取得できなかったら、
ログが大変になってるのを修正しました