### PR TITLE
SNRでのShapeshifterをImpostorghostに変更する処理をShiftActor単独にしてSHRではshape置き換えになっている役職に影響が出ないようにした

### DIFF
--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1124,7 +1124,13 @@ public static class MurderPlayerPatch
                 }
             }
             Minimalist.MurderPatch.Postfix(__instance);
-            if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
+            /*
+                DefaultModeにシフトアクター以外のシェイプシフター置き換え役職が増えた場合
+                [if (target.IsShapeshifter()) ~ ] のコメントアウトを解除し、
+                [if (target.IsRole(RoleId.ShiftActor)) ~ ]のコードを削除してください。
+            */
+            // if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
+            if (target.IsRole(RoleId.ShiftActor)) target.ResetAndSetImpostorghost();
         }
         Vampire.OnMurderPlayer(__instance, target);
         if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && ModeHandler.IsMode(ModeId.Default))

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -194,7 +194,13 @@ class WrapUpPatch
                     CheckGameEndPatch.CustomEndGame((GameOverReason)CustomGameOverReason.MadJesterWin, false);
                 }
             }
+            /*
+                DefaultModeにシフトアクター以外のシェイプシフター置き換え役職が増えた場合
+                [if (exiled.Object.IsShapeshifter()) ~ ] のコメントアウトを解除し、
+                [if (exiled.Object.IsRole(RoleId.ShiftActor)) ~ ]のコードを削除してください。
+            */
             if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
+            if (exiled.Object.IsRole(RoleId.ShiftActor)) exiled.Object.ResetAndSetImpostorghost();
         }
         Mode.SuperHostRoles.Main.RealExiled = null;
     }


### PR DESCRIPTION
Impostorghost化のコードが不安定なようなので、デフォルトモードでSHRモードではシェイプ置き換えになっている役職にこのコードを使用しないようにした。
(ShiftActorのみが処理されるようにした)