### PR TITLE
サボタージュ修理画面を開けなくするプログラムを追加

### DIFF
--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -58,6 +58,7 @@ public static class RoleClass
         MapCustoms.SpecimenVital.ClearAndReload();
         MapCustoms.MoveElecPad.ClearAndReload();
         Beacon.ClearBeacons();
+        FixSabotage.ClearAndReload();
 
         Debugger.ClearAndReload();
         SoothSayer.ClearAndReload();

--- a/SuperNewRoles/Sabotage/FixSabotage.cs
+++ b/SuperNewRoles/Sabotage/FixSabotage.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using HarmonyLib;
+
+namespace SuperNewRoles.Sabotage;
+
+public class FixSabotage
+{
+    /// <summary>
+    /// (リアクター, 停電, 通信, 酸素)
+    /// </summary>
+    public static Dictionary<RoleId, (bool, bool, bool, bool)> SetFixSabotageDictionary = new()
+    {
+        { RoleId.Fox, (false, false, false, false) },
+        { RoleId.FireFox, (false, false, false, false) },
+    };
+    [HarmonyPatch(typeof(Console), nameof(Console.Use))]
+    public static class ConsolsUsePatch
+    {
+        public static bool Prefix(Console __instance)
+        {
+            if (!SetFixSabotageDictionary.ContainsKey(PlayerControl.LocalPlayer.GetRole())) return true;
+            __instance.CanUse(PlayerControl.LocalPlayer.Data, out var canUse, out var _);
+            if (canUse) return IsBlocked(__instance.FindTask(CachedPlayer.LocalPlayer).TaskType);
+            return true;
+        }
+        public static bool IsBlocked(TaskTypes type)
+        {
+            (bool, bool, bool, bool) fixSabotage = SetFixSabotageDictionary[PlayerControl.LocalPlayer.GetRole()];
+            if (type is TaskTypes.StopCharles or TaskTypes.ResetSeismic or TaskTypes.ResetReactor && fixSabotage.Item1) return true;
+            if (type is TaskTypes.FixLights && fixSabotage.Item2) return true;
+            if (type is TaskTypes.FixComms && fixSabotage.Item3) return true;
+            if (type is TaskTypes.RestoreOxy && fixSabotage.Item4) return true;
+            return false;
+        }
+    }
+}

--- a/SuperNewRoles/Sabotage/FixSabotage.cs
+++ b/SuperNewRoles/Sabotage/FixSabotage.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 using HarmonyLib;
 
 namespace SuperNewRoles.Sabotage;
@@ -10,29 +8,63 @@ public class FixSabotage
     /// <summary>
     /// (リアクター, 停電, 通信, 酸素)
     /// </summary>
-    public static Dictionary<RoleId, (bool, bool, bool, bool)> SetFixSabotageDictionary = new()
+    public static Dictionary<RoleId, (bool, bool, bool, bool)> SetFixSabotageDictionary = new();
+    public static void ClearAndReload()
     {
-        { RoleId.Fox, (false, false, false, false) },
-        { RoleId.FireFox, (false, false, false, false) },
-    };
+        SetFixSabotageDictionary = new()
+        {
+            { RoleId.Fox, (false, false, false, false) },
+            { RoleId.FireFox, (false, false, false, false) },
+            { RoleId.God, (false,false, false, false) },
+            { RoleId.Vampire, (true, false, true, true) },
+            { RoleId.Dependents, (true, false, true, true) },
+            { RoleId.Madmate, (true, CustomOptionHolder.MadRolesCanFixElectrical.GetBool(), CustomOptionHolder.MadRolesCanFixComms.GetBool(), true) },
+        };
+    }
     [HarmonyPatch(typeof(Console), nameof(Console.Use))]
     public static class ConsolsUsePatch
     {
         public static bool Prefix(Console __instance)
         {
-            if (!SetFixSabotageDictionary.ContainsKey(PlayerControl.LocalPlayer.GetRole())) return true;
+            if (!(SetFixSabotageDictionary.ContainsKey(PlayerControl.LocalPlayer.GetRole()) || PlayerControl.LocalPlayer.IsMadRoles())) return true;
             __instance.CanUse(PlayerControl.LocalPlayer.Data, out var canUse, out var _);
-            if (canUse) return IsBlocked(__instance.FindTask(CachedPlayer.LocalPlayer).TaskType);
+            if (canUse) return IsBlocked(__instance.FindTask(CachedPlayer.LocalPlayer).TaskType, !PlayerControl.LocalPlayer.IsMadRoles() ? PlayerControl.LocalPlayer.GetRole() : RoleId.Madmate);
             return true;
         }
-        public static bool IsBlocked(TaskTypes type)
+    }
+    [HarmonyPatch(typeof(UseButton), nameof(UseButton.SetTarget))]
+    public static class UseButtonSetTargetPatch
+    {
+        public static bool Prefix(UseButton __instance, [HarmonyArgument(0)] IUsable target)
         {
-            (bool, bool, bool, bool) fixSabotage = SetFixSabotageDictionary[PlayerControl.LocalPlayer.GetRole()];
-            if (type is TaskTypes.StopCharles or TaskTypes.ResetSeismic or TaskTypes.ResetReactor && fixSabotage.Item1) return true;
-            if (type is TaskTypes.FixLights && fixSabotage.Item2) return true;
-            if (type is TaskTypes.FixComms && fixSabotage.Item3) return true;
-            if (type is TaskTypes.RestoreOxy && fixSabotage.Item4) return true;
-            return false;
+            if (IsBlocked(target))
+            {
+                __instance.currentTarget = null;
+                __instance.graphic.color = Palette.DisabledClear;
+                __instance.graphic.material.SetFloat("_Desat", 0f);
+                return false;
+            }
+            __instance.enabled = true;
+            __instance.currentTarget = target;
+            return true;
         }
+    }
+    public static bool IsBlocked(TaskTypes type, RoleId roleId)
+    {
+        if (!SetFixSabotageDictionary.ContainsKey(roleId)) return true;
+        (bool, bool, bool, bool) fixSabotage = SetFixSabotageDictionary[roleId];
+        if (type is TaskTypes.StopCharles or TaskTypes.ResetSeismic or TaskTypes.ResetReactor && fixSabotage.Item1) return true;
+        if (type is TaskTypes.FixLights && fixSabotage.Item2) return true;
+        if (type is TaskTypes.FixComms && fixSabotage.Item3) return true;
+        if (type is TaskTypes.RestoreOxy && fixSabotage.Item4) return true;
+        return false;
+    }
+    public static bool IsBlocked(IUsable target)
+    {
+        if (target == null) return false;
+        Console console = target.TryCast<Console>();
+        if (console != null && !IsBlocked(console.FindTask(CachedPlayer.LocalPlayer).TaskType, !PlayerControl.LocalPlayer.IsMadRoles() ? PlayerControl.LocalPlayer.GetRole() : RoleId.Madmate))
+            return true;
+        return false;
     }
 }


### PR DESCRIPTION
特定のサボタージュ修理画面に移行できなくしました。
これで妖狐や炎狐。神が特定しやすくなったよ()
あと開けないサボタージュ修理画面の近くで使用ボタンが光らないようにしました。
これってラベルなに張ればいいんでしょうね()

## 修理不可にしたもの
1. 妖狐 
　全て
2. 炎狐
　全て
3. 神
　全て
4. ヴァンパイア
　停電のみ
5. 眷属
　停電のみ
6. マッドメイト
　停電と通信(設定で変更可)