### PR TITLE
シェリフ系役職のキル可能か判定するコードをすべて纏めた&誤射に巻き込まれたクルーの死因を変更した

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1423,6 +1423,7 @@ static class HudManagerStartPatch
                         killWriter.Write(alwaysKill);
                         AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                         FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : target, misfire ? FinalStatus.SheriffMisFire : (target.IsRole(RoleId.HauntedWolf) ? FinalStatus.SheriffHauntedWolfKill : FinalStatus.SheriffKill));
+                        if (alwaysKill) FinalStatusClass.RpcSetFinalStatus(target, FinalStatus.SheriffInvolvedOutburst);
                         Sheriff.ResetKillCooldown();
                         RoleClass.Sheriff.KillMaxCount--;
                     }

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1403,11 +1403,9 @@ static class HudManagerStartPatch
                     {
                         var target = PlayerControlFixedUpdatePatch.SetTarget();
                         var localId = CachedPlayer.LocalPlayer.PlayerId;
-                        var misfire = !Sheriff.IsSheriffKill(target);
+                        var misfire = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, target);
                         PlayerControlFixedUpdatePatch.SetPlayerOutline(target, RoleClass.Sheriff.color);
-                        if (RoleClass.Chief.SheriffPlayer.Contains(localId)) misfire = !Sheriff.IsChiefSheriffKill(target);
-                        var alwaysKill = !Sheriff.IsSheriffKill(target) && CustomOptionHolder.SheriffAlwaysKills.GetBool();
-                        if (RoleClass.Chief.SheriffPlayer.Contains(localId)) alwaysKill = !Sheriff.IsChiefSheriffKill(target) && CustomOptionHolder.ChiefSheriffAlwaysKills.GetBool();
+                        var alwaysKill = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, target) && CustomOptionHolder.SheriffAlwaysKills.GetBool();
                         if (alwaysKill && target.IsRole(RoleId.Squid) && Squid.IsVigilance.ContainsKey(target.PlayerId) && Squid.IsVigilance[target.PlayerId])
                         {
                             alwaysKill = false;

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -132,7 +132,9 @@ public class CustomOptionHolder
     public static CustomOption RemoteSheriffAlwaysKills;
     public static CustomOption RemoteSheriffMadRoleKill;
     public static CustomOption RemoteSheriffNeutralKill;
+    public static CustomOption RemoteSheriffFriendRolesKill;
     public static CustomOption RemoteSheriffLoversKill;
+    public static CustomOption RemoteSheriffQuarreledKill;
     public static CustomOption RemoteSheriffKillMaxCount;
     public static CustomOption RemoteSheriffIsKillTeleportSetting;
 
@@ -141,6 +143,9 @@ public class CustomOptionHolder
     public static CustomOption MeetingSheriffAlwaysKills;
     public static CustomOption MeetingSheriffMadRoleKill;
     public static CustomOption MeetingSheriffNeutralKill;
+    public static CustomOption MeetingSheriffFriendsRoleKill;
+    public static CustomOption MeetingSheriffLoversKill;
+    public static CustomOption MeetingSheriffQuarreledKill;
     public static CustomOption MeetingSheriffKillMaxCount;
     public static CustomOption MeetingSheriffOneMeetingMultiKill;
 
@@ -648,6 +653,9 @@ public class CustomOptionHolder
     public static CustomOption ChiefSheriffCanKillNeutral;
     public static CustomOption ChiefSheriffCanKillLovers;
     public static CustomOption ChiefSheriffCanKillMadRole;
+    public static CustomOption ChiefSheriffFriendsRoleKill;
+    public static CustomOption ChiefSheriffQuarreledKill;
+
     public static CustomOption ChiefSheriffKillLimit;
 
     public static CustomRoleOption CleanerOption;
@@ -1094,44 +1102,51 @@ public class CustomOptionHolder
         EvilScientistCoolTime = Create(35, false, CustomOptionType.Impostor, "EvilScientistCooldownSetting", 30f, 2.5f, 60f, 2.5f, EvilScientistOption, format: "unitSeconds");
         EvilScientistDurationTime = Create(36, false, CustomOptionType.Impostor, "EvilScientistDurationSetting", 10f, 2.5f, 20f, 2.5f, EvilScientistOption, format: "unitSeconds");
 
-        SheriffOption = SetupCustomRoleOption(37, true, RoleId.Sheriff);
-        SheriffPlayerCount = Create(38, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], SheriffOption);
-        SheriffCoolTime = Create(39, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
-        SheriffKillMaxCount = Create(43, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
-        SheriffCanKillImpostor = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
-        SheriffAlwaysKills = Create(732, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, SheriffOption);
-        SheriffMadRoleKill = Create(42, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
+        SheriffOption = SetupCustomRoleOption(700, true, RoleId.Sheriff);
+        SheriffPlayerCount = Create(701, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], SheriffOption);
+        SheriffCoolTime = Create(702, true, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, SheriffOption, format: "unitSeconds");
+        SheriffKillMaxCount = Create(703, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, SheriffOption, format: "unitSeconds");
+        SheriffAlwaysKills = Create(704, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, SheriffOption);
+        SheriffCanKillImpostor = Create(705, true, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, SheriffOption);
+        SheriffMadRoleKill = Create(706, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, SheriffOption);
+        SheriffNeutralKill = Create(707, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
         SheriffFriendsRoleKill = Create(708, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, SheriffOption);
-        SheriffNeutralKill = Create(40, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, SheriffOption);
-        SheriffLoversKill = Create(41, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, SheriffOption);
-        SheriffQuarreledKill = Create(730, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, SheriffOption);
+        SheriffLoversKill = Create(709, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, SheriffOption);
+        SheriffQuarreledKill = Create(710, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, SheriffOption);
 
-        RemoteSheriffOption = SetupCustomRoleOption(44, true, RoleId.RemoteSheriff);
-        RemoteSheriffPlayerCount = Create(45, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
-        RemoteSheriffCoolTime = Create(46, false, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
-        RemoteSheriffAlwaysKills = Create(733, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, RemoteSheriffOption);
-        RemoteSheriffNeutralKill = Create(47, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, RemoteSheriffOption);
-        RemoteSheriffLoversKill = Create(48, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
-        RemoteSheriffMadRoleKill = Create(49, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
-        RemoteSheriffKillMaxCount = Create(50, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, RemoteSheriffOption, format: "unitSeconds");
-        RemoteSheriffIsKillTeleportSetting = Create(51, true, CustomOptionType.Crewmate, "RemoteSheriffIsKillTeleportSetting", false, RemoteSheriffOption);
+        RemoteSheriffOption = SetupCustomRoleOption(711, true, RoleId.RemoteSheriff);
+        RemoteSheriffPlayerCount = Create(712, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], RemoteSheriffOption);
+        RemoteSheriffCoolTime = Create(713, false, CustomOptionType.Crewmate, ModTranslation.GetString("SheriffCooldownSetting"), 30f, 2.5f, 60f, 2.5f, RemoteSheriffOption, format: "unitSeconds");
+        RemoteSheriffKillMaxCount = Create(714, true, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, RemoteSheriffOption, format: "unitSeconds");
+        RemoteSheriffIsKillTeleportSetting = Create(715, true, CustomOptionType.Crewmate, "RemoteSheriffIsKillTeleportSetting", false, RemoteSheriffOption);
+        RemoteSheriffAlwaysKills = Create(716, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, RemoteSheriffOption);
+        RemoteSheriffMadRoleKill = Create(717, true, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, RemoteSheriffOption);
+        RemoteSheriffNeutralKill = Create(718, true, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, RemoteSheriffOption);
+        RemoteSheriffFriendRolesKill = Create(719, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, RemoteSheriffOption);
+        RemoteSheriffLoversKill = Create(720, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, RemoteSheriffOption);
+        RemoteSheriffQuarreledKill = Create(721, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, RemoteSheriffOption);
 
-        MeetingSheriffOption = SetupCustomRoleOption(52, false, RoleId.MeetingSheriff);
-        MeetingSheriffPlayerCount = Create(53, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
-        MeetingSheriffAlwaysKills = Create(734, false, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, MeetingSheriffOption);
-        MeetingSheriffNeutralKill = Create(54, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
-        MeetingSheriffMadRoleKill = Create(55, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
-        MeetingSheriffKillMaxCount = Create(56, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
-        MeetingSheriffOneMeetingMultiKill = Create(57, false, CustomOptionType.Crewmate, "MeetingSheriffMeetingmultipleKillSetting", false, MeetingSheriffOption);
+        MeetingSheriffOption = SetupCustomRoleOption(723, false, RoleId.MeetingSheriff);
+        MeetingSheriffPlayerCount = Create(724, false, CustomOptionType.Crewmate, Cs(Color.white, "SettingPlayerCountName"), CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MeetingSheriffOption);
+        MeetingSheriffKillMaxCount = Create(725, false, CustomOptionType.Crewmate, "MeetingSheriffMaxKillCountSetting", 1f, 1f, 20f, 1f, MeetingSheriffOption, format: "unitSeconds");
+        MeetingSheriffOneMeetingMultiKill = Create(726, false, CustomOptionType.Crewmate, "MeetingSheriffMeetingmultipleKillSetting", false, MeetingSheriffOption);
+        MeetingSheriffAlwaysKills = Create(727, false, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, MeetingSheriffOption);
+        MeetingSheriffMadRoleKill = Create(728, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
+        MeetingSheriffNeutralKill = Create(729, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
+        MeetingSheriffFriendsRoleKill = Create(730, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, MeetingSheriffOption);
+        MeetingSheriffLoversKill = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, MeetingSheriffOption);
+        MeetingSheriffQuarreledKill = Create(732, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, MeetingSheriffOption);
 
-        ChiefOption = SetupCustomRoleOption(394, false, RoleId.Chief);
-        ChiefPlayerCount = Create(395, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
-        ChiefSheriffCoolTime = Create(626, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
-        ChiefSheriffAlwaysKills = Create(735, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, ChiefOption);
-        ChiefSheriffCanKillNeutral = Create(627, false, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, ChiefOption);
-        ChiefSheriffCanKillLovers = Create(628, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
-        ChiefSheriffCanKillMadRole = Create(629, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
-        ChiefSheriffKillLimit = Create(630, false, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, ChiefOption, format: "unitSeconds");
+        ChiefOption = SetupCustomRoleOption(733, false, RoleId.Chief);
+        ChiefPlayerCount = Create(734, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
+        ChiefSheriffCoolTime = Create(735, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
+        ChiefSheriffKillLimit = Create(736, false, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, ChiefOption, format: "unitSeconds");
+        ChiefSheriffAlwaysKills = Create(737, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, ChiefOption);
+        ChiefSheriffCanKillMadRole = Create(738, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
+        ChiefSheriffCanKillNeutral = Create(739, false, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, ChiefOption);
+        ChiefSheriffFriendsRoleKill = Create(740, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, ChiefOption);
+        ChiefSheriffCanKillLovers = Create(741, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
+        ChiefSheriffQuarreledKill = Create(742, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, ChiefOption);
 
         MayorOption = SetupCustomRoleOption(229, true, RoleId.Mayor);
         MayorPlayerCount = Create(230, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MayorOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -650,6 +650,7 @@ public class CustomOptionHolder
     public static CustomOption ChiefPlayerCount;
     public static CustomOption ChiefSheriffCoolTime;
     public static CustomOption ChiefSheriffAlwaysKills;
+    public static CustomOption ChiefSheriffCanKillImpostor;
     public static CustomOption ChiefSheriffCanKillNeutral;
     public static CustomOption ChiefSheriffCanKillLovers;
     public static CustomOption ChiefSheriffCanKillMadRole;
@@ -1133,20 +1134,21 @@ public class CustomOptionHolder
         MeetingSheriffAlwaysKills = Create(727, false, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, MeetingSheriffOption);
         MeetingSheriffMadRoleKill = Create(728, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillMadRoleSetting", false, MeetingSheriffOption);
         MeetingSheriffNeutralKill = Create(729, false, CustomOptionType.Crewmate, "MeetingSheriffIsKillNeutralSetting", false, MeetingSheriffOption);
-        MeetingSheriffFriendsRoleKill = Create(730, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, MeetingSheriffOption);
-        MeetingSheriffLoversKill = Create(731, true, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, MeetingSheriffOption);
-        MeetingSheriffQuarreledKill = Create(732, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, MeetingSheriffOption);
+        MeetingSheriffFriendsRoleKill = Create(730, false, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, MeetingSheriffOption);
+        MeetingSheriffLoversKill = Create(731, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, MeetingSheriffOption);
+        MeetingSheriffQuarreledKill = Create(732, false, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, MeetingSheriffOption);
 
         ChiefOption = SetupCustomRoleOption(733, false, RoleId.Chief);
         ChiefPlayerCount = Create(734, false, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], ChiefOption);
         ChiefSheriffCoolTime = Create(735, false, CustomOptionType.Crewmate, "SheriffCooldownSetting", 30f, 2.5f, 60f, 2.5f, ChiefOption, format: "unitSeconds");
         ChiefSheriffKillLimit = Create(736, false, CustomOptionType.Crewmate, "SheriffMaxKillCountSetting", 1f, 1f, 20f, 1, ChiefOption, format: "unitSeconds");
-        ChiefSheriffAlwaysKills = Create(737, true, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, ChiefOption);
-        ChiefSheriffCanKillMadRole = Create(738, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
-        ChiefSheriffCanKillNeutral = Create(739, false, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, ChiefOption);
-        ChiefSheriffFriendsRoleKill = Create(740, true, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, ChiefOption);
-        ChiefSheriffCanKillLovers = Create(741, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
-        ChiefSheriffQuarreledKill = Create(742, true, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, ChiefOption);
+        ChiefSheriffAlwaysKills = Create(737, false, CustomOptionType.Crewmate, "SheriffAlwaysKills", false, ChiefOption);
+        ChiefSheriffCanKillImpostor = Create(738, false, CustomOptionType.Crewmate, "SheriffIsKillImpostorSetting", true, ChiefOption);
+        ChiefSheriffCanKillMadRole = Create(739, false, CustomOptionType.Crewmate, "SheriffIsKillMadRoleSetting", false, ChiefOption);
+        ChiefSheriffCanKillNeutral = Create(740, false, CustomOptionType.Crewmate, "SheriffIsKillNeutralSetting", false, ChiefOption);
+        ChiefSheriffFriendsRoleKill = Create(741, false, CustomOptionType.Crewmate, "SheriffIsKillFriendsRoleSetting", false, ChiefOption);
+        ChiefSheriffCanKillLovers = Create(742, false, CustomOptionType.Crewmate, "SheriffIsKillLoversSetting", false, ChiefOption);
+        ChiefSheriffQuarreledKill = Create(743, false, CustomOptionType.Crewmate, "SheriffIsKillQuarreledSetting", false, ChiefOption);
 
         MayorOption = SetupCustomRoleOption(229, true, RoleId.Mayor);
         MayorPlayerCount = Create(230, true, CustomOptionType.Crewmate, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], MayorOption);

--- a/SuperNewRoles/Modules/FinalStatus.cs
+++ b/SuperNewRoles/Modules/FinalStatus.cs
@@ -49,6 +49,7 @@ public enum FinalStatus
     RemoteSheriffHauntedWolfKill,
     RemoteSheriffKill,
     RemoteSheriffMisFire,
+    SheriffInvolvedOutburst,
     SerialKillerSelfDeath,
     VampireKill,
     OverKillerOverKill,

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -95,7 +95,7 @@ class RpcShapeshiftPatch
                     if (target.IsDead()) return true;
                     if (!RoleClass.RemoteSheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.RemoteSheriff.KillCount[__instance.PlayerId] >= 1)
                     {
-                        if ((!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool())
+                        if ((!Sheriff.IsSheriffRolesKill(__instance, target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool())
                         {
                             FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
                             __instance.RpcMurderPlayerCheck(target);
@@ -105,7 +105,7 @@ class RpcShapeshiftPatch
                             FinalStatusClass.RpcSetFinalStatus(__instance, FinalStatus.RemoteSheriffMisFire);
                             return true;
                         }
-                        else if (!Sheriff.IsRemoteSheriffKill(target) || target.IsRole(RoleId.RemoteSheriff))
+                        else if (!Sheriff.IsSheriffRolesKill(__instance, target) || target.IsRole(RoleId.RemoteSheriff))
                         {
                             FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                             __instance.RpcMurderPlayer(__instance);
@@ -333,8 +333,8 @@ class ShapeshifterMinigameShapeshiftPatch
                     if (player.IsAlive())
                     {
                         var Target = player;
-                        var misfire = !Sheriff.IsRemoteSheriffKill(Target);
-                        var alwaysKill = !Sheriff.IsRemoteSheriffKill(Target) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool();
+                        var misfire = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, Target);
+                        var alwaysKill = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, Target) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool();
                         var TargetID = Target.PlayerId;
                         var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 
@@ -537,7 +537,7 @@ static class CheckMurderPatch
                     case RoleId.Sheriff:
                         if (!RoleClass.Sheriff.KillCount.ContainsKey(__instance.PlayerId) || RoleClass.Sheriff.KillCount[__instance.PlayerId] >= 1)
                         {
-                            if (!Sheriff.IsSheriffKill(target) && CustomOptionHolder.SheriffAlwaysKills.GetBool())
+                            if (!Sheriff.IsSheriffRolesKill(__instance, target) && CustomOptionHolder.SheriffAlwaysKills.GetBool())
                             {
                                 FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
                                 __instance.RpcMurderPlayerCheck(target);
@@ -547,7 +547,7 @@ static class CheckMurderPatch
                                 __instance.RpcMurderPlayer(__instance);
                                 __instance.RpcSetFinalStatus(FinalStatus.SheriffMisFire);
                             }
-                            else if (!Sheriff.IsSheriffKill(target))
+                            else if (!Sheriff.IsSheriffRolesKill(__instance, target))
                             {
                                 FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                                 __instance.RpcMurderPlayer(__instance);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -97,9 +97,9 @@ class RpcShapeshiftPatch
                     {
                         if ((!Sheriff.IsSheriffRolesKill(__instance, target) || target.IsRole(RoleId.RemoteSheriff)) && CustomOptionHolder.RemoteSheriffAlwaysKills.GetBool())
                         {
-                            FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
+                            FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffInvolvedOutburst;
                             __instance.RpcMurderPlayerCheck(target);
-                            FinalStatusClass.RpcSetFinalStatus(target, target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill);
+                            FinalStatusClass.RpcSetFinalStatus(target, target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.SheriffInvolvedOutburst);
                             FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                             __instance.RpcMurderPlayer(__instance);
                             FinalStatusClass.RpcSetFinalStatus(__instance, FinalStatus.RemoteSheriffMisFire);
@@ -348,6 +348,7 @@ class ShapeshifterMinigameShapeshiftPatch
                         killWriter.Write(alwaysKill);
                         AmongUsClient.Instance.FinishRpcImmediately(killWriter);
                         FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.RemoteSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.RemoteSheriffHauntedWolfKill : FinalStatus.RemoteSheriffKill));
+                        if (alwaysKill) FinalStatusClass.RpcSetFinalStatus(Target, FinalStatus.SheriffInvolvedOutburst);
                         RoleClass.RemoteSheriff.KillMaxCount--;
                     }
                     Sheriff.ResetKillCooldown();
@@ -539,10 +540,10 @@ static class CheckMurderPatch
                         {
                             if (!Sheriff.IsSheriffRolesKill(__instance, target) && CustomOptionHolder.SheriffAlwaysKills.GetBool())
                             {
-                                FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffKill;
+                                FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.SheriffInvolvedOutburst;
                                 __instance.RpcMurderPlayerCheck(target);
                                 if (target.IsRole(RoleId.HauntedWolf)) __instance.RpcSetFinalStatus(FinalStatus.SheriffHauntedWolfKill);
-                                else __instance.RpcSetFinalStatus(FinalStatus.SheriffKill);
+                                else __instance.RpcSetFinalStatus(FinalStatus.SheriffInvolvedOutburst);
                                 FinalStatusPatch.FinalStatusData.FinalStatuses[__instance.PlayerId] = FinalStatus.SheriffMisFire;
                                 __instance.RpcMurderPlayer(__instance);
                                 __instance.RpcSetFinalStatus(FinalStatus.SheriffMisFire);

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -326,6 +326,7 @@ FinalStatusRevenge,Revenge,復讐,仇杀
 FinalStatusHitmanKill,Mission accomplished.,任務遂行,遇刺
 FinalStatusHitmanDead,Disposition.,処分,沉江
 FinalStatusWorshiperSelfDeath,Suicide,自決
+FinalStatusSheriffInvolvedOutburst,Collateral damage to the sheriff's misfire.,暴発巻き添え
 
 # Sabotages
 SabotageSetting,Sabotage Setting,サボタージュの設定,破坏设置

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -108,6 +108,7 @@ class MeetingSheriff_Patch
         killWriter.Write(alwaysKill);
         AmongUsClient.Instance.FinishRpcImmediately(killWriter);
         FinalStatusClass.RpcSetFinalStatus(misfire ? CachedPlayer.LocalPlayer : Target, misfire ? FinalStatus.MeetingSheriffMisFire : (Target.IsRole(RoleId.HauntedWolf) ? FinalStatus.MeetingSheriffHauntedWolfKill : FinalStatus.MeetingSheriffKill));
+        if (alwaysKill) FinalStatusClass.RpcSetFinalStatus(Target, FinalStatus.SheriffInvolvedOutburst);
         RoleClass.MeetingSheriff.KillMaxCount--;
         if (RoleClass.MeetingSheriff.KillMaxCount <= 0 || !RoleClass.MeetingSheriff.OneMeetingMultiKill || misfire)
         {

--- a/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
+++ b/SuperNewRoles/Roles/CrewMate/MeetingSheriff_Patch.cs
@@ -91,19 +91,11 @@ class Meetingsheriff_updatepatch
 [HarmonyPatch(typeof(MeetingHud), nameof(MeetingHud.Start))]
 class MeetingSheriff_Patch
 {
-    public static bool IsMeetingSheriffKill(PlayerControl Target)
-    {
-        var roledata = CountChanger.GetRoleType(Target);
-        return (roledata == TeamRoleType.Impostor)
-            || (Target.IsMadRoles() && RoleClass.MeetingSheriff.MadRoleKill)
-            || (Target.IsFriendRoles() && RoleClass.MeetingSheriff.MadRoleKill)
-            || (Target.IsNeutral() && RoleClass.MeetingSheriff.NeutralKill) || Target.IsRole(RoleId.HauntedWolf);
-    }
     static void MeetingSheriffOnClick(int Index, MeetingHud __instance)
     {
         var Target = ModHelpers.PlayerById(__instance.playerStates[Index].TargetPlayerId);
-        var misfire = !IsMeetingSheriffKill(Target);
-        var alwaysKill = !IsMeetingSheriffKill(Target) && CustomOptionHolder.MeetingSheriffAlwaysKills.GetBool();
+        var misfire = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, Target);
+        var alwaysKill = !Sheriff.IsSheriffRolesKill(CachedPlayer.LocalPlayer, Target) && CustomOptionHolder.MeetingSheriffAlwaysKills.GetBool();
         var TargetID = Target.PlayerId;
         var LocalID = CachedPlayer.LocalPlayer.PlayerId;
 

--- a/SuperNewRoles/Roles/CrewMate/Sheriff.cs
+++ b/SuperNewRoles/Roles/CrewMate/Sheriff.cs
@@ -54,6 +54,7 @@ class Sheriff
                 }
                 else // 村長シェリフの場合
                 {
+                    isImpostorKill = CustomOptionHolder.ChiefSheriffCanKillImpostor.GetBool();
                     isMadRolesKill = CustomOptionHolder.ChiefSheriffCanKillMadRole.GetBool();
                     isNeutralKill = CustomOptionHolder.ChiefSheriffCanKillNeutral.GetBool();
                     isFriendRolesKill = CustomOptionHolder.ChiefSheriffFriendsRoleKill.GetBool();

--- a/SuperNewRoles/Roles/CrewMate/Sheriff.cs
+++ b/SuperNewRoles/Roles/CrewMate/Sheriff.cs
@@ -26,38 +26,68 @@ class Sheriff
         }
         catch { }
     }
-    public static bool IsSheriffKill(PlayerControl Target)
-    {
-        var roledata = CountChanger.GetRoleType(Target);
-        RoleId role = Target.GetRole();
 
-        if ((roledata == TeamRoleType.Impostor) || Target.IsRole(RoleId.HauntedWolf)) return CustomOptionHolder.SheriffCanKillImpostor.GetBool();//インポスター、狼付きは設定がimp設定が有効な時切れる
-        if (RoleClass.Sheriff.IsLoversKill && Target.IsLovers()) return true;//ラバーズ
-        if (CustomOptionHolder.SheriffQuarreledKill.GetBool() && Target.IsQuarreled()) return true;//クラード
-        if (RoleClass.Sheriff.IsMadRoleKill && (Target.IsMadRoles() || Target.IsRole(RoleId.MadKiller) || Target.IsRole(RoleId.Dependents))) return true;
-        if (CustomOptionHolder.SheriffFriendsRoleKill.GetBool() && Target.IsFriendRoles()) return true;
-        if (RoleClass.Sheriff.IsNeutralKill && Target.IsNeutral()) return true;
+    public static bool IsSheriffRolesKill(PlayerControl sheriff, PlayerControl target)
+    {
+        var targetRoleData = CountChanger.GetRoleType(target);
+        var isImpostorKill = true;
+        var isMadRolesKill = false;
+        var isNeutralKill = false;
+        var isFriendRolesKill = false;
+        var isLoversKill = false;
+        var isQuarreledKill = false;
+
+        RoleId role = sheriff.GetRole();
+
+        switch (role)
+        {
+            case RoleId.Sheriff:
+                // 通常Sheriffの場合
+                if (!RoleClass.Chief.SheriffPlayer.Contains(sheriff.PlayerId))
+                {
+                    isImpostorKill = CustomOptionHolder.SheriffCanKillImpostor.GetBool();
+                    isMadRolesKill = CustomOptionHolder.SheriffMadRoleKill.GetBool(); ;
+                    isNeutralKill = CustomOptionHolder.SheriffNeutralKill.GetBool();
+                    isFriendRolesKill = CustomOptionHolder.SheriffFriendsRoleKill.GetBool();
+                    isLoversKill = CustomOptionHolder.SheriffLoversKill.GetBool();
+                    isQuarreledKill = CustomOptionHolder.SheriffQuarreledKill.GetBool();
+                }
+                else // 村長シェリフの場合
+                {
+                    isMadRolesKill = CustomOptionHolder.ChiefSheriffCanKillMadRole.GetBool();
+                    isNeutralKill = CustomOptionHolder.ChiefSheriffCanKillNeutral.GetBool();
+                    isFriendRolesKill = CustomOptionHolder.ChiefSheriffFriendsRoleKill.GetBool();
+                    isLoversKill = CustomOptionHolder.ChiefSheriffCanKillLovers.GetBool();
+                    isQuarreledKill = CustomOptionHolder.ChiefSheriffQuarreledKill.GetBool();
+                }
+                break;
+            case RoleId.RemoteSheriff:
+                isMadRolesKill = CustomOptionHolder.RemoteSheriffMadRoleKill.GetBool();
+                isNeutralKill = CustomOptionHolder.RemoteSheriffNeutralKill.GetBool();
+                isFriendRolesKill = CustomOptionHolder.RemoteSheriffFriendRolesKill.GetBool();
+                isLoversKill = CustomOptionHolder.RemoteSheriffLoversKill.GetBool();
+                isQuarreledKill = CustomOptionHolder.RemoteSheriffQuarreledKill.GetBool();
+                break;
+            case RoleId.MeetingSheriff:
+                isMadRolesKill = CustomOptionHolder.MeetingSheriffMadRoleKill.GetBool();
+                isNeutralKill = CustomOptionHolder.MeetingSheriffNeutralKill.GetBool();
+                isFriendRolesKill = CustomOptionHolder.MeetingSheriffFriendsRoleKill.GetBool();
+                isLoversKill = CustomOptionHolder.MeetingSheriffLoversKill.GetBool();
+                isQuarreledKill = CustomOptionHolder.MeetingSheriffQuarreledKill.GetBool();
+                break;
+        }
+        if ((targetRoleData == TeamRoleType.Impostor) || target.IsRole(RoleId.HauntedWolf)) return isImpostorKill;//インポスター、狼付きは設定がimp設定が有効な時切れる
+        if (target.IsMadRoles()
+            || target.IsRole(RoleId.MadKiller)
+            || target.IsRole(RoleId.Dependents))
+            return isMadRolesKill;
+        if (target.IsNeutral()) return isNeutralKill;
+        if (target.IsFriendRoles()) return isFriendRolesKill;
+        if (target.IsLovers()) return isLoversKill;//ラバーズ
+        if (target.IsQuarreled()) return isQuarreledKill;//クラード
         return false;
     }
-    public static bool IsChiefSheriffKill(PlayerControl Target)
-    {
-        var roledata = CountChanger.GetRoleType(Target);
-        return (roledata == TeamRoleType.Impostor)
-        || ((Target.IsMadRoles() || Target.IsRole(RoleId.MadKiller) || Target.IsRole(RoleId.Dependents)) && RoleClass.Chief.IsMadRoleKill)
-        || (Target.IsFriendRoles() && RoleClass.Chief.IsMadRoleKill)
-        || (Target.IsNeutral() && RoleClass.Chief.IsNeutralKill)
-        || (RoleClass.Chief.IsLoversKill && Target.IsLovers()) || Target.IsRole(RoleId.HauntedWolf);
-    }
-    public static bool IsRemoteSheriffKill(PlayerControl Target)
-    {
-        var roledata = CountChanger.GetRoleType(Target);
-        return (roledata == TeamRoleType.Impostor)
-        || ((Target.IsMadRoles() || Target.IsRole(RoleId.MadKiller) || Target.IsRole(RoleId.Dependents)) && RoleClass.RemoteSheriff.IsMadRoleKill)
-        || (Target.IsFriendRoles() && RoleClass.RemoteSheriff.IsMadRoleKill)
-        || (Target.IsNeutral() && RoleClass.RemoteSheriff.IsNeutralKill)
-        || (RoleClass.RemoteSheriff.IsLoversKill && Target.IsLovers())
-        || Target.IsRole(RoleId.HauntedWolf);
-    }
+
     public static bool IsSheriff(PlayerControl Player)
     {
         return Player.IsRole(RoleId.Sheriff) || Player.IsRole(RoleId.RemoteSheriff);

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -322,10 +322,6 @@ public static class RoleClass
         public static Color32 color = SheriffYellow;
         public static PlayerControl currentTarget;
         public static float CoolTime;
-        public static bool IsNeutralKill;
-        public static bool IsLoversKill;
-        public static bool IsMadRoleKill;
-        public static bool IsFriendsRoleKill;
         public static float KillMaxCount;
         public static Dictionary<int, int> KillCount;
         public static DateTime ButtonTimer;
@@ -336,10 +332,6 @@ public static class RoleClass
         {
             SheriffPlayer = new();
             CoolTime = CustomOptionHolder.SheriffCoolTime.GetFloat();
-            IsNeutralKill = CustomOptionHolder.SheriffNeutralKill.GetBool();
-            IsLoversKill = CustomOptionHolder.SheriffLoversKill.GetBool();
-            IsMadRoleKill = CustomOptionHolder.SheriffMadRoleKill.GetBool();
-            IsFriendsRoleKill = CustomOptionHolder.SheriffFriendsRoleKill.GetBool();
             KillMaxCount = CustomOptionHolder.SheriffKillMaxCount.GetFloat();
             KillCount = new();
         }
@@ -348,8 +340,6 @@ public static class RoleClass
     {
         public static List<PlayerControl> MeetingSheriffPlayer;
         public static Color32 color = SheriffYellow;
-        public static bool NeutralKill;
-        public static bool MadRoleKill;
         public static float KillMaxCount;
         public static bool OneMeetingMultiKill;
 
@@ -357,8 +347,6 @@ public static class RoleClass
         public static void ClearAndReload()
         {
             MeetingSheriffPlayer = new();
-            NeutralKill = CustomOptionHolder.MeetingSheriffNeutralKill.GetBool();
-            MadRoleKill = CustomOptionHolder.MeetingSheriffMadRoleKill.GetBool();
             KillMaxCount = CustomOptionHolder.MeetingSheriffKillMaxCount.GetFloat();
             OneMeetingMultiKill = CustomOptionHolder.MeetingSheriffOneMeetingMultiKill.GetBool();
         }
@@ -1676,10 +1664,6 @@ public static class RoleClass
         public static List<PlayerControl> RemoteSheriffPlayer;
         public static Color32 color = SheriffYellow;
         public static float CoolTime;
-        public static bool IsNeutralKill;
-        public static bool IsLoversKill;
-        public static bool IsMadRoleKill;
-        public static bool MadRoleKill;
         public static float KillMaxCount;
         public static Dictionary<int, int> KillCount;
         public static bool IsKillTeleport;
@@ -1688,10 +1672,6 @@ public static class RoleClass
         {
             RemoteSheriffPlayer = new();
             CoolTime = CustomOptionHolder.RemoteSheriffCoolTime.GetFloat();
-            IsNeutralKill = CustomOptionHolder.RemoteSheriffNeutralKill.GetBool();
-            IsLoversKill = CustomOptionHolder.RemoteSheriffLoversKill.GetBool();
-            IsMadRoleKill = CustomOptionHolder.RemoteSheriffMadRoleKill.GetBool();
-            MadRoleKill = CustomOptionHolder.RemoteSheriffMadRoleKill.GetBool();
             KillMaxCount = CustomOptionHolder.RemoteSheriffKillMaxCount.GetFloat();
             KillCount = new();
             IsKillTeleport = CustomOptionHolder.RemoteSheriffIsKillTeleportSetting.GetBool();
@@ -1929,10 +1909,6 @@ public static class RoleClass
         public static Color32 color = SheriffYellow;
         public static bool IsCreateSheriff;
         public static float CoolTime;
-        public static bool IsNeutralKill;
-        public static bool IsLoversKill;
-        public static bool IsMadRoleKill;
-        public static bool MadRoleKill;
         public static int KillLimit;
         public static Sprite GetButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.ChiefSidekickButton.png", 115f);
 
@@ -1943,9 +1919,6 @@ public static class RoleClass
             NoTaskSheriffPlayer = new();
             IsCreateSheriff = false;
             CoolTime = CustomOptionHolder.ChiefSheriffCoolTime.GetFloat();
-            IsNeutralKill = CustomOptionHolder.ChiefSheriffCanKillNeutral.GetBool();
-            IsLoversKill = CustomOptionHolder.ChiefSheriffCanKillLovers.GetBool();
-            IsMadRoleKill = CustomOptionHolder.ChiefSheriffCanKillMadRole.GetBool();
             KillLimit = CustomOptionHolder.ChiefSheriffKillLimit.GetInt();
         }
     }


### PR DESCRIPTION
# [めも]
- リファクタしたつもりが コード増えたんですが なんででしょうね()

# [変更点]
- シェリフ4役職のキル可能か判定するコードがバラバラだった為、すべて一つにまとめた。
  - これにより、「眷族」のようなIsTeam判定から外れる役職を追加した際に、
  シェリフ(村長シェリフ)・ミーティングシェリフ・リモートシェリフそれぞれに個別で記載する必要がなくなった。
  - ミーティングシェリフが眷族とマッドキラーを切れなかった問題を修正した。<br><br>
- シェリフ系役職でシェリフと比較し、足りていなかったキル可能陣営設定を追加した.<br><br>
  - 各シェリフで設定が異なり、キルの結果が変わってきてしまう問題を修正した。
    - 問題ピックアップ
      - 元々の仕様 
        - シェリフ
          - マッドを切れる設定を有効 且つ フレンズを切れる設定を無効にした場合、マッドは切れてフレンズは誤爆する。
        - リモートシェリフ
          - マッドを切れる設定を有効にした場合、マッドもフレンズも切れた。
      - 変更した仕様
        - シェリフ & リモートシェリフ
          - マッドを切れる設定を有効 且つ フレンズを切れる設定を無効にした場合、マッドは切れてフレンズは誤爆する。<br><br>
  - 「インポスターをキルできる」に関しては、村長シェリフ以外には追加せず、常にtrueになるようにした。
    - 村長シェリフに追加した理由
      - 内部的には同じ役職なら設定も同じように変更できた方が良いと思った為。
      - インポを切れない設定かつ、誤射時対象を殺す設定にする事で、
      実質シェリフ*2 且つ 第三陣営をタスクのないクルーにする事ができて強い村長の
      バランス調整に使えると思った為。<br><br>
- 誤射に巻き込まれたクルーの死因を[暴発巻き添え]に変更した。
  - ![image](https://user-images.githubusercontent.com/104145991/218370415-cc6842d7-d74e-4084-885f-1c3ec8657e43.png)
    - (マッド役職を切れない設定 且つ 誤射時対象を殺す設定)
