### PR TITLE
新役職 : 3匹の仔豚 (#1021の後にマージ)

### DIFF
--- a/SuperNewRoles/ModHelpers.cs
+++ b/SuperNewRoles/ModHelpers.cs
@@ -342,6 +342,39 @@ public static class ModHelpers
             GameOptionsManager.Instance.CurrentGameOptions.SetInt(Int32OptionNames.KillDistance, 0);
             Squid.InkSet();
         }
+        if (target.IsRole(RoleId.TheSecondLittlePig) && !killer.IsRole(RoleId.OverKiller) && TheThreeLittlePigs.TaskCheck(target) && (!TheThreeLittlePigs.TheSecondLittlePig.GuardCount.ContainsKey(target.PlayerId) || TheThreeLittlePigs.TheSecondLittlePig.GuardCount[target.PlayerId] > 0))
+        {
+            MessageWriter writer1 = RPCHelper.StartRPC(CustomRPC.ShielderProtect);
+            writer1.Write(target.PlayerId);
+            writer1.Write(target.PlayerId);
+            writer1.Write(0);
+            writer1.EndRPC();
+            RPCProcedure.ShielderProtect(target.PlayerId, target.PlayerId, 0);
+            MessageWriter writer2 = RPCHelper.StartRPC(CustomRPC.UseTheThreeLittlePigsCount);
+            writer2.Write(target.PlayerId);
+            writer2.EndRPC();
+            RPCProcedure.UseTheThreeLittlePigsCount(target.PlayerId);
+        }
+        if (target.IsRole(RoleId.TheThirdLittlePig) && !killer.IsRole(RoleId.OverKiller) && TheThreeLittlePigs.TaskCheck(target) && (!TheThreeLittlePigs.TheThirdLittlePig.CounterCount.ContainsKey(target.PlayerId) || TheThreeLittlePigs.TheThirdLittlePig.CounterCount[target.PlayerId] > 0))
+        {
+            MessageWriter writer1 = RPCHelper.StartRPC(CustomRPC.ShielderProtect);
+            writer1.Write(target.PlayerId);
+            writer1.Write(target.PlayerId);
+            writer1.Write(0);
+            writer1.EndRPC();
+            RPCProcedure.ShielderProtect(target.PlayerId, target.PlayerId, 0);
+            MessageWriter writer2 = RPCHelper.StartRPC(CustomRPC.UseTheThreeLittlePigsCount);
+            writer2.Write(target.PlayerId);
+            writer2.EndRPC();
+            RPCProcedure.UseTheThreeLittlePigsCount(target.PlayerId);
+            MessageWriter writer3 = RPCHelper.StartRPC(CustomRPC.RPCMurderPlayer);
+            writer3.Write(target.PlayerId);
+            writer3.Write(killer.PlayerId);
+            writer3.Write((byte)0);
+            writer3.EndRPC();
+            RPCProcedure.RPCMurderPlayer(target.PlayerId, killer.PlayerId, 0);
+            FinalStatusClass.RpcSetFinalStatus(killer, FinalStatus.TheThirdLittlePigCounterKill);
+        }
         return MurderAttemptResult.PerformKill;
     }
     public static void GenerateAndAssignTasks(this PlayerControl player, int numCommon, int numShort, int numLong)
@@ -836,6 +869,19 @@ public static class ModHelpers
     /// <param name="target">対象の文字列</param>
     /// <returns>文字列が半角の場合はtrue、それ以外はfalse</returns>
     public static bool IsOneByteOnlyString(string target) => new Regex("^[\u0020-\u007E\uFF66-\uFF9F]+$").IsMatch(target);
+    public static string[] CustomRates(int start = 0)
+    {
+        start = start >= 10 ? 10 : start;
+        start = start <= 0 ? 0 : start;
+        List<string> rates = new(CustomOptionHolder.rates);
+        for (int i = 0; i < start; i++)
+        {
+            string text = rates[0];
+            rates.Remove(text);
+            rates.Add(text);
+        }
+        return rates.ToArray();
+    }
 }
 public static class CreateFlag
 {

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1956,6 +1956,8 @@ public class CustomOptionHolder
 
         DyingMessenger.SetupCustomOptions();
 
+        TheThreeLittlePigs.SetupCustomOptions();
+
         // 表示設定
 
         QuarreledOption = Create(432, true, CustomOptionType.Neutral, Cs(RoleClass.Quarreled.color, "QuarreledName"), false, null, isHeader: true);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -183,6 +183,9 @@ public enum RoleId
     FireFox,
     Squid,
     DyingMessenger,
+    TheFirstLittlePig,
+    TheSecondLittlePig,
+    TheThirdLittlePig,
     //RoleId
 }
 
@@ -275,10 +278,43 @@ public enum CustomRPC
     SafecrackerGuardCount,
     SetVigilance,
     Chat,
+    SetTheThreeLittlePigsTeam,
+    UseTheThreeLittlePigsCount,
 }
 
 public static class RPCProcedure
 {
+    public static void UseTheThreeLittlePigsCount(byte id)
+    {
+        PlayerControl player = ModHelpers.PlayerById(id);
+        if (player == null) return;
+        if (player.IsRole(RoleId.TheSecondLittlePig))
+        {
+            if (!TheThreeLittlePigs.TheSecondLittlePig.GuardCount.ContainsKey(player.PlayerId))
+                TheThreeLittlePigs.TheSecondLittlePig.GuardCount[player.PlayerId] = TheThreeLittlePigs.TheSecondLittlePigMaxGuardCount.GetInt() - 1;
+            else TheThreeLittlePigs.TheSecondLittlePig.GuardCount[player.PlayerId]--;
+        }
+        else if (player.IsRole(RoleId.TheThirdLittlePig))
+        {
+            if (!TheThreeLittlePigs.TheThirdLittlePig.CounterCount.ContainsKey(player.PlayerId))
+                TheThreeLittlePigs.TheThirdLittlePig.CounterCount[player.PlayerId] = TheThreeLittlePigs.TheThirdLittlePigMaxCounterCount.GetInt() - 1;
+            else TheThreeLittlePigs.TheThirdLittlePig.CounterCount[player.PlayerId]--;
+        }
+    }
+    public static void SetTheThreeLittlePigsTeam(byte first, byte second, byte third)
+    {
+        PlayerControl firstPlayer = ModHelpers.PlayerById(first);
+        PlayerControl secondPlayer = ModHelpers.PlayerById(second);
+        PlayerControl thirdPlayer = ModHelpers.PlayerById(third);
+        if (firstPlayer == null || secondPlayer == null || thirdPlayer == null) return;
+        List<PlayerControl> theThreeLittlePigsPlayer = new()
+        {
+            firstPlayer,
+            secondPlayer,
+            thirdPlayer
+        };
+        TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(theThreeLittlePigsPlayer);
+    }
     public static void Chat(byte id, string text)
     {
         PlayerControl player = ModHelpers.PlayerById(id);
@@ -1695,6 +1731,12 @@ public static class RPCProcedure
                         break;
                     case CustomRPC.Chat:
                         Chat(reader.ReadByte(), reader.ReadString());
+                        break;
+                    case CustomRPC.SetTheThreeLittlePigsTeam:
+                        SetTheThreeLittlePigsTeam(reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
+                        break;
+                    case CustomRPC.UseTheThreeLittlePigsCount:
+                        UseTheThreeLittlePigsCount(reader.ReadByte());
                         break;
                 }
             }

--- a/SuperNewRoles/Modules/FinalStatus.cs
+++ b/SuperNewRoles/Modules/FinalStatus.cs
@@ -58,4 +58,5 @@ public enum FinalStatus
     HitmanKill,
     HitmanDead,
     WorshiperSelfDeath,
+    TheThirdLittlePigCounterKill,
 }

--- a/SuperNewRoles/Modules/IntroData.cs
+++ b/SuperNewRoles/Modules/IntroData.cs
@@ -266,8 +266,12 @@ public class IntroData
     public static IntroData NiceJumboIntro = new("NiceJumbo", CrewmateIntro.color, 1, RoleId.Jumbo, TeamRoleType.Crewmate);
     public static IntroData EvilJumboIntro = new("EvilJumbo", ImpostorIntro.color, 1, RoleId.Jumbo, TeamRoleType.Impostor, IntroSound: RoleTypes.Impostor);
     public static IntroData WorshiperIntro = new("Worshiper", Roles.Impostor.MadRole.Worshiper.color, 1, RoleId.Worshiper);
-    public static IntroData SafecrackerIntro = new("Safecracker", Safecracker.color, 1, RoleId.Safecracker, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter); static IntroData FireFoxIntro = new("FireFox", FireFox.color, 1, RoleId.FireFox, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
+    public static IntroData SafecrackerIntro = new("Safecracker", Safecracker.color, 1, RoleId.Safecracker, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
+    public static IntroData FireFoxIntro = new("FireFox", FireFox.color, 1, RoleId.FireFox, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
     public static IntroData SquidIntro = new("Squid", Squid.color, 2, RoleId.Squid, TeamRoleType.Crewmate);
     public static IntroData DyingMessengerIntro = new("DyingMessenger", DyingMessenger.color, 1, RoleId.DyingMessenger, TeamRoleType.Crewmate);
+    public static IntroData TheFirstLittlePigIntro = new("TheFirstLittlePig", TheThreeLittlePigs.color, 1, RoleId.TheFirstLittlePig, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
+    public static IntroData TheSecondLittlePigIntro = new("TheSecondLittlePig", TheThreeLittlePigs.color, 1, RoleId.TheSecondLittlePig, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
+    public static IntroData TheThirdLittlePig = new("TheThirdLittlePig", TheThreeLittlePigs.color, 1, RoleId.TheThirdLittlePig, TeamRoleType.Neutral, IntroSound: RoleTypes.Shapeshifter);
     // イントロオブジェ
 }

--- a/SuperNewRoles/Modules/SetNames.cs
+++ b/SuperNewRoles/Modules/SetNames.cs
@@ -454,6 +454,19 @@ public class SetNameUpdate
                     }
                 }
             }
+            else if (LocalRole is RoleId.TheFirstLittlePig or RoleId.TheSecondLittlePig or RoleId.TheThirdLittlePig)
+            {
+                foreach (var players in TheThreeLittlePigs.TheThreeLittlePigsPlayer)
+                {
+                    if (players.TrueForAll(x => x.PlayerId != PlayerControl.LocalPlayer.PlayerId)) continue;
+                    foreach (PlayerControl p in players)
+                    {
+                        SetNamesClass.SetPlayerRoleNames(p);
+                        SetNamesClass.SetPlayerNameColors(p);
+                    }
+                    break;
+                }
+            }
             SetNamesClass.SetPlayerRoleNames(PlayerControl.LocalPlayer);
             SetNamesClass.SetPlayerNameColors(PlayerControl.LocalPlayer);
         }

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -241,7 +241,7 @@ public class EndGameManagerSetUpPatch
                 {WinCondition.LoversBreakerWin,("LoversBreakerName",RoleClass.LoversBreaker.color)},
                 {WinCondition.NoWinner,("NoWinner",Color.white)},
                 {WinCondition.SafecrackerWin,("SafecrackerName",Safecracker.color)},
-                {WinCondition.TheThreeLittlePigsWin,("TheThreeLittlePigsWinName",TheThreeLittlePigs.color)},
+                {WinCondition.TheThreeLittlePigsWin,("TheThreeLittlePigsName",TheThreeLittlePigs.color)},
             };
         if (WinConditionDictionary.ContainsKey(AdditionalTempData.winCondition))
         {

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -46,7 +46,8 @@ public enum CustomGameOverReason
     LoversBreakerWin,
     NoWinner,
     BugEnd,
-    SafecrackerWin
+    SafecrackerWin,
+    TheThreeLittlePigsWin,
 }
 enum WinCondition
 {
@@ -78,7 +79,8 @@ enum WinCondition
     LoversBreakerWin,
     NoWinner,
     BugEnd,
-    SafecrackerWin
+    SafecrackerWin,
+    TheThreeLittlePigsWin,
 }
 class FinalStatusPatch
 {
@@ -238,7 +240,8 @@ public class EndGameManagerSetUpPatch
                 {WinCondition.PavlovsTeamWin,("PavlovsTeamWinText",RoleClass.Pavlovsdogs.color)},
                 {WinCondition.LoversBreakerWin,("LoversBreakerName",RoleClass.LoversBreaker.color)},
                 {WinCondition.NoWinner,("NoWinner",Color.white)},
-                {WinCondition.SafecrackerWin,("SafecrackerName",Safecracker.color)}
+                {WinCondition.SafecrackerWin,("SafecrackerName",Safecracker.color)},
+                {WinCondition.TheThreeLittlePigsWin,("TheThreeLittlePigsWinName",TheThreeLittlePigs.color)},
             };
         if (WinConditionDictionary.ContainsKey(AdditionalTempData.winCondition))
         {
@@ -583,6 +586,9 @@ public static class OnGameEndPatch
             RoleClass.LoversBreaker.LoversBreakerPlayer,
             Roles.Impostor.MadRole.Worshiper.WorshiperPlayer,
             Safecracker.SafecrackerPlayer,
+            TheThreeLittlePigs.TheFirstLittlePig.Player,
+            TheThreeLittlePigs.TheSecondLittlePig.Player,
+            TheThreeLittlePigs.TheThirdLittlePig.Player,
             });
         notWinners.AddRange(RoleClass.Cupid.CupidPlayer);
         notWinners.AddRange(RoleClass.Dependents.DependentsPlayer);
@@ -956,6 +962,60 @@ public static class OnGameEndPatch
                     AdditionalTempData.winCondition = WinCondition.SpelunkerWin;
                 }
                 isreset = true;
+            }
+        }
+        isReset = false;
+        foreach (List<PlayerControl> plist in TheThreeLittlePigs.TheThreeLittlePigsPlayer)
+        {
+            bool isAllAlive = true;
+            foreach (PlayerControl player in plist)
+            {
+                if (player.IsDead())
+                {
+                    isAllAlive = false;
+                    break;
+                }
+            }
+            if (isAllAlive)
+            {
+                if (!((isDleted && changeTheWinCondition) || isReset))
+                {
+                    TempData.winners = new();
+                    isDleted = true;
+                    isReset = true;
+                }
+                foreach (PlayerControl player in plist)
+                {
+                    TempData.winners.Add(new(player.Data));
+                    AdditionalTempData.winCondition = WinCondition.TheThreeLittlePigsWin;
+                }
+            }
+            else
+            {
+                bool isAllKillerDead = true;
+                foreach (PlayerControl player in PlayerControl.AllPlayerControls)
+                {
+                    if (player.IsDead()) continue;
+                    if (player.IsImpostor() || player.IsKiller())
+                    {
+                        isAllKillerDead = false;
+                        break;
+                    }
+                }
+                if (isAllKillerDead)
+                {
+                    if (!((isDleted && changeTheWinCondition) || isReset))
+                    {
+                        TempData.winners = new();
+                        isDleted = true;
+                        isReset = true;
+                    }
+                    foreach (PlayerControl player in plist)
+                    {
+                        TempData.winners.Add(new(player.Data));
+                        AdditionalTempData.winCondition = WinCondition.TheThreeLittlePigsWin;
+                    }
+                }
             }
         }
         isReset = false;

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -7,6 +7,7 @@ using SuperNewRoles.Mode;
 using SuperNewRoles.Mode.SuperHostRoles;
 using SuperNewRoles.Roles;
 using SuperNewRoles.Roles.Crewmate;
+using SuperNewRoles.Roles.Neutral;
 using SuperNewRoles.Sabotage;
 using UnityEngine;
 
@@ -197,6 +198,9 @@ public class FixedUpdate
                             break;
                         case RoleId.Dependents:
                             Vampire.FixedUpdate.DependentsOnly();
+                            break;
+                        case RoleId.TheFirstLittlePig:
+                            TheThreeLittlePigs.TheFirstLittlePig.FixedUpdate();
                             break;
                     }
                 }

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -199,9 +199,6 @@ public class FixedUpdate
                         case RoleId.Dependents:
                             Vampire.FixedUpdate.DependentsOnly();
                             break;
-                        case RoleId.TheFirstLittlePig:
-                            TheThreeLittlePigs.TheFirstLittlePig.FixedUpdate();
-                            break;
                     }
                 }
                 else // -- 死亡時 --

--- a/SuperNewRoles/Patches/IntroPatch.cs
+++ b/SuperNewRoles/Patches/IntroPatch.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Linq;
 using AmongUs.GameOptions;
 using BepInEx.IL2CPP.Utils.Collections;
 using HarmonyLib;
@@ -243,6 +244,23 @@ public class IntroPatch
                             }
                         }
                         yourTeam = FireFoxTeams;
+                        break;
+                    case RoleId.TheFirstLittlePig:
+                    case RoleId.TheSecondLittlePig:
+                    case RoleId.TheThirdLittlePig:
+                        Il2CppSystem.Collections.Generic.List<PlayerControl> TheThreeLittlePigsTeams = new();
+                        int TheThreeLittlePigsNum = 0;
+                        foreach (var players in TheThreeLittlePigs.TheThreeLittlePigsPlayer)
+                        {
+                            if (players.TrueForAll(x => x.PlayerId != PlayerControl.LocalPlayer.PlayerId)) continue;
+                            foreach (PlayerControl player in players)
+                            {
+                                TheThreeLittlePigsNum++;
+                                TheThreeLittlePigsTeams.Add(player);
+                            }
+                            break;
+                        }
+                        yourTeam = TheThreeLittlePigsTeams;
                         break;
                     default:
                         if (PlayerControl.LocalPlayer.IsImpostor())

--- a/SuperNewRoles/Patches/MeetingHudPatch.cs
+++ b/SuperNewRoles/Patches/MeetingHudPatch.cs
@@ -500,6 +500,7 @@ class MeetingHudStartPatch
             }, 3f, "StartMeeting CustomSyncSetting");
         }
         Roles.Crewmate.Celebrity.TimerStop();
+        TheThreeLittlePigs.TheFirstLittlePig.TimerStop();
         if (ModeHandler.IsMode(ModeId.Default))
         {
             new LateTask(() =>

--- a/SuperNewRoles/Patches/SelectTaskPatch.cs
+++ b/SuperNewRoles/Patches/SelectTaskPatch.cs
@@ -59,6 +59,12 @@ public static class SelectTask
         taskData.Add(RoleId.Tasker, (TaskerCommonTask.GetInt(), TaskerShortTask.GetInt(), TaskerLongTask.GetInt()));
         taskData.Add(RoleId.HamburgerShop, (HamburgerShopCommonTask.GetInt(), HamburgerShopShortTask.GetInt(), HamburgerShopLongTask.GetInt()));
         taskData.Add(RoleId.Safecracker, (Safecracker.SafecrackerCommonTask.GetInt(), Safecracker.SafecrackerShortTask.GetInt(), Safecracker.SafecrackerLongTask.GetInt()));
+        if (TheThreeLittlePigs.TheThreeLittlePigsTask.GetBool())
+        {
+            taskData.Add(RoleId.TheFirstLittlePig, (TheThreeLittlePigs.TheThreeLittlePigsCommonTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsShortTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsLongTask.GetInt()));
+            taskData.Add(RoleId.TheSecondLittlePig, (TheThreeLittlePigs.TheThreeLittlePigsCommonTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsShortTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsLongTask.GetInt()));
+            taskData.Add(RoleId.TheThirdLittlePig, (TheThreeLittlePigs.TheThreeLittlePigsCommonTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsShortTask.GetInt(), TheThreeLittlePigs.TheThreeLittlePigsLongTask.GetInt()));
+        }
 
         //テンプレート
         //taskData.Add(RoleId, (CommonTask.GetInt(), ShortTask.GetInt(), LongTask.GetInt()));

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -114,6 +114,7 @@ class WrapUpPatch
         Seer.WrapUpPatch.WrapUpPostfix();
         Vampire.SetActiveBloodStaiWrapUpPatch();
         Roles.Crewmate.Celebrity.WrapUp();
+        Roles.Neutral.TheThreeLittlePigs.TheFirstLittlePig.WrapUp();
         foreach (PlayerControl p in PlayerControl.AllPlayerControls)
         {
             p.resetChange();

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1256,9 +1256,9 @@ TheFirstLittlePigClearTaskSetting,Percentage of tasks required for The first lit
 TheFirstLittlePigIsCustomTimerSetting,Set the timer for The first little pig,1番目の仔豚のタイマーを設定する
 TheFirstLittlePigCustomTimerSetting,The first little pig timer,1番目の仔豚のタイマー
 TheSecondLittlePigClearTaskSetting,Percentage of tasks required for The second little pig to complete the house,2番目の仔豚が家を完成させるのに必要なタスクの割合
-TheSecondLittlePigManGuardMaxCountSetting,Number of times The second little pig can be guarded.,2番目の仔豚がガードできる回数
+TheSecondLittlePigManGuardMaxCountSetting,Number of times The second little pig can be guarded,2番目の仔豚がガードできる回数
 TheThirdLittlePigClearTaskSetting,Percentage of tasks required for The third little pig to complete the house,3番目の仔豚が家を完成させるのに必要なタスクの割合
-TheThirdLittlePigCounterKillSetting,Number of times The third little pig can be countered.,3番目の仔豚がカウンターできる回数
+TheThirdLittlePigCounterKillSetting,Number of times The third little pig can be countered,3番目の仔豚がカウンターできる回数
 
 #ConfigRoles
 IsNotUsingBlood,Make the blood expression black.,血液表現を黒にする,和谐血液显示

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -326,6 +326,7 @@ FinalStatusRevenge,Revenge,復讐,仇杀
 FinalStatusHitmanKill,Mission accomplished.,任務遂行,遇刺
 FinalStatusHitmanDead,Disposition.,処分,沉江
 FinalStatusWorshiperSelfDeath,Suicide,自決
+FinalStatusTheThirdLittlePigCounterKill,Counter Kill,カウンターキル
 
 # Sabotages
 SabotageSetting,Sabotage Setting,サボタージュの設定,破坏设置
@@ -1243,6 +1244,21 @@ DyingMessengerFirstPerson1,me,私,我
 DyingMessengerFirstPerson2,me,僕,我
 DyingMessengerGetRoleText,The role of the person who killed {0} was {1}.,{0}をキルした人の役職は{1}でした。,把{0}杀害的人是一名{1}。
 DyingMessengerGetLightAndDarkerText,The person who killed {0} had {1} color.,{0}をキルした人の色は{1}色でした。,把{0}杀害的人是{1}色的。
+TheThreeLittlePigsName,The Three Little Pigs,3匹の仔豚
+TheFirstLittlePigName,The First Little Pig,1番目の仔豚
+TheSecondLittlePigName,The Second Little Pig,2番目の仔豚
+TheThirdLittlePigName,The Third Little Pig,3番目の仔豚
+TheFirstLittlePigTitle1,House， keep us safe!,家を作って狼から身を守ろう
+TheSecondLittlePigTitle1,House， keep us safe!,家を作って狼から身を守ろう
+TheThirdLittlePigTitle1,House， keep us safe!,家を作って狼から身を守ろう
+TheThreeLittlePigsTaskSetting,Assign tasks separately,別にタスクを割り当てる
+TheFirstLittlePigClearTaskSetting,Percentage of tasks required for The first little pig to complete the house,1番目の仔豚が家を完成させるのに必要なタスクの割合
+TheFirstLittlePigIsCustomTimerSetting,Set the timer for The first little pig,1番目の仔豚のタイマーを設定する
+TheFirstLittlePigCustomTimerSetting,The first little pig timer,1番目の仔豚のタイマー
+TheSecondLittlePigClearTaskSetting,Percentage of tasks required for The second little pig to complete the house,2番目の仔豚が家を完成させるのに必要なタスクの割合
+TheSecondLittlePigManGuardMaxCountSetting,Number of times The second little pig can be guarded.,2番目の仔豚がガードできる回数
+TheThirdLittlePigClearTaskSetting,Percentage of tasks required for The third little pig to complete the house,3番目の仔豚が家を完成させるのに必要なタスクの割合
+TheThirdLittlePigCounterKillSetting,Number of times The third little pig can be countered.,3番目の仔豚がカウンターできる回数
 
 #ConfigRoles
 IsNotUsingBlood,Make the blood expression black.,血液表現を黒にする,和谐血液显示

--- a/SuperNewRoles/Roles/AllRoleSetClass.cs
+++ b/SuperNewRoles/Roles/AllRoleSetClass.cs
@@ -651,12 +651,12 @@ class AllRoleSetClass
                             TheThreeLittlePigsPlayer.Add(p);
                             CrewmatePlayers.Remove(p);
                             NeutralPlayerNum = NeutralPlayerNum - 3;
-                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
                             MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
                             writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
                             writer.EndRPC();
+                            RPCProcedure.SetTheThreeLittlePigsTeam(TheThreeLittlePigsPlayer[0].PlayerId, TheThreeLittlePigsPlayer[1].PlayerId, TheThreeLittlePigsPlayer[2].PlayerId);
                         }
                         if (0 >= NeutralPlayerNum || 0 >= CrewmatePlayers.Count)
                             IsNotEndRandomSelect = false;
@@ -683,12 +683,12 @@ class AllRoleSetClass
                             TheThreeLittlePigsPlayer.Add(p);
                             CrewmatePlayers.Remove(p);
                             NeutralPlayerNum = NeutralPlayerNum - 3;
-                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
                             MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
                             writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
                             writer.EndRPC();
+                            RPCProcedure.SetTheThreeLittlePigsTeam(TheThreeLittlePigsPlayer[0].PlayerId, TheThreeLittlePigsPlayer[1].PlayerId, TheThreeLittlePigsPlayer[2].PlayerId);
                         }
                         if (0 >= NeutralPlayerNum || 0 >= CrewmatePlayers.Count)
                             IsNotEndRandomSelect = false;
@@ -714,12 +714,12 @@ class AllRoleSetClass
                             TheThreeLittlePigsPlayer.Add(p);
                             CrewmatePlayers.Remove(p);
                             NeutralPlayerNum = NeutralPlayerNum - 3;
-                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
                             MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
                             writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
                             writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
                             writer.EndRPC();
+                            RPCProcedure.SetTheThreeLittlePigsTeam(TheThreeLittlePigsPlayer[0].PlayerId, TheThreeLittlePigsPlayer[1].PlayerId, TheThreeLittlePigsPlayer[2].PlayerId);
                         }
                     }
                 }

--- a/SuperNewRoles/Roles/AllRoleSetClass.cs
+++ b/SuperNewRoles/Roles/AllRoleSetClass.cs
@@ -595,33 +595,132 @@ class AllRoleSetClass
                 }
 
                 int PlayerCount = (int)GetPlayerCount(selectRoleData);
-                if (PlayerCount >= NeutralPlayerNum)
+                if (selectRoleData is not RoleId.TheFirstLittlePig)
                 {
-                    for (int i = 1; i <= NeutralPlayerNum; i++)
+                    if (PlayerCount >= NeutralPlayerNum)
                     {
-                        PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
-                        p.SetRoleRPC(selectRoleData);
-                        CrewmatePlayers.Remove(p);
+                        for (int i = 1; i <= NeutralPlayerNum; i++)
+                        {
+                            PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(selectRoleData);
+                            CrewmatePlayers.Remove(p);
+                        }
+                        IsNotEndRandomSelect = false;
                     }
-                    IsNotEndRandomSelect = false;
-                }
-                else if (PlayerCount >= CrewmatePlayers.Count)
-                {
-                    foreach (PlayerControl Player in CrewmatePlayers)
+                    else if (PlayerCount >= CrewmatePlayers.Count)
                     {
-                        NeutralPlayerNum--;
-                        Player.SetRoleRPC(selectRoleData);
+                        foreach (PlayerControl Player in CrewmatePlayers)
+                        {
+                            NeutralPlayerNum--;
+                            Player.SetRoleRPC(selectRoleData);
+                        }
+                        IsNotEndRandomSelect = false;
                     }
-                    IsNotEndRandomSelect = false;
-                }
-                else
-                {
-                    for (int i = 1; i <= PlayerCount; i++)
+                    else
                     {
-                        NeutralPlayerNum--;
-                        PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
-                        p.SetRoleRPC(selectRoleData);
-                        CrewmatePlayers.Remove(p);
+                        for (int i = 1; i <= PlayerCount; i++)
+                        {
+                            NeutralPlayerNum--;
+                            PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(selectRoleData);
+                            CrewmatePlayers.Remove(p);
+                        }
+                    }
+                }
+                else if (selectRoleData is RoleId.TheFirstLittlePig)
+                {
+                    if (PlayerCount * 3 >= NeutralPlayerNum)
+                    {
+                        int TheThreeLittlePigsTeam = (int)Math.Truncate(NeutralPlayerNum / 3f);
+                        for (int i = 1; i <= NeutralPlayerNum; i++)
+                        {
+                            List<PlayerControl> TheThreeLittlePigsPlayer = new();
+                            // 1番目の仔豚決定
+                            PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheFirstLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 2番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheSecondLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 3番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheThirdLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            NeutralPlayerNum = NeutralPlayerNum - 3;
+                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
+                            MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
+                            writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
+                            writer.EndRPC();
+                        }
+                        if (0 >= NeutralPlayerNum || 0 >= CrewmatePlayers.Count)
+                            IsNotEndRandomSelect = false;
+                    }
+                    else if (PlayerCount * 3 >= CrewmatePlayers.Count)
+                    {
+                        int TheThreeLittlePigsTeam = (int)Math.Truncate(CrewmatePlayers.Count / 3f);
+                        for (int i = 1; i <= CrewmatePlayers.Count; i++)
+                        {
+                            List<PlayerControl> TheThreeLittlePigsPlayer = new();
+                            // 1番目の仔豚決定
+                            PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheFirstLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 2番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheSecondLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 3番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheThirdLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            NeutralPlayerNum = NeutralPlayerNum - 3;
+                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
+                            MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
+                            writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
+                            writer.EndRPC();
+                        }
+                        if (0 >= NeutralPlayerNum || 0 >= CrewmatePlayers.Count)
+                            IsNotEndRandomSelect = false;
+                    }
+                    else
+                    {
+                        for (int i = 1; i <= PlayerCount; i++)
+                        {
+                            List<PlayerControl> TheThreeLittlePigsPlayer = new();
+                            // 1番目の仔豚決定
+                            PlayerControl p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheFirstLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 2番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheSecondLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            // 3番目の仔豚決定
+                            p = ModHelpers.GetRandom(CrewmatePlayers);
+                            p.SetRoleRPC(RoleId.TheThirdLittlePig);
+                            TheThreeLittlePigsPlayer.Add(p);
+                            CrewmatePlayers.Remove(p);
+                            NeutralPlayerNum = NeutralPlayerNum - 3;
+                            TheThreeLittlePigs.TheThreeLittlePigsPlayer.Add(TheThreeLittlePigsPlayer);
+                            MessageWriter writer = RPCHelper.StartRPC(CustomRPC.SetTheThreeLittlePigsTeam);
+                            writer.Write(TheThreeLittlePigsPlayer[0].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[1].PlayerId);
+                            writer.Write(TheThreeLittlePigsPlayer[2].PlayerId);
+                            writer.EndRPC();
+                        }
                     }
                 }
                 Neutonepar.RemoveAt(selectRoleDataIndex);
@@ -969,6 +1068,9 @@ class AllRoleSetClass
             RoleId.FireFox => FireFox.FireFoxPlayerCount.GetFloat(),
             RoleId.Squid => Squid.SquidPlayerCount.GetFloat(),
             RoleId.DyingMessenger => DyingMessenger.DyingMessengerPlayerCount.GetFloat(),
+            RoleId.TheFirstLittlePig => TheThreeLittlePigs.TheThreeLittlePigsTeamCount.GetFloat(),
+            RoleId.TheSecondLittlePig => TheThreeLittlePigs.TheThreeLittlePigsTeamCount.GetFloat(),
+            RoleId.TheThirdLittlePig => TheThreeLittlePigs.TheThreeLittlePigsTeamCount.GetFloat(),
             // プレイヤーカウント
             _ => 1,
         };

--- a/SuperNewRoles/Roles/CrewMate/Celebrity.cs
+++ b/SuperNewRoles/Roles/CrewMate/Celebrity.cs
@@ -101,5 +101,6 @@ public class CelebrityTimerStop
     public static void Postfix()
     {
         Celebrity.TimerStop();
+        Neutral.TheThreeLittlePigs.TheFirstLittlePig.TimerStop();
     }
 }

--- a/SuperNewRoles/Roles/Neutral/TheThreeLittlePigs.cs
+++ b/SuperNewRoles/Roles/Neutral/TheThreeLittlePigs.cs
@@ -113,10 +113,10 @@ public class TheThreeLittlePigs
                                  (CustomOptionHolder.IsAlwaysReduceCooldownExceptOnTask.GetBool() && ElectricPatch.onTask);
                 if (PlayerControl.LocalPlayer.CanMove || (!PlayerControl.LocalPlayer.CanMove && exception))
                     Timer -= Time.fixedDeltaTime;
-                if (Timer <= 0 && IsFlash && TaskCheck(PlayerControl.LocalPlayer))
+                if (Timer <= 0 && IsFlash)
                 {
                     IsFlash = false;
-                    Seer.ShowFlash(new Color32(245, 95, 71, byte.MaxValue), 2.5f);
+                    if (TaskCheck(PlayerControl.LocalPlayer)) Seer.ShowFlash(new Color32(245, 95, 71, byte.MaxValue), 2.5f);
                 }
             }
             else

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -211,6 +211,7 @@ public static class RoleClass
         FireFox.ClearAndReload();
         Squid.ClearAndReload();
         DyingMessenger.ClearAndReload();
+        TheThreeLittlePigs.ClearAndReload();
         // ロールクリア
         Quarreled.ClearAndReload();
         Lovers.ClearAndReload();

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -118,6 +118,23 @@ public static class RoleHelpers
         }
         return false;
     }
+
+    public static bool IsKiller(this PlayerControl player) =>
+        (player.GetRole() == RoleId.Pavlovsowner &&
+            (!RoleClass.Pavlovsowner.CountData.ContainsKey(player.PlayerId) ||
+            RoleClass.Pavlovsowner.CountData[player.PlayerId] > 0)) ||
+        player.GetRole() is
+        RoleId.Pavlovsdogs or
+        RoleId.Jackal or
+        RoleId.Sidekick or
+        RoleId.TeleportingJackal or
+        RoleId.JackalSeer or
+        RoleId.SidekickSeer or
+        RoleId.WaveCannonJackal or
+        RoleId.Hitman or
+        RoleId.Egoist;
+    // 第三キル人外か
+
     public static bool IsFakeLoversFake(this PlayerControl player)
     {
         if (player == null) return false;
@@ -776,6 +793,15 @@ public static class RoleHelpers
             case RoleId.DyingMessenger:
                 DyingMessenger.DyingMessengerPlayer.Add(player);
                 break;
+            case RoleId.TheFirstLittlePig:
+                TheThreeLittlePigs.TheFirstLittlePig.Player.Add(player);
+                break;
+            case RoleId.TheSecondLittlePig:
+                TheThreeLittlePigs.TheSecondLittlePig.Player.Add(player);
+                break;
+            case RoleId.TheThirdLittlePig:
+                TheThreeLittlePigs.TheThirdLittlePig.Player.Add(player);
+                break;
             // ロールアド
             default:
                 SuperNewRolesPlugin.Logger.LogError($"[SetRole]:No Method Found for Role Type {role}");
@@ -1264,7 +1290,16 @@ public static class RoleHelpers
             case RoleId.DyingMessenger:
                 DyingMessenger.DyingMessengerPlayer.RemoveAll(ClearRemove);
                 break;
-                //ロールリモベ
+            case RoleId.TheFirstLittlePig:
+                TheThreeLittlePigs.TheFirstLittlePig.Player.RemoveAll(ClearRemove);
+                break;
+            case RoleId.TheSecondLittlePig:
+                TheThreeLittlePigs.TheSecondLittlePig.Player.RemoveAll(ClearRemove);
+                break;
+            case RoleId.TheThirdLittlePig:
+                TheThreeLittlePigs.TheThirdLittlePig.Player.RemoveAll(ClearRemove);
+                break;
+            //ロールリモベ
         }
         ChacheManager.ResetMyRoleChache();
     }
@@ -1335,6 +1370,9 @@ public static class RoleHelpers
             case RoleId.LoversBreaker:
             case RoleId.Safecracker:
             case RoleId.FireFox:
+            case RoleId.TheFirstLittlePig:
+            case RoleId.TheSecondLittlePig:
+            case RoleId.TheThirdLittlePig:
                 // タスククリアか
                 IsTaskClear = true;
                 break;
@@ -1524,7 +1562,10 @@ public static class RoleHelpers
         RoleId.Pavlovsowner or
         RoleId.LoversBreaker or
         RoleId.Safecracker or
-        RoleId.FireFox;
+        RoleId.FireFox or
+        RoleId.TheFirstLittlePig or
+        RoleId.TheSecondLittlePig or
+        RoleId.TheThirdLittlePig;
     // 第三か
     public static bool IsRole(this PlayerControl p, RoleId role, bool IsChache = true)
     {
@@ -1780,6 +1821,9 @@ public static class RoleHelpers
             else if (FireFox.FireFoxPlayer.IsCheckListPlayerControl(player)) return RoleId.FireFox;
             else if (Squid.SquidPlayer.IsCheckListPlayerControl(player)) return RoleId.Squid;
             else if (DyingMessenger.DyingMessengerPlayer.IsCheckListPlayerControl(player)) return RoleId.DyingMessenger;
+            else if (TheThreeLittlePigs.TheFirstLittlePig.Player.IsCheckListPlayerControl(player)) return RoleId.TheFirstLittlePig;
+            else if (TheThreeLittlePigs.TheSecondLittlePig.Player.IsCheckListPlayerControl(player)) return RoleId.TheSecondLittlePig;
+            else if (TheThreeLittlePigs.TheThirdLittlePig.Player.IsCheckListPlayerControl(player)) return RoleId.TheThirdLittlePig;
             // ロールチェック
         }
         catch (Exception e)


### PR DESCRIPTION
作るの大変だった & 昔の僕はなぜ2個目で3匹の仔豚を作ろうとしたのだろうか()

# 概要
3人1グループの役職
## 役職
- 3匹の仔豚 (総称)
- 1番目の仔豚
- 2番目の仔豚
- 3番目の仔豚
### 陣営
- 第三陣営
### 能力
- 3匹の仔豚 : 3匹の仔豚全体の能力
  1. グループ内の仲間を視認できる
  2. 特定の条件で塗り替え勝利
- 1番目の仔豚
  1. タスクをn%終わらせることで能力を取得できます (デフォルト30%(設定で変更可))
     1. 開始または会議終了後からn秒経つことで、画面が赤く光ります
     2. 秒数は、キルクールまたは設定した秒数にすることができます
- 2番目の仔豚
  1. タスクをn%終わらせることで能力を取得できます (デフォルト60%(設定で変更可))
     1. キルガードをn回できます (設定で変更可)
- 3番目の仔豚
  1. タスクをn%終わらせることで能力を取得できます (デフォルト100%(設定で変更可))
     1. カウンターキルをn回できます (設定で変更可)
     2. カウンターキルはキルされた際、そのキルを無効化し、キル者が死亡します
     3. 現在の場合、シェリフ自爆みたいになります()
### 勝利条件
- 上書き勝利 (状況によって上書き勝利の条件が変わります)
  1.  チーム全員生存の場合
      1. 妖狐、炎狐以外の勝利や上書き勝利を上書きして勝利します
  2. チームが1人以上死亡している場合
     1. キル可能役職が全員死亡している場合のみ、妖狐、炎狐以外の勝利や上書き勝利を上書きして勝利します