### PR TITLE
キルボタンの名前にFinalStatusKillを使っている物を純正の翻訳に変更&サイドキック能力を適切な翻訳に変更

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -179,7 +179,7 @@ static class HudManagerStartPatch
             () => false
         )
         {
-            buttonText = ModTranslation.GetString("FinalStatusKill"),
+            buttonText = FastDestroyableSingleton<HudManager>.Instance.KillButton.buttonLabelText.text,
             showButtonText = true
         };
 
@@ -2360,7 +2360,7 @@ static class HudManagerStartPatch
             }
         )
         {
-            buttonText = ModTranslation.GetString("FinalStatusKill"),
+            buttonText = FastDestroyableSingleton<HudManager>.Instance.KillButton.buttonLabelText.text,
             showButtonText = true
         };
 
@@ -3087,7 +3087,7 @@ static class HudManagerStartPatch
             }
         )
         {
-            buttonText = ModTranslation.GetString("FinalStatusKill"),
+            buttonText = FastDestroyableSingleton<HudManager>.Instance.KillButton.buttonLabelText.text,
             showButtonText = true
         };
 

--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -1623,7 +1623,7 @@ static class HudManagerStartPatch
             () => { return false; }
         )
         {
-            buttonText = ModTranslation.GetString("SidekickName"),
+            buttonText = ModTranslation.GetString("CreateMadmateButton"),
             showButtonText = true
         };
 
@@ -1661,7 +1661,7 @@ static class HudManagerStartPatch
             () => { return false; }
         )
         {
-            buttonText = ModTranslation.GetString("SidekickName"),
+            buttonText = ModTranslation.GetString("SideKillerSidekickButtonName"),
             showButtonText = true
         };
 
@@ -1710,7 +1710,7 @@ static class HudManagerStartPatch
             () => { return false; }
         )
         {
-            buttonText = ModTranslation.GetString("SidekickName"),
+            buttonText = ModTranslation.GetString("MadMakerSidekickButtonName"),
             showButtonText = true
         };
 
@@ -1910,7 +1910,7 @@ static class HudManagerStartPatch
             () => { return false; }
         )
         {
-            buttonText = ModTranslation.GetString("SidekickName"),
+            buttonText = ModTranslation.GetString("ChiefSidekickButtonName"),
             showButtonText = true
         };
 

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -734,6 +734,7 @@ AmnesiacName,Amnesiac,忘却者,失忆者
 AmnesiacTitle1,Let's call the cops and join them.,通報して仲間になろう,努力回想你的职业
 SideKillerName,SideKiller,サイドキラー,头目
 SideKillerTitle1,Make friends and win!,仲間を作って勝利しよう,招募喽啰来获得胜利
+SideKillerSidekickButtonName,Erosion,浸食する
 SideKillerKillCoolTimeSetting,SideKiller Kill Cool Time.,サイドキラーのキルクールタイム,头目击杀冷却
 SideKillerMadKillerKillCoolTimeSetting,MadKiller Kill Cool Time.,マッドキラーのキルクールタイム,喽啰击杀冷却
 MadKillerName,MadKiller,マッドキラー,喽啰
@@ -827,6 +828,7 @@ TeleportingJackalName,TeleportingJackal,テレポートジャッカル,狼族传
 TeleportingJackalTitle1,Teleport and kill all crewmates and impostors!,テレポートして全員ぶち殺そう,传送并杀死所有人
 MadMakerName,MadMaker,マッドメーカー,走狗
 MadMakerTitle1,Let's get more lunatics!,狂人を増やそう！,让更多的人叛变
+MadMakerSidekickButtonName,Solicitation,勧誘する
 DemonName,Demon,悪魔,恶魔
 DemonTitle1,Curse the Crew and Help the Impostor!,クルーを呪いながらインポスターを手助けせよ,诅咒船员并协助内鬼
 DemonIsAliveWinSetting,You have to be alive to win.,生存していないと勝利できない,恶魔存活才能获胜
@@ -860,6 +862,7 @@ ArsonistIgniteButtonName,Ignite,燃やす,点燃
 ArsonistDescription,If you oil them all and burn them. you win alone.,油を全員に塗り燃やしたら単独勝利です。,纵火犯属于独立阵营。\n纵火犯给所有人涂油后按下点燃按钮则纵火犯独自获胜。
 ChiefName,Chief,村長,警察局长
 ChiefTitle1,Appoint a sheriff to help your crew.,シェリフを任命してクルーを助けよう,任命一位警长来帮助船员
+ChiefSidekickButtonName,Appointment,任命する
 CleanerName,Cleaner,クリーナー,清理者
 CleanerTitle1,Let's destroy the evidence!,証拠を隠滅しよう!,毁尸灭迹
 CleanerButtonName,CleanButton,死体を消す!,清理


### PR DESCRIPTION
- キルボタンの名前にFinalStatusKillを使っている物を、純正キルボタンの翻訳を使用するように変更

- サイドキック能力の名前をそれぞれ適切なものに変更
  - サイドキラー => 浸食する
  - レベリンガー => 狂わせる
  - マッドメイカー => 勧誘する
  - 村長 => 任命する