### PR TITLE
うまく動かない　陣営Playerをコメントアウトし、勝利除外を個別記載した

### DIFF
--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -545,6 +545,9 @@ public static class OnGameEndPatch
         List<PlayerControl> notWinners = new();
         List<PlayerControl> peculiarNotWinners = new();
 
+        /*
+        TODO: 蔵徒:陣営Playerがうまく動かない為コメントアウトし、個別表記式に変更。いつか直す。
+
         // Neutral,MadRoles,FriendRolesから溢れたクルー勝利から除外する必要のある役職を個別追記する
         peculiarNotWinners.AddRanges(new[]
             {
@@ -552,8 +555,8 @@ public static class OnGameEndPatch
                 RoleClass.SideKiller.MadKillerPlayer, // マッドロールから外され[CrewmatePlayer]に含まれている為
                 RoleClass.Dependents.DependentsPlayer, // マッドロールから外され[CrewmatePlayer]に含まれている為
                 OrientalShaman.ShermansServantPlayer, // 第三陣営ではなく[CrewmatePlayer]に含まれている為
-                /*  RoleClass.Cupid.CupidPlayer,
-                    キューピットはNeutralPlayerだが元々記載の方法が特殊だった為コメントアウトで記載を残した。*/
+                //  RoleClass.Cupid.CupidPlayer,
+                //  キューピットはNeutralPlayerだが元々記載の方法が特殊だった為コメントアウトで記載を残した。
             });
 
         notWinners.AddRanges(new[]
@@ -564,6 +567,63 @@ public static class OnGameEndPatch
                 RoleHelpers.FriendRolesPlayer,
                 peculiarNotWinners, // 上記に含まれないクルー勝利除外役職
             });
+        */
+
+        notWinners.AddRanges(new[]{RoleClass.Jester.JesterPlayer,
+            RoleClass.Madmate.MadmatePlayer,
+            RoleClass.Jackal.JackalPlayer,
+            RoleClass.Jackal.SidekickPlayer,
+            RoleClass.JackalFriends.JackalFriendsPlayer,
+            RoleClass.God.GodPlayer,
+            RoleClass.Opportunist.OpportunistPlayer,
+            RoleClass.Truelover.trueloverPlayer,
+            RoleClass.Egoist.EgoistPlayer,
+            RoleClass.Workperson.WorkpersonPlayer,
+            RoleClass.Amnesiac.AmnesiacPlayer,
+            RoleClass.SideKiller.MadKillerPlayer,
+            RoleClass.MadMayor.MadMayorPlayer,
+            RoleClass.MadStuntMan.MadStuntManPlayer,
+            RoleClass.MadHawk.MadHawkPlayer,
+            RoleClass.MadJester.MadJesterPlayer,
+            RoleClass.MadSeer.MadSeerPlayer,
+            RoleClass.FalseCharges.FalseChargesPlayer,
+            RoleClass.Fox.FoxPlayer,
+            BotManager.AllBots,
+            RoleClass.MadMaker.MadMakerPlayer,
+            RoleClass.Demon.DemonPlayer,
+            RoleClass.SeerFriends.SeerFriendsPlayer,
+            RoleClass.JackalSeer.JackalSeerPlayer,
+            RoleClass.JackalSeer.SidekickSeerPlayer,
+            RoleClass.Arsonist.ArsonistPlayer,
+            RoleClass.Vulture.VulturePlayer,
+            RoleClass.MadCleaner.MadCleanerPlayer,
+            RoleClass.MayorFriends.MayorFriendsPlayer,
+            RoleClass.Tuna.TunaPlayer,
+            RoleClass.BlackCat.BlackCatPlayer,
+            RoleClass.Neet.NeetPlayer,
+            RoleClass.SatsumaAndImo.SatsumaAndImoPlayer,
+            RoleClass.Revolutionist.RevolutionistPlayer,
+            RoleClass.SuicidalIdeation.SuicidalIdeationPlayer,
+            RoleClass.Spelunker.SpelunkerPlayer,
+            RoleClass.Hitman.HitmanPlayer,
+            RoleClass.PartTimer.PartTimerPlayer,
+            RoleClass.Photographer.PhotographerPlayer,
+            RoleClass.Stefinder.StefinderPlayer,
+            RoleClass.Pavlovsdogs.PavlovsdogsPlayer,
+            RoleClass.Pavlovsowner.PavlovsownerPlayer,
+            RoleClass.LoversBreaker.LoversBreakerPlayer,
+            Roles.Impostor.MadRole.Worshiper.WorshiperPlayer,
+            Safecracker.SafecrackerPlayer,
+            FireFox.FireFoxPlayer,
+            OrientalShaman.OrientalShamanPlayer,
+            OrientalShaman.ShermansServantPlayer,
+            TheThreeLittlePigs.TheFirstLittlePig.Player,
+            TheThreeLittlePigs.TheSecondLittlePig.Player,
+            TheThreeLittlePigs.TheThirdLittlePig.Player,
+            RoleClass.WaveCannonJackal.WaveCannonJackalPlayer,
+            });
+        notWinners.AddRange(RoleClass.Cupid.CupidPlayer);
+        notWinners.AddRange(RoleClass.Dependents.DependentsPlayer);
 
         foreach (PlayerControl p in RoleClass.Survivor.SurvivorPlayer)
         {

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -62,12 +62,14 @@ public static class RoleClass
         MeetingHudUpdatePatch.ErrorNames = new();
         FixSabotage.ClearAndReload();
 
+        /* 陣営playerがうまく動かず使われてない為コメントアウト。
         RoleHelpers.CrewmatePlayer = new();
         RoleHelpers.ImposterPlayer = new();
         RoleHelpers.NeutralPlayer = new();
         RoleHelpers.MadRolesPlayer = new();
         RoleHelpers.FriendRolesPlayer = new();
-        //RoleHelpers.NeutralKillingPlayer = new();
+        RoleHelpers.NeutralKillingPlayer = new();
+        */
 
         Debugger.ClearAndReload();
         SoothSayer.ClearAndReload();

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -21,11 +21,13 @@ public enum TeamRoleType
 }
 public static class RoleHelpers
 {
+    /* TODO: 蔵徒:陣営playerがうまく動いていない。SetRoleの時に``if (player.Is陣営())``がうまく動かず、リスト入りされていない。直す
     public static List<PlayerControl> CrewmatePlayer;
     public static List<PlayerControl> ImposterPlayer;
     public static List<PlayerControl> NeutralPlayer;
     public static List<PlayerControl> MadRolesPlayer;
     public static List<PlayerControl> FriendRolesPlayer;
+    */
 
     // FIXME:パブロフの犬オーナーのリスト入りがうまくいかなかった為、一度コメントアウト勝利条件整理の時に修正お願いします・・・
     // public static List<PlayerControl> NeutralKillingPlayer;
@@ -894,12 +896,14 @@ public static class RoleHelpers
                 SuperNewRolesPlugin.Logger.LogError($"[SetRole]:No Method Found for Role Type {role}");
                 return;
         }
+        /* if (player.Is陣営())がうまく動かず、リスト入りされない為コメントアウト
         if (player.IsImpostor()) ImposterPlayer.Add(player);
         else if (player.IsNeutral()) NeutralPlayer.Add(player);
         else if (player.IsMadRoles()) MadRolesPlayer.Add(player);
         else if (player.IsFriendRoles()) FriendRolesPlayer.Add(player);
         else CrewmatePlayer.Add(player);
-        //if (player.IsKiller()) NeutralKillingPlayer.Add(player);
+        if (player.IsKiller()) NeutralKillingPlayer.Add(player);
+        */
         bool flag = player.GetRole() != role && player.PlayerId == CachedPlayer.LocalPlayer.PlayerId;
         if (role.IsGhostRole())
         {
@@ -1400,12 +1404,14 @@ public static class RoleHelpers
                 break;
                 //ロールリモベ
         }
+        /* if (player.Is陣営())がうまく動かず、リスト入りされない為コメントアウト
         if (player.IsImpostor()) ImposterPlayer.RemoveAll(ClearRemove);
         else if (player.IsNeutral()) NeutralPlayer.RemoveAll(ClearRemove);
         else if (player.IsMadRoles()) MadRolesPlayer.RemoveAll(ClearRemove);
         else if (player.IsFriendRoles()) FriendRolesPlayer.RemoveAll(ClearRemove);
         else CrewmatePlayer.RemoveAll(ClearRemove); // 眷族等クルーではない役職も此処に含まれる
-        //if (player.IsKiller()) NeutralKillingPlayer.RemoveAll(ClearRemove);
+        if (player.IsKiller()) NeutralKillingPlayer.RemoveAll(ClearRemove);
+        */
         ChacheManager.ResetMyRoleChache();
     }
     public static void SetRoleRPC(this PlayerControl Player, RoleId selectRoleData)


### PR DESCRIPTION
いつか直します・・・

取りあえず 第三陣営 マッドメイト ジャッカルフレンズがクルー勝利に乗る問題修正しました。
元々勝利除外されてなかった波動砲ジャッカルを追記しておきました。