### PR TITLE
マッドロールとフレンズロールの狂信能力発動後にSKされた場合能力が発動したままの問題を修正

### DIFF
--- a/SuperNewRoles/Patches/ControllerManagerPatch.cs
+++ b/SuperNewRoles/Patches/ControllerManagerPatch.cs
@@ -5,8 +5,6 @@ using SuperNewRoles.Helpers;
 using SuperNewRoles.Mode;
 using SuperNewRoles.Mode.SuperHostRoles;
 using SuperNewRoles.Roles;
-using Agartha;
-using AmongUs.GameOptions;
 using System.Linq;
 using UnityEngine;
 using Hazel;
@@ -86,7 +84,7 @@ class ControllerManagerUpdatePatch
             //ここにデバッグ用のものを書いてね
             if (Input.GetKeyDown(KeyCode.I))
             {
-                for(int i = 0; i < 29; i++)
+                for (int i = 0; i < 29; i++)
                 {
                     BotManager.Spawn("よっキングのBot");
                 }

--- a/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
+++ b/SuperNewRoles/Roles/Impostor/MadRole/Madmate.cs
@@ -6,10 +6,13 @@ namespace SuperNewRoles.Roles;
 
 class Madmate
 {
-    public static List<byte> CheckedImpostor;
+    public static Dictionary<byte, RoleId> CheckedImpostor;
     public static bool CheckImpostor(PlayerControl p)
     {
-        if (CheckedImpostor.Contains(p.PlayerId)) return true;
+        if (CheckedImpostor.ContainsKey(p.PlayerId) && p.GetRole() == CheckedImpostor[p.PlayerId]) return true;
+        if (CheckedImpostor.ContainsKey(p.PlayerId) && p.GetRole() != CheckedImpostor[p.PlayerId])
+            CheckedImpostor.Remove(p.PlayerId);
+
         int CheckTask = 0;
         switch (p.GetRole())
         {
@@ -43,7 +46,7 @@ class Madmate
         var taskdata = TaskCount.TaskDate(p.Data).Item1;
         if (CheckTask <= taskdata)
         {
-            CheckedImpostor.Add(p.PlayerId);
+            CheckedImpostor.Add(p.PlayerId, p.GetRole());
             return true;
         }
         return false;

--- a/SuperNewRoles/Roles/Neutral/FriendsRole/JackalFriends.cs
+++ b/SuperNewRoles/Roles/Neutral/FriendsRole/JackalFriends.cs
@@ -5,10 +5,12 @@ namespace SuperNewRoles.Roles;
 
 class JackalFriends
 {
-    public static List<byte> CheckedJackal;
+    public static Dictionary<byte, RoleId> CheckedJackal;
     public static bool CheckJackal(PlayerControl p)
     {
-        if (CheckedJackal.Contains(p.PlayerId)) return true;
+        if (CheckedJackal.ContainsKey(p.PlayerId)) return true;
+        if (CheckedJackal.ContainsKey(p.PlayerId) && p.GetRole() != CheckedJackal[p.PlayerId])
+            CheckedJackal.Remove(p.PlayerId);
         RoleId role = p.GetRole();
         int CheckTask = 0;
         switch (role)
@@ -31,7 +33,7 @@ class JackalFriends
         var taskdata = TaskCount.TaskDate(p.Data).Item1;
         if (CheckTask <= taskdata)
         {
-            CheckedJackal.Add(p.PlayerId);
+            CheckedJackal.Add(p.PlayerId, p.GetRole());
             return true;
         }
         return false;


### PR DESCRIPTION
~~・サイエンティストの能力中にサイドキックされた場合能力が終了しないバグの修正
・スピーダーが能力使用中に死亡した場合能力が終了しないバグの修正~~
・マッドメイト系役職の狂信とジャッカル系のジャッカル視認が発動している時にサイドキックされると狂信もしくはジャッカル視認が発動したままになるバグ修正

・その他コードのリファクタリング

多重起動できないのでテストできてないです