### PR TITLE
仔豚の修正とか

### DIFF
--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -1023,17 +1023,27 @@ public static class OnGameEndPatch
                 isreset = true;
             }
         }
+        isReset = false;
         foreach (List<PlayerControl> plist in TheThreeLittlePigs.TheThreeLittlePigsPlayer)
         {
+            if (AdditionalTempData.winCondition is WinCondition.LoversBreakerWin or WinCondition.SafecrackerWin or WinCondition.JesterWin or
+                                                   WinCondition.VultureWin or WinCondition.WorkpersonWin or WinCondition.FalseChargesWin or
+                                                   WinCondition.DemonWin or WinCondition.SuicidalIdeationWin or WinCondition.PhotographerWin or
+                                                   WinCondition.RevolutionistWin or WinCondition.QuarreledWin) break;
+            if (!TheThreeLittlePigs.IsTheThreeLittlePigs(plist) || plist.IsAllDead()) continue;
             bool isAllAlive = true;
-            foreach (PlayerControl player in plist)
+            if (plist.Count >= 3)
             {
-                if (player.IsDead())
+                foreach (PlayerControl player in plist)
                 {
-                    isAllAlive = false;
-                    break;
+                    if (player.IsDead() || !TheThreeLittlePigs.IsTheThreeLittlePigs(player))
+                    {
+                        isAllAlive = false;
+                        break;
+                    }
                 }
             }
+            else isAllAlive = false;
             if (isAllAlive)
             {
                 if (!((isDleted && changeTheWinCondition) || isReset))
@@ -1044,6 +1054,7 @@ public static class OnGameEndPatch
                 }
                 foreach (PlayerControl player in plist)
                 {
+                    if (!TheThreeLittlePigs.IsTheThreeLittlePigs(player)) continue;
                     TempData.winners.Add(new(player.Data));
                     AdditionalTempData.winCondition = WinCondition.TheThreeLittlePigsWin;
                 }
@@ -1070,6 +1081,7 @@ public static class OnGameEndPatch
                     }
                     foreach (PlayerControl player in plist)
                     {
+                        if (!TheThreeLittlePigs.IsTheThreeLittlePigs(player)) continue;
                         TempData.winners.Add(new(player.Data));
                         AdditionalTempData.winCondition = WinCondition.TheThreeLittlePigsWin;
                     }
@@ -1262,6 +1274,11 @@ public static class OnGameEndPatch
             };
             PlayerData.Add(data);
         }
+        Logger.Info($"WinCondition : {AdditionalTempData.winCondition}", "EndGame");
+        string text = "勝利したプレイヤー : ";
+        foreach (var date in TempData.winners)
+            text += $"\n{date.PlayerName}";
+        Logger.Info(text, "EndGame");
     }
 }
 [HarmonyPatch(typeof(TranslationController), nameof(TranslationController.GetString), new Type[] { typeof(StringNames), typeof(Il2CppReferenceArray<Il2CppSystem.Object>) })]

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -1274,11 +1274,6 @@ public static class OnGameEndPatch
             };
             PlayerData.Add(data);
         }
-        Logger.Info($"WinCondition : {AdditionalTempData.winCondition}", "EndGame");
-        string text = "勝利したプレイヤー : ";
-        foreach (var date in TempData.winners)
-            text += $"\n{date.PlayerName}";
-        Logger.Info(text, "EndGame");
     }
 }
 [HarmonyPatch(typeof(TranslationController), nameof(TranslationController.GetString), new Type[] { typeof(StringNames), typeof(Il2CppReferenceArray<Il2CppSystem.Object>) })]

--- a/SuperNewRoles/Patches/FixedUpdatePatch.cs
+++ b/SuperNewRoles/Patches/FixedUpdatePatch.cs
@@ -107,6 +107,7 @@ public class FixedUpdate
                 Roles.Impostor.Penguin.FixedUpdate();
                 Squid.FixedUpdate();
                 OrientalShaman.FixedUpdate();
+                TheThreeLittlePigs.FixedUpdate();
                 if (PlayerControl.LocalPlayer.IsAlive())
                 {
                     if (PlayerControl.LocalPlayer.IsImpostor()) { SetTarget.ImpostorSetTarget(); }

--- a/SuperNewRoles/Roles/Neutral/TheThreeLittlePigs.cs
+++ b/SuperNewRoles/Roles/Neutral/TheThreeLittlePigs.cs
@@ -89,6 +89,21 @@ public class TheThreeLittlePigs
         return clearTask <= TaskCount.TaskDate(player.Data).Item1;
     }
 
+    public static void FixedUpdate()
+    {
+        foreach (List<PlayerControl> plist in TheThreeLittlePigsPlayer)
+        {
+            List<PlayerControl> removes = new();
+            foreach (PlayerControl player in plist)
+                if (!IsTheThreeLittlePigs(player)) removes.Add(player);
+            if (removes.Count > 0)
+            {
+                foreach (PlayerControl id in removes)
+                    plist.Remove(id);
+            }
+        }
+    }
+
     public class TheFirstLittlePigClass
     {
         public List<PlayerControl> Player;
@@ -160,5 +175,14 @@ public class TheThreeLittlePigs
             Logger.Info($"3番目の仔豚のタスク割合 : {ClearTask}, 割合 : {TheThirdLittlePigClearTask.GetString()}", "TheThreeLittlePigs");
             CounterCount = new();
         }
+    }
+
+    public static bool IsTheThreeLittlePigs(PlayerControl player) =>
+        player.IsRole(RoleId.TheFirstLittlePig, RoleId.TheSecondLittlePig, RoleId.TheThirdLittlePig);
+    public static bool IsTheThreeLittlePigs(List<PlayerControl> players)
+    {
+        foreach (PlayerControl player in players)
+            if (IsTheThreeLittlePigs(player)) return true;
+        return false;
     }
 }

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -133,10 +133,9 @@ public static class RoleHelpers
     // 第三か
 
     public static bool IsKiller(this PlayerControl player) =>
-        player.GetRole() ==
-            RoleId.Pavlovsowner
-            && !RoleClass.Pavlovsowner.CountData.ContainsKey(player.PlayerId)
-            || RoleClass.Pavlovsowner.CountData[player.PlayerId] > 0
+        (player.GetRole() == RoleId.Pavlovsowner &&
+        (!RoleClass.Pavlovsowner.CountData.ContainsKey(player.PlayerId) ||
+        RoleClass.Pavlovsowner.CountData[player.PlayerId] > 0))
         ||
         player.GetRole() is
         RoleId.Pavlovsdogs or
@@ -147,7 +146,8 @@ public static class RoleHelpers
         RoleId.SidekickSeer or
         RoleId.WaveCannonJackal or
         RoleId.Hitman or
-        RoleId.Egoist;
+        RoleId.Egoist or
+        RoleId.FireFox;
     // 第三キル人外か
 
     public static bool IsPavlovsTeam(this PlayerControl player) => player.GetRole() is
@@ -1882,5 +1882,11 @@ public static class RoleHelpers
     public static bool IsAlive(this CachedPlayer player)
     {
         return player != null && !player.Data.Disconnected && !player.Data.IsDead;
+    }
+    public static bool IsAllDead(this List<PlayerControl> lest)
+    {
+        foreach (PlayerControl player in lest)
+            if (player.IsAlive()) return false;
+        return true;
     }
 }


### PR DESCRIPTION
仔豚がサイドキックされた場合透ける問題を修正
仔豚が全滅していても勝利してしまう問題の修正
仔豚が一部勝利を塗り替えないように変更