### PR TITLE
[/MyRole]コマンド作成 & [/SL]コマンドをゲーム中使用できなかった問題修正

### DIFF
--- a/SuperNewRoles/Patches/ChatCommandPatch.cs
+++ b/SuperNewRoles/Patches/ChatCommandPatch.cs
@@ -144,6 +144,11 @@ public static class DynamicLobbies
                 // memoの中身があるなら ファイル名を任意の文字列にする。
                 else Logger.SaveLog(memo, via);
             }
+            if (text.ToLower().StartsWith("/mr") || text.ToLower().StartsWith("/MyRole"))
+            {
+                handled = true;
+                AddChatPatch.MyRoleCommand(/*SendTime: sendTime, */ commandUser: PlayerControl.LocalPlayer);
+            }
             if (handled)
             {
                 __instance.TextArea.Clear();

--- a/SuperNewRoles/Patches/ChatCommandPatch.cs
+++ b/SuperNewRoles/Patches/ChatCommandPatch.cs
@@ -78,25 +78,6 @@ public static class DynamicLobbies
                         SuperNewRolesPlugin.Logger.LogWarning($"ホストでない時に{text}を使用しました。ホストでない時は/renameは使用できません。");
                     }
                 }
-                else if (text.ToLower().StartsWith("/sl") || text.ToLower().StartsWith("/savelog"))
-                {// ファイル名を付けてログを別の場所に保管するコマンド
-
-                    handled = true;
-                    string memo;
-                    string via = "ChatCommandVia";
-
-                    // textからコマンドを削除し、ファイル名につける文字列を抜き出す
-                    memo = text.ToLower()
-                        .Replace("/sl", "")
-                        .Replace("/savelog", "")
-                        .Replace(" ", "")
-                        .Replace("　", "");
-
-                    // memoが空なら ファイル名をChatCommandViaにする。
-                    if (memo == "") Logger.SaveLog(via, via);
-                    // memoの中身があるなら ファイル名を任意の文字列にする。
-                    else Logger.SaveLog(memo, via);
-                }
                 if (AmongUsClient.Instance.NetworkMode == NetworkModes.FreePlay)
                 {
                     if (text.ToLower().Equals("/murder"))

--- a/SuperNewRoles/Patches/ChatCommandPatch.cs
+++ b/SuperNewRoles/Patches/ChatCommandPatch.cs
@@ -124,12 +124,31 @@ public static class DynamicLobbies
                         __instance.AddChat(PlayerControl.LocalPlayer, "Changed name succesfully");
                     }
                 }
-                if (handled)
-                {
-                    __instance.TextArea.Clear();
-                    FastDestroyableSingleton<HudManager>.Instance.Chat.TimeSinceLastMessage = 0f;
-                    __instance.quickChatMenu.ResetGlyphs();
-                }
+            }
+            if (text.ToLower().StartsWith("/sl") || text.ToLower().StartsWith("/savelog"))
+            {// ファイル名を付けてログを別の場所に保管するコマンド
+
+                handled = true;
+                string memo;
+                string via = "ChatCommandVia";
+
+                // textからコマンドを削除し、ファイル名につける文字列を抜き出す
+                memo = text.ToLower()
+                    .Replace("/sl", "")
+                    .Replace("/savelog", "")
+                    .Replace(" ", "")
+                    .Replace("　", "");
+
+                // memoが空なら ファイル名をChatCommandViaにする。
+                if (memo == "") Logger.SaveLog(via, via);
+                // memoの中身があるなら ファイル名を任意の文字列にする。
+                else Logger.SaveLog(memo, via);
+            }
+            if (handled)
+            {
+                __instance.TextArea.Clear();
+                FastDestroyableSingleton<HudManager>.Instance.Chat.TimeSinceLastMessage = 0f;
+                __instance.quickChatMenu.ResetGlyphs();
             }
             return !handled;
         }

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -192,6 +192,16 @@ class AddChatPatch
             Commands[0].Equals("/mr", StringComparison.OrdinalIgnoreCase)
             )
         {
+            if (AmongUsClient.Instance.GameState != AmongUsClient.GameStates.Started)
+            {
+                SendCommand(sourcePlayer, ModTranslation.GetString("MyRoleErrorNotGameStart"));
+                return false;
+            }
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+            {
+                SendCommand(sourcePlayer, ModTranslation.GetString("MyRoleErrorSHRMode"));
+                return false;
+            }
             if (Commands.Length == 1)
             {
                 Logger.Info("Length==1", "/mr");
@@ -376,10 +386,10 @@ class AddChatPatch
 
     /// <summary>
     /// コマンド使用者の役職説明を取得し、チャットに流す。
-    /// 送信間隔をコメントアウトしているのは、重複役の説明が必要になった時に、復活させ設定可能にする為。
+    /// 送信間隔をコメントアウトしているのは重複役の説明が必要になった時に復活させ設定可能にする為
     /// </summary>
-    /// <param name="target">送信対象者(Hostの場合nullが渡されている)</param>
-    /// <param name="commandUser">コマンド使用者</param>
+    /// <param name="target"></param>
+    /// <param name="commandUser"></param>
     static void MyRoleCommand(PlayerControl target = null, PlayerControl commandUser = null/*, float SendTime = 1.5f*/)
     {
         if (!AmongUsClient.Instance.AmHost) return;
@@ -410,29 +420,10 @@ class AddChatPatch
             string text = GetText(option);
             string roleName = "<size=115%>\n" + CustomOptionHolder.Cs(option.Intro.color, option.Intro.NameKey + "Name") + "</size>";
             SuperNewRolesPlugin.Logger.LogInfo(roleName);
-            SuperNewRolesPlugin.Logger.LogInfo(text);
+            SuperNewRolesPlugin.Logger.LogInfo(option);
             Send(target, roleName, text, time);
             // time += SendTime;
         }
-
-        /*
-        List<CustomRoleOption> myRoleOptions = new();
-
-        foreach (CustomRoleOption option in CustomRoleOption.RoleOptions)
-        {
-            if (myRole != option.RoleId) continue;
-            myRoleOptions.Add(option);
-        }
-        float time = 0;
-        foreach (CustomRoleOption option in myRoleOptions)
-        {
-            string text = GetText(option);
-            string roleName = "<size=115%>\n" + CustomOptionHolder.Cs(option.Intro.color, option.Intro.NameKey + "Name") + "</size>";
-            SuperNewRolesPlugin.Logger.LogInfo(myRoleOptions);
-            Send(target, roleName, text, time);
-            // time += SendTime;
-        }
-        */
     }
 
     static void Send(PlayerControl target, string rolename, string text, float time = 0)

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -188,6 +188,16 @@ class AddChatPatch
             return false;
         }
         else if (
+            Commands[0].Equals("/MyRole", StringComparison.OrdinalIgnoreCase) ||
+            Commands[0].Equals("/mr", StringComparison.OrdinalIgnoreCase)
+            )
+        {
+            if (!AmongUsClient.Instance.AmHost) return true;
+            if (sourcePlayer.IsMod()) return true;
+            AddChatPatch.MyRoleCommand(/*SendTime: sendTime, */ commandUser: sourcePlayer);
+            return true;
+        }
+        else if (
             Commands[0].Equals("/Winners", StringComparison.OrdinalIgnoreCase) ||
             Commands[0].Equals("/w", StringComparison.OrdinalIgnoreCase)
             )
@@ -355,7 +365,7 @@ class AddChatPatch
 
         if (errorText != null)
         {
-            if (!AmongUsClient.Instance.AmHost) FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(commandUser, errorText);
+            if (!(AmongUsClient.Instance.AmHost && ModeHandler.IsMode(ModeId.SuperHostRoles, false))) FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(commandUser, errorText);
             else SendCommand(commandUser, errorText);
             return;
         }

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -188,14 +188,6 @@ class AddChatPatch
             return false;
         }
         else if (
-            Commands[0].Equals("/MyRole", StringComparison.OrdinalIgnoreCase) ||
-            Commands[0].Equals("/mr", StringComparison.OrdinalIgnoreCase)
-            )
-        {
-            MyRoleCommand(/*SendTime: sendTime, */ commandUser: sourcePlayer);
-            return false;
-        }
-        else if (
             Commands[0].Equals("/Winners", StringComparison.OrdinalIgnoreCase) ||
             Commands[0].Equals("/w", StringComparison.OrdinalIgnoreCase)
             )
@@ -311,7 +303,7 @@ class AddChatPatch
         if (!AmongUsClient.Instance.AmHost) return;
         if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.SuperHostRoles, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
         {
-            SendCommand(target, ModTranslation.GetString("Notassign"));
+            SendCommand(target, ModTranslation.GetString("NotAssign"));
             return;
         }
         List<CustomRoleOption> EnableOptions = new();
@@ -336,7 +328,7 @@ class AddChatPatch
         if (!AmongUsClient.Instance.AmHost) return;
         if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.SuperHostRoles, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
         {
-            SendCommand(target, ModTranslation.GetString("Notassign"));
+            SendCommand(target, ModTranslation.GetString("NotAssign"));
             return;
         }
         List<CustomRoleOption> EnableOptions = new();
@@ -354,22 +346,17 @@ class AddChatPatch
     /// 送信間隔をコメントアウトしているのは重複役の説明が必要になった時に復活させ設定可能にする為
     /// </summary>
     /// <param name="commandUser">コマンドを使用し、役職説明送信対象となるplayer</param>
-    static void MyRoleCommand(PlayerControl commandUser = null/*, float SendTime = 1.5f*/)
+    public static void MyRoleCommand(PlayerControl commandUser = null/*, float SendTime = 1.5f*/)
     {
-        if (!AmongUsClient.Instance.AmHost) return;
-        if (AmongUsClient.Instance.GameState != AmongUsClient.GameStates.Started)
+        string errorText = null;
+        if (AmongUsClient.Instance.GameState != AmongUsClient.GameStates.Started) errorText = ModTranslation.GetString("MyRoleErrorNotGameStart");
+        else if (ModeHandler.IsMode(ModeId.SuperHostRoles, false)) errorText = ModTranslation.GetString("MyRoleErrorSHRMode");
+        else if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.Werewolf, false))) errorText = ModTranslation.GetString("NotAssign");
+
+        if (errorText != null)
         {
-            SendCommand(commandUser, ModTranslation.GetString("MyRoleErrorNotGameStart"));
-            return;
-        }
-        if (ModeHandler.IsMode(ModeId.SuperHostRoles, false))
-        {
-            SendCommand(commandUser, ModTranslation.GetString("MyRoleErrorSHRMode"));
-            return;
-        }
-        if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
-        {
-            SendCommand(commandUser, ModTranslation.GetString("Notassign"));
+            if (!AmongUsClient.Instance.AmHost) FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(commandUser, errorText);
+            else SendCommand(commandUser, errorText);
             return;
         }
 

--- a/SuperNewRoles/Patches/ChatHandlerPatch.cs
+++ b/SuperNewRoles/Patches/ChatHandlerPatch.cs
@@ -192,42 +192,7 @@ class AddChatPatch
             Commands[0].Equals("/mr", StringComparison.OrdinalIgnoreCase)
             )
         {
-            if (AmongUsClient.Instance.GameState != AmongUsClient.GameStates.Started)
-            {
-                SendCommand(sourcePlayer, ModTranslation.GetString("MyRoleErrorNotGameStart"));
-                return false;
-            }
-            if (ModeHandler.IsMode(ModeId.SuperHostRoles))
-            {
-                SendCommand(sourcePlayer, ModTranslation.GetString("MyRoleErrorSHRMode"));
-                return false;
-            }
-            if (Commands.Length == 1)
-            {
-                Logger.Info("Length==1", "/mr");
-                if (sourcePlayer.AmOwner)
-                {
-                    MyRoleCommand(null, sourcePlayer);
-                }
-                else
-                {
-                    MyRoleCommand(sourcePlayer, sourcePlayer);
-                }
-            }
-            else
-            {
-                Logger.Info("Length!=1", "/mr");
-                PlayerControl target = sourcePlayer.AmOwner ? null : sourcePlayer;
-                if (Commands.Length >= 3 && (Commands[2].Equals("mp", StringComparison.OrdinalIgnoreCase) || Commands[2].Equals("myplayer", StringComparison.OrdinalIgnoreCase) || Commands[2].Equals("myp", StringComparison.OrdinalIgnoreCase)))
-                {
-                    target = sourcePlayer;
-                }
-                if (!float.TryParse(Commands[1], out float sendTime))
-                {
-                    return false;
-                }
-                MyRoleCommand(/*SendTime: sendTime, */target: target, commandUser: sourcePlayer);
-            }
+            MyRoleCommand(/*SendTime: sendTime, */ commandUser: sourcePlayer);
             return false;
         }
         else if (
@@ -388,24 +353,23 @@ class AddChatPatch
     /// コマンド使用者の役職説明を取得し、チャットに流す。
     /// 送信間隔をコメントアウトしているのは重複役の説明が必要になった時に復活させ設定可能にする為
     /// </summary>
-    /// <param name="target"></param>
-    /// <param name="commandUser"></param>
-    static void MyRoleCommand(PlayerControl target = null, PlayerControl commandUser = null/*, float SendTime = 1.5f*/)
+    /// <param name="commandUser">コマンドを使用し、役職説明送信対象となるplayer</param>
+    static void MyRoleCommand(PlayerControl commandUser = null/*, float SendTime = 1.5f*/)
     {
         if (!AmongUsClient.Instance.AmHost) return;
         if (AmongUsClient.Instance.GameState != AmongUsClient.GameStates.Started)
         {
-            SendCommand(target, ModTranslation.GetString("MyRoleErrorNotGameStart"));
+            SendCommand(commandUser, ModTranslation.GetString("MyRoleErrorNotGameStart"));
             return;
         }
         if (ModeHandler.IsMode(ModeId.SuperHostRoles, false))
         {
-            SendCommand(target, ModTranslation.GetString("MyRoleErrorSHRMode"));
+            SendCommand(commandUser, ModTranslation.GetString("MyRoleErrorSHRMode"));
             return;
         }
         if (!(ModeHandler.IsMode(ModeId.Default, false) || ModeHandler.IsMode(ModeId.Werewolf, false)))
         {
-            SendCommand(target, ModTranslation.GetString("Notassign"));
+            SendCommand(commandUser, ModTranslation.GetString("Notassign"));
             return;
         }
 
@@ -420,8 +384,8 @@ class AddChatPatch
             string text = GetText(option);
             string roleName = "<size=115%>\n" + CustomOptionHolder.Cs(option.Intro.color, option.Intro.NameKey + "Name") + "</size>";
             SuperNewRolesPlugin.Logger.LogInfo(roleName);
-            SuperNewRolesPlugin.Logger.LogInfo(option);
-            Send(target, roleName, text, time);
+            SuperNewRolesPlugin.Logger.LogInfo(text);
+            Send(commandUser, roleName, text, time);
             // time += SendTime;
         }
     }
@@ -444,7 +408,7 @@ class AddChatPatch
             else
             {
                 string name = PlayerControl.LocalPlayer.GetDefaultName();
-                PlayerControl.LocalPlayer.SetName(SNRCommander + "\n" + rolename);
+                PlayerControl.LocalPlayer.SetName(SNRCommander + rolename);
                 FastDestroyableSingleton<HudManager>.Instance.Chat.AddChat(PlayerControl.LocalPlayer, text);
                 PlayerControl.LocalPlayer.SetName(name);
             }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1329,6 +1329,8 @@ Team,Team,陣営,阵营
 MessageSettings,Settings,設定,设置
 NowRolesMessage,Activate Roles,現在入っている役職,当前激活的职业
 Notassign,This is the mode in which no roles are assigned.,役職が選出されないモードに設定されています。,目前还没有激活任何职业。
+MyRoleErrorNotGameStart,This command cannot be used because the game is not in progress.,ゲーム中でない為、このコマンドは使用できません。
+MyRoleErrorSHRMode,This command is not available in SHR mode.,SHRモードではこのコマンドは使用できません。
 TeamMessage,【Team:{0}】,【{0}陣営】,【{0}阵营】
 NameIncludeMod,You cannot make a room public contains mod in your name.,modが名前に含まれている状態では公開部屋にすることはできません。,不能在昵称里有“mod”时将房间状态设置为公开。
 CannotUseRenameMessage,Cannot rename.\nThe /rename command can only be used on\navailable only when hosted.,名前を変更することができません。\n/renameコマンドは\nホスト時のみ使用可能です。,无法重命名。\n/rename命令仅房主可用。

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1328,7 +1328,7 @@ TwitterDevLink,Development Information Account : https://twitter.com/SNRDevs,開
 Team,Team,陣営,阵营
 MessageSettings,Settings,設定,设置
 NowRolesMessage,Activate Roles,現在入っている役職,当前激活的职业
-Notassign,This is the mode in which no roles are assigned.,役職が選出されないモードに設定されています。,目前还没有激活任何职业。
+NotAssign,This is the mode in which no roles are assigned.,役職が選出されないモードに設定されています。,目前还没有激活任何职业。
 MyRoleErrorNotGameStart,This command cannot be used because the game is not in progress.,ゲーム中でない為、このコマンドは使用できません。
 MyRoleErrorSHRMode,This command is not available in SHR mode.,SHRモードではこのコマンドは使用できません。
 TeamMessage,【Team:{0}】,【{0}陣営】,【{0}阵营】


### PR DESCRIPTION
# [内容]
- Defaultと人狼モードでのみ使用可能な[/MyRole]コマンド作成
  - /arと違い``ChatCommandPatch.cs``で記載している為Client処理
  - SHR時非導入者向けに``ChatHandlerPatch.cs``で、
  コマンドが送信された時に``MyRoleCommand``を呼び、hostが「コマンドは使用できない」旨の説明を送信している。
  - コマンド処理本体は``ChatHandlerPatch.cs``にあるのは、使用したい関数がpublicでなかった為

- [/SL]コマンドをゲーム中使用できなかった問題を修正

# [テスト]
- SNR
  - ![image](https://user-images.githubusercontent.com/104145991/221752034-b27f1591-1770-42ba-8997-efb965da2fe6.png)
  - ![image](https://user-images.githubusercontent.com/104145991/221752099-15705e0d-6c84-45ed-8bae-f688e2899b6b.png)
  - ![image](https://user-images.githubusercontent.com/104145991/221752163-395b4142-df3b-4e7c-b1a9-ca3631744c6e.png)
    - ホストでもゲストでも正常に反映されていること確認
      - ホスト送信時、ゲストに送信されていない
      - ゲスト送信時、他者に送信していない 


- SHR
  - ![image](https://user-images.githubusercontent.com/104145991/221753328-e166ed30-0c03-4c72-ad51-0ae11b8b1332.png)
  - ![image](https://user-images.githubusercontent.com/104145991/221753540-fa95c604-1876-4d2a-9a11-cf2fe71e061c.png)
  - ![image](https://user-images.githubusercontent.com/104145991/221753585-c7cbf4fc-239d-43ea-ba9a-899aedfb9900.png)
    - ホスト,導入者ゲスト,非導入者ゲストで正常に反映されていること確認
      - ホスト送信時、ゲストに送信されていない
      - 導入者ゲスト送信時、他者に送信していない
      - 非導入者ゲスト送信時
        - ホストはコマンド使用者のみに、使用不可の旨のメッセージを送信している。
        - 導入者ゲストはメッセージを送信していない。
        - 非導入者ゲストはメッセージを受け取っている。
