### PR TITLE
シェイプシフター系が死亡時Impostorghostに変更するコード削除

### DIFF
--- a/SuperNewRoles/Helpers/RPCHelper.cs
+++ b/SuperNewRoles/Helpers/RPCHelper.cs
@@ -231,30 +231,6 @@ public static class RPCHelper
         target.SetRoleRPC(Id);
         Logger.Info($"[{target.GetDefaultName()}] の役職を [{Id}] に変更しました。");
     }
-
-    /// <summary>
-    ///　役職をImpostorghostにリセットします。
-    /// </summary>
-    /// <param name="target">役職が変更される対象</param>
-    public static void ResetAndSetImpostorghost(this PlayerControl target)
-    {
-        var targetRole = target.GetRole();
-
-        if (AmongUsClient.Instance.AmHost)
-        {
-            target.RPCSetRoleUnchecked(RoleTypes.ImpostorGhost);
-            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(target.NetId, (byte)RpcCalls.SetRole, SendOption.None);
-            writer.Write((ushort)RoleTypes.ImpostorGhost);
-            AmongUsClient.Instance.FinishRpcImmediately(writer);
-        }
-        else
-        {
-            target.RPCSetRoleUnchecked(RoleTypes.ImpostorGhost);
-        }
-        target.SetRole(RoleTypes.ImpostorGhost);
-        Logger.Info($"[{targetRole}] であった [{target.GetDefaultName()}] の役職を ImpostorGhost に変更しました。");
-    }
-
     public static void RpcResetAbilityCooldown(this PlayerControl target)
     {
         if (!AmongUsClient.Instance.AmHost) return;

--- a/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/WrapUp.cs
@@ -89,6 +89,5 @@ class WrapUpClass
         }
         Roles.Jester.WrapUp(exiled);
         Roles.Nekomata.WrapUp(exiled);
-        if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
     }
 }

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -147,7 +147,6 @@ class RpcShapeshiftPatch
                         }
                     }
                     __instance.RpcMurderPlayer(__instance);
-                    __instance.ResetAndSetImpostorghost();
                     __instance.RpcSetFinalStatus(FinalStatus.SelfBomberBomb);
                     return false;
                 case RoleId.Samurai:
@@ -192,7 +191,6 @@ class RpcShapeshiftPatch
                     return false;
                 case RoleId.SuicideWisher:
                     __instance.RpcMurderPlayer(__instance);
-                    __instance.ResetAndSetImpostorghost();
                     __instance.RpcSetFinalStatus(FinalStatus.SuicideWisherSelfDeath);
                     return false;
                 case RoleId.ToiletFan:
@@ -787,7 +785,6 @@ static class CheckMurderPatch
                     }
                 }
             }
-            else if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
         }
         Logger.Info("全スタントマン系通過", "CheckMurder");
         __instance.RpcMurderPlayerCheck(target);
@@ -1175,13 +1172,6 @@ public static class MurderPlayerPatch
                 }
             }
             Minimalist.MurderPatch.Postfix(__instance);
-            /*
-                DefaultModeにシフトアクター以外のシェイプシフター置き換え役職が増えた場合
-                [if (target.IsShapeshifter()) ~ ] のコメントアウトを解除し、
-                [if (target.IsRole(RoleId.ShiftActor)) ~ ]のコードを削除してください。
-            */
-            // if (target.IsShapeshifter()) target.ResetAndSetImpostorghost();
-            if (target.IsRole(RoleId.ShiftActor)) target.ResetAndSetImpostorghost();
         }
         Vampire.OnMurderPlayer(__instance, target);
         if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && ModeHandler.IsMode(ModeId.Default))

--- a/SuperNewRoles/Patches/WrapUpPatch.cs
+++ b/SuperNewRoles/Patches/WrapUpPatch.cs
@@ -198,13 +198,6 @@ class WrapUpPatch
                     CheckGameEndPatch.CustomEndGame((GameOverReason)CustomGameOverReason.MadJesterWin, false);
                 }
             }
-            /*
-                DefaultModeにシフトアクター以外のシェイプシフター置き換え役職が増えた場合
-                [if (exiled.Object.IsShapeshifter()) ~ ] のコメントアウトを解除し、
-                [if (exiled.Object.IsRole(RoleId.ShiftActor)) ~ ]のコードを削除してください。
-            */
-            if (exiled.Object.IsShapeshifter()) exiled.Object.ResetAndSetImpostorghost();
-            if (exiled.Object.IsRole(RoleId.ShiftActor)) exiled.Object.ResetAndSetImpostorghost();
         }
         Mode.SuperHostRoles.Main.RealExiled = null;
     }

--- a/SuperNewRoles/Roles/Role/RoleHelper.cs
+++ b/SuperNewRoles/Roles/Role/RoleHelper.cs
@@ -43,25 +43,6 @@ public static class RoleHelpers
     {
         return !player.IsRole(RoleId.Sheriff, RoleId.Sheriff) && player != null && player.Data.Role.IsImpostor;
     }
-
-    /// <summary>
-    /// v2022.12.8で発生したシェイプシフターが死亡後クルーメイトゴーストになるバグの修正用。
-    /// We are Shapeshifter!
-    /// </summary>
-    /// <param name="player">シェイプシフターであるか判定されるプレイヤー</param>
-    /// <returns>プレイヤーがシェイプシフターである場合trueを返す</returns>
-    public static bool IsShapeshifter(this PlayerControl player) =>
-        player.GetRole() is
-        RoleId.SelfBomber or
-        RoleId.Samurai or
-        RoleId.EvilButtoner or
-        RoleId.SuicideWisher or
-        RoleId.Doppelganger or
-        RoleId.Camouflager or
-        RoleId.EvilSeer or
-        RoleId.ShiftActor;
-    // IsShapeshifter
-
     public static bool IsHauntedWolf(this PlayerControl player) => player.IsRole(RoleId.HauntedWolf);
 
     /// <summary>
@@ -1426,7 +1407,6 @@ public static class RoleHelpers
     {
         var IsTaskClear = false;
         if (player.IsImpostor()) IsTaskClear = true;
-        if (player.IsShapeshifter()) IsTaskClear = true;
         if (player.IsMadRoles()) IsTaskClear = true;
         if (player.IsFriendRoles()) IsTaskClear = true;
         if (player.IsNeutral()) IsTaskClear = true;


### PR DESCRIPTION
# [変更点]
- AmongUs v2023.2.28 で、シェイプシフターが死後Crewmateghostになるバグが、公式から修正されたようなのでMod側で対処したコードを削除しました

# [メモ]
- 最新対応してから出せとは言わないで()
- ビルドできることは確認しましたがテストはしてません。