### PR TITLE
ペンギンのバグ修正

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1911,7 +1911,7 @@ public class CustomOptionHolder
         PenguinCoolTime = Create(1088, false, CustomOptionType.Impostor, "NiceScientistCooldownSetting", 30f, 2.5f, 60f, 2.5f, PenguinOption, format: "unitSeconds");
         PenguinDurationTime = Create(1089, false, CustomOptionType.Impostor, "NiceScientistDurationSetting", 10f, 2.5f, 30f, 2.5f, PenguinOption, format: "unitSeconds");
         PenguinCanDefaultKill = Create(1090, false, CustomOptionType.Impostor, "PenguinCanDefaultKill", false, PenguinOption);
-        PenguinMeetingKill = Create(1251, false, CustomOptionType.Impostor, "PenguinMeetingKill", false, PenguinOption);
+        PenguinMeetingKill = Create(1251, false, CustomOptionType.Impostor, "PenguinMeetingKill", true, PenguinOption);
 
         LoversBreakerOption = SetupCustomRoleOption(1132, false, RoleId.LoversBreaker);
         LoversBreakerPlayerCount = Create(1133, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], LoversBreakerOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -931,6 +931,7 @@ public class CustomOptionHolder
     public static CustomOption PenguinCoolTime;
     public static CustomOption PenguinDurationTime;
     public static CustomOption PenguinCanDefaultKill;
+    public static CustomOption PenguinMeetingKill;
 
     public static CustomRoleOption DependentsOption;
     public static CustomOption DependentsPlayerCount;
@@ -1910,6 +1911,7 @@ public class CustomOptionHolder
         PenguinCoolTime = Create(1088, false, CustomOptionType.Impostor, "NiceScientistCooldownSetting", 30f, 2.5f, 60f, 2.5f, PenguinOption, format: "unitSeconds");
         PenguinDurationTime = Create(1089, false, CustomOptionType.Impostor, "NiceScientistDurationSetting", 10f, 2.5f, 30f, 2.5f, PenguinOption, format: "unitSeconds");
         PenguinCanDefaultKill = Create(1090, false, CustomOptionType.Impostor, "PenguinCanDefaultKill", false, PenguinOption);
+        PenguinMeetingKill = Create(1251, false, CustomOptionType.Impostor, "PenguinMeetingKill", false, PenguinOption);
 
         LoversBreakerOption = SetupCustomRoleOption(1132, false, RoleId.LoversBreaker);
         LoversBreakerPlayerCount = Create(1133, false, CustomOptionType.Neutral, "SettingPlayerCountName", CrewPlayers[0], CrewPlayers[1], CrewPlayers[2], CrewPlayers[3], LoversBreakerOption);

--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -9,6 +9,7 @@ using HarmonyLib;
 using Hazel;
 using InnerNet;
 using Sentry;
+using SuperNewRoles.Buttons;
 using SuperNewRoles.CustomObject;
 using SuperNewRoles.Helpers;
 using SuperNewRoles.MapOption;
@@ -291,6 +292,7 @@ public enum CustomRPC
     SetOutfit,
     CreateShermansServant,
     SetVisible,
+    PenguinMeetingEnd,
 }
 
 public static class RPCProcedure
@@ -1461,6 +1463,13 @@ public static class RPCProcedure
         Seer.ShowFlash(new Color(42f / 255f, 187f / 255f, 245f / 255f));
     }
 
+    public static void PenguinMeetingEnd()
+    {
+        RoleClass.Penguin.PenguinData.Clear();
+        if (PlayerControl.LocalPlayer.GetRole() == RoleId.Penguin)
+            HudManagerStartPatch.PenguinButton.actionButton.cooldownTimerText.color = Palette.EnabledColor;
+    }
+
     public static void SetLoversBreakerWinner(byte playerid) => RoleClass.LoversBreaker.CanEndGamePlayers.Add(playerid);
 
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.HandleRpc))]
@@ -1809,6 +1818,9 @@ public static class RPCProcedure
                         break;
                     case CustomRPC.SetVisible:
                         SetVisible(reader.ReadByte(), reader.ReadBoolean());
+                        break;
+                    case CustomRPC.PenguinMeetingEnd:
+                        PenguinMeetingEnd();
                         break;
                 }
             }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1184,6 +1184,7 @@ PenguinName,Penguin,ペンギン,绑匪,綁匪
 PenguinTitle1,Let's drag and kill!,ぺちぺち！,绑架他人,綁架他人
 PenguinButtonName,Abduction,拉致,绑架,綁架
 PenguinCanDefaultKill,Can default kill,通常キルができる,绑匪可以进行通常击杀,綁匪可以進行通常擊殺
+PenguinMeetingKill,Kill when the meeting starts,能力発動中に会議が始まった場合キルをする
 LoversBreakerName,LoversBreaker,爆ぜ師,FFF团,現充爆破者
 LoversBreakerTitle1,fulfilling life explosion!!fulfilling life explosion!!,リア充爆発！！リア充爆発！！,现充去死！现充爆炸！,現充通通爆破吧！
 LoversBreakerBreakCount,Number of explosions needed to win,勝利に必要な爆破数,FFF团获胜所需击杀的恋人数,現充爆破者所需擊殺戀人數

--- a/SuperNewRoles/Roles/Impostor/Penguin.cs
+++ b/SuperNewRoles/Roles/Impostor/Penguin.cs
@@ -3,9 +3,11 @@ using HarmonyLib;
 using SuperNewRoles.Buttons;
 using SuperNewRoles.Mode;
 using SuperNewRoles.Roles.Crewmate;
+using SuperNewRoles.Helpers;
 
 namespace SuperNewRoles.Roles.Impostor;
 
+[HarmonyPatch]
 public static class Penguin
 {
     [HarmonyPatch(typeof(PlayerPhysics), nameof(PlayerPhysics.FixedUpdate))]
@@ -31,8 +33,7 @@ public static class Penguin
             if (data.Key == null || data.Value == null
                 || !data.Key.IsRole(RoleId.Penguin)
                 || data.Key.IsDead()
-                || data.Value.IsDead()
-                || RoleClass.IsMeeting)
+                || data.Value.IsDead())
             {
                 if (data.Key != null && data.Key.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
                 {
@@ -50,4 +51,22 @@ public static class Penguin
                 data.Value.transform.position = data.Key.transform.position;
         }
     }
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.ReportDeadBody))]
+    public static void Prefix(PlayerControl __instance)
+    {
+        if (!AmongUsClient.Instance.AmHost) return;
+        if (CustomOptionHolder.PenguinMeetingKill.GetBool())
+        {
+            foreach (var data in RoleClass.Penguin.PenguinData.ToArray())
+            {
+                ModHelpers.CheckMurderAttemptAndKill(data.Key, data.Value);
+            }
+        }
+        else
+        {
+            RPCHelper.StartRPC(CustomRPC.PenguinMeetingEnd).EndRPC();
+            RPCProcedure.PenguinMeetingEnd();
+        }
+    }
+
 }

--- a/SuperNewRoles/Roles/Impostor/Penguin.cs
+++ b/SuperNewRoles/Roles/Impostor/Penguin.cs
@@ -31,7 +31,8 @@ public static class Penguin
             if (data.Key == null || data.Value == null
                 || !data.Key.IsRole(RoleId.Penguin)
                 || data.Key.IsDead()
-                || data.Value.IsDead())
+                || data.Value.IsDead()
+                || RoleClass.IsMeeting)
             {
                 if (data.Key != null && data.Key.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
                 {


### PR DESCRIPTION
ペンギンの引き寄せ中に会議が始まると会議終了後も引き寄せているバグの修正

設定で会議に入ったらキルするかどうか決める
キルする場合
追放→キルアニメーションの手順
死体はでない