### PR TITLE
妖狐に飽和勝利の設定を追加

### DIFF
--- a/SuperNewRoles/Mode/CopsRobbers/CheckEndGame.cs
+++ b/SuperNewRoles/Mode/CopsRobbers/CheckEndGame.cs
@@ -21,6 +21,11 @@ public static class CheckEndGame
             GameManager.Instance.RpcEndGame(GameOverReason.ImpostorByKill, false);
             return false;
         }
+        else if (CustomOptionHolder.FoxCanHouwaWin.GetBool())
+        {
+            if (SuperHostRoles.EndGameCheck.CheckAndEndGameForFoxHouwaWin(__instance)) return false;
+            return false;
+        }
         else if (GameData.Instance.TotalTasks > 0 && GameData.Instance.TotalTasks <= GameData.Instance.CompletedTasks)
         {
             __instance.enabled = false;

--- a/SuperNewRoles/Mode/CopsRobbers/main.cs
+++ b/SuperNewRoles/Mode/CopsRobbers/main.cs
@@ -83,6 +83,8 @@ public static class Main
             GameManager.Instance.RpcEndGame(GameOverReason.HumansByTask, false);
             return true;
         }
+        else if (SuperHostRoles.EndGameCheck.CheckAndEndGameForFoxHouwaWin(__instance))
+            return false;
         else if (SuperHostRoles.EndGameCheck.CheckAndEndGameForWorkpersonWin(__instance))
             return false;
         else

--- a/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
@@ -242,11 +242,10 @@ class EndGameCheck
 
             if (p.IsImpostor()) impostorNum++;
             else if (p.IsCrew()) crewNum++;
-            else if (RoleClass.Fox.FoxPlayer.Contains(p) && p.IsAlive()) foxAlive = true;
+            else if (RoleClass.Fox.FoxPlayer.Contains(p) || FireFox.FireFoxPlayer.Contains(p)) foxAlive = true;
         }
-        if (!CustomOptionHolder.FoxCanHouwaWin.GetBool() || !foxAlive) return false;
 
-        if (impostorNum == crewNum) {
+        if (impostorNum == crewNum && foxAlive && CustomOptionHolder.FoxCanHouwaWin.GetBool()) {
             List<PlayerControl> foxPlayers = new(RoleClass.Fox.FoxPlayer);
             foxPlayers.AddRange(FireFox.FireFoxPlayer);
             foreach (PlayerControl p in foxPlayers) {

--- a/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
+++ b/SuperNewRoles/Mode/SuperHostRoles/EndGameCheck.cs
@@ -5,6 +5,7 @@ using Hazel;
 using SuperNewRoles.Helpers;
 using SuperNewRoles.Patches;
 using SuperNewRoles.Roles;
+using SuperNewRoles.Roles.Neutral;
 using static SuperNewRoles.Patches.CheckGameEndPatch;
 
 namespace SuperNewRoles.Mode.SuperHostRoles;
@@ -19,6 +20,7 @@ class EndGameCheck
         if (CheckAndEndGameForJackalWin(__instance, statistics)) return false;
         if (CheckAndEndGameForSabotageWin(__instance)) return false;
         if (CheckAndEndGameForWorkpersonWin(__instance)) return false;
+        if (CustomOptionHolder.FoxCanHouwaWin.GetBool() && CheckAndEndGameForFoxHouwaWin(__instance)) return false;
         return false;
     }
     public static bool CheckEndGameHnSs(ShipStatus __instance, PlayerStatistics statistics)
@@ -227,6 +229,43 @@ class EndGameCheck
                 }
             }
         }
+        return false;
+    }
+    public static bool CheckAndEndGameForFoxHouwaWin(ShipStatus __instance)
+    {
+        int impostorNum = 0;
+        int crewNum = 0;
+        bool foxAlive = false;
+        foreach (PlayerControl p in CachedPlayer.AllPlayers)
+        {
+            if (p.IsDead() || p.Data.Disconnected || p == null) continue;
+
+            if (p.IsImpostor()) impostorNum++;
+            else if (p.IsCrew()) crewNum++;
+            else if (RoleClass.Fox.FoxPlayer.Contains(p) && p.IsAlive()) foxAlive = true;
+        }
+        if (!CustomOptionHolder.FoxCanHouwaWin.GetBool() || !foxAlive) return false;
+
+        if (impostorNum == crewNum) {
+            List<PlayerControl> foxPlayers = new(RoleClass.Fox.FoxPlayer);
+            foxPlayers.AddRange(FireFox.FireFoxPlayer);
+            foreach (PlayerControl p in foxPlayers) {
+                if (p.IsDead()) continue;
+                MessageWriter Writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.ShareWinner, SendOption.Reliable, -1);
+                Writer.Write(p.PlayerId);
+                AmongUsClient.Instance.FinishRpcImmediately(Writer);
+                RPCProcedure.ShareWinner(p.PlayerId);
+
+                Writer = RPCHelper.StartRPC(CustomRPC.SetWinCond);
+                Writer.Write((byte)CustomGameOverReason.FoxWin);
+                Writer.EndRPC();
+                RPCProcedure.SetWinCond((byte)CustomGameOverReason.FoxWin);
+
+                __instance.enabled = false;
+                CustomEndGame(__instance, (GameOverReason)CustomGameOverReason.FoxWin, false);
+            }
+            return true;
+        };
         return false;
     }
     public static void EndGameForSabotage(ShipStatus __instance)

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -487,6 +487,7 @@ public class CustomOptionHolder
     public static CustomOption FoxIsUseVent;
     public static CustomOption FoxIsImpostorLight;
     public static CustomOption FoxReport;
+    public static CustomOption FoxCanHouwaWin;
 
     public static CustomRoleOption DarkKillerOption;
     public static CustomOption DarkKillerPlayerCount;
@@ -1484,6 +1485,7 @@ public class CustomOptionHolder
         FoxIsUseVent = Create(312, true, CustomOptionType.Neutral, "MadmateUseVentSetting", false, FoxOption);
         FoxIsImpostorLight = Create(313, true, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, FoxOption);
         FoxReport = Create(314, true, CustomOptionType.Neutral, "MinimalistReportSetting", true, FoxOption);
+        FoxCanHouwaWin = Create(1024, true, CustomOptionType.Neutral, "CanHouwaWin", true, FoxOption);
 
         DarkKillerOption = SetupCustomRoleOption(315, true, RoleId.DarkKiller);
         DarkKillerPlayerCount = Create(316, true, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], DarkKillerOption);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1485,7 +1485,7 @@ public class CustomOptionHolder
         FoxIsUseVent = Create(312, true, CustomOptionType.Neutral, "MadmateUseVentSetting", false, FoxOption);
         FoxIsImpostorLight = Create(313, true, CustomOptionType.Neutral, "MadmateImpostorLightSetting", false, FoxOption);
         FoxReport = Create(314, true, CustomOptionType.Neutral, "MinimalistReportSetting", true, FoxOption);
-        FoxCanHouwaWin = Create(1024, true, CustomOptionType.Neutral, "CanHouwaWin", true, FoxOption);
+        FoxCanHouwaWin = Create(1024, true, CustomOptionType.Neutral, "CanHouwaWin", false, FoxOption);
 
         DarkKillerOption = SetupCustomRoleOption(315, true, RoleId.DarkKiller);
         DarkKillerPlayerCount = Create(316, true, CustomOptionType.Impostor, "SettingPlayerCountName", ImpostorPlayers[0], ImpostorPlayers[1], ImpostorPlayers[2], ImpostorPlayers[3], DarkKillerOption);

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -1613,11 +1613,10 @@ public static class CheckGameEndPatch
 
             if (p.IsImpostor()) impostorNum++;
             else if (p.IsCrew()) crewNum++;
-            else if (RoleClass.Fox.FoxPlayer.Contains(p) && p.IsAlive()) foxAlive = true;
+            else if (RoleClass.Fox.FoxPlayer.Contains(p) || FireFox.FireFoxPlayer.Contains(p)) foxAlive = true;
         }
-        if (!CustomOptionHolder.FoxCanHouwaWin.GetBool() || !foxAlive) return false;
 
-        if (impostorNum == crewNum) {
+        if (impostorNum == crewNum && foxAlive && CustomOptionHolder.FoxCanHouwaWin.GetBool()) {
             List<PlayerControl> foxPlayers = new(RoleClass.Fox.FoxPlayer);
             foxPlayers.AddRange(FireFox.FireFoxPlayer);
             foreach (PlayerControl p in foxPlayers) {

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -820,6 +820,7 @@ DarkKillerTitle1,Let's kill in the dark,闇に紛れて殺そう,将你的杀戮
 DarkKillerKillCoolSetting,Dark Killer's Kill Cool Time,ダークキラーのキルクールタイム,暗夜杀手击杀冷却,暗影殺手擊殺冷卻時間
 FoxName,Fox,妖狐,妖狐,狐妖
 FoxTitle1,I am Fox!,私は狐です!,我是一只小狐狸！,我是一隻小狐狸！
+CanHouwaWin,Fox can win on stalemate,飽和勝利が可能
 SeerName,Seer,シーア,灵媒,先知
 SeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n取得した情報を用いてインポスターを特定しましょう。,灵媒属于船员阵营，可以获知死亡时间与死亡场所，来获取与死亡有关的情报。\n灵媒需要利用手中的情报来确认内鬼。,先知屬於船員陣營，可以獲知死亡時間與死亡場所，來獲取與死亡有關的情報。\n先知需要利用手中的情報來確認內鬼。,
 SeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡,你能感知死亡


### PR DESCRIPTION
# 仕様
- 狐及び炎狐が生存している状態でインポスターとクルーの人数が同数になった際、飽和状態として妖狐勝利になる

<details>
<summary> 映像、スクショ </summary>

![0](https://user-images.githubusercontent.com/102277752/230770655-7472404d-8983-42c0-ab70-c85cc90be4d2.png)

https://user-images.githubusercontent.com/102277752/230770701-0a5e6cca-c052-4c2a-917e-f7b8a667fb85.mp4

https://user-images.githubusercontent.com/102277752/230770704-a1fd90fa-e302-46b2-8a18-be9fded5a2ec.mp4

</details>

SHR、デフォルトモードにて正常動作確認済です

