### PR TITLE
SHR🏇モードを封印していたコードを削除

### DIFF
--- a/SuperNewRoles/Patches/HorseModePatch.cs
+++ b/SuperNewRoles/Patches/HorseModePatch.cs
@@ -9,48 +9,41 @@ namespace SuperNewRoles.Patches;
 [HarmonyPatch(typeof(MainMenuManager), nameof(MainMenuManager.Start))]
 public class MainMenuPatch
 {
-    public static bool BeforeAprilR5() => DateTime.UtcNow <= new DateTime(2023, 3, 31, 15, 0, 0, 0, DateTimeKind.Utc);
     private static bool horseButtonState = HorseModeOption.enableHorseMode;
     private static Sprite horseModeOffSprite = null;
 
     private static void Prefix()
     {
         var bottomTemplate = GameObject.Find("InventoryButton");
+        // Horse mode stuff
+        var horseModeSelectionBehavior = new ClientModOptionsPatch.SelectionBehaviour("Enable Horse Mode", () => HorseModeOption.enableHorseMode = ConfigRoles.EnableHorseMode.Value = !ConfigRoles.EnableHorseMode.Value, ConfigRoles.EnableHorseMode.Value);
 
-        //FIXME:[SHRモードを一時封印] #1100 mergeをリバートしてください
-        if (!BeforeAprilR5())
+        if (bottomTemplate == null) return;
+        var horseButton = Object.Instantiate(bottomTemplate, bottomTemplate.transform.parent);
+        var passiveHorseButton = horseButton.GetComponent<PassiveButton>();
+        var spriteHorseButton = horseButton.GetComponent<SpriteRenderer>();
+
+        horseModeOffSprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.HorseModeButtonOff.png", 75f);
+
+        spriteHorseButton.sprite = horseModeOffSprite;
+
+        passiveHorseButton.OnClick = new ButtonClickedEvent();
+
+        passiveHorseButton.OnClick.AddListener((UnityEngine.Events.UnityAction)delegate
         {
-            // Horse mode stuff
-            var horseModeSelectionBehavior = new ClientModOptionsPatch.SelectionBehaviour("Enable Horse Mode", () => HorseModeOption.enableHorseMode = ConfigRoles.EnableHorseMode.Value = !ConfigRoles.EnableHorseMode.Value, ConfigRoles.EnableHorseMode.Value);
-
-            if (bottomTemplate == null) return;
-            var horseButton = Object.Instantiate(bottomTemplate, bottomTemplate.transform.parent);
-            var passiveHorseButton = horseButton.GetComponent<PassiveButton>();
-            var spriteHorseButton = horseButton.GetComponent<SpriteRenderer>();
-
-            horseModeOffSprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.HorseModeButtonOff.png", 75f);
-
+            horseButtonState = horseModeSelectionBehavior.OnClick();
+            if (horseModeOffSprite == null) horseModeOffSprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.HorseModeButtonOff.png", 75f);
             spriteHorseButton.sprite = horseModeOffSprite;
-
-            passiveHorseButton.OnClick = new ButtonClickedEvent();
-
-            passiveHorseButton.OnClick.AddListener((UnityEngine.Events.UnityAction)delegate
+            spriteHorseButton.transform.localScale *= -1;
+            CredentialsPatch.LogoPatch.UpdateSprite();
+            // Avoid wrong Player Particles floating around in the background
+            var particles = GameObject.FindObjectOfType<PlayerParticles>();
+            if (particles != null)
             {
-                horseButtonState = horseModeSelectionBehavior.OnClick();
-                if (horseModeOffSprite == null) horseModeOffSprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.HorseModeButtonOff.png", 75f);
-                spriteHorseButton.sprite = horseModeOffSprite;
-                spriteHorseButton.transform.localScale *= -1;
-                CredentialsPatch.LogoPatch.UpdateSprite();
-                // Avoid wrong Player Particles floating around in the background
-                var particles = GameObject.FindObjectOfType<PlayerParticles>();
-                if (particles != null)
-                {
-                    particles.pool.ReclaimAll();
-                    particles.Start();
-                }
-            });
-        }
-
+                particles.pool.ReclaimAll();
+                particles.Start();
+            }
+        });
 
         var CreditsButton = Object.Instantiate(bottomTemplate, bottomTemplate.transform.parent);
         var passiveCreditsButton = CreditsButton.GetComponent<PassiveButton>();

--- a/SuperNewRoles/Patches/IntroPatch.cs
+++ b/SuperNewRoles/Patches/IntroPatch.cs
@@ -22,8 +22,8 @@ public static class ShouldAlwaysHorseAround
         if (isHorseMode != HorseModeOption.enableHorseMode && LobbyBehaviour.Instance != null) __result = isHorseMode;
         else
         {
-            __result = !MainMenuPatch.BeforeAprilR5() && HorseModeOption.enableHorseMode;
-            isHorseMode = !MainMenuPatch.BeforeAprilR5() && HorseModeOption.enableHorseMode;
+            __result = HorseModeOption.enableHorseMode;
+            isHorseMode = HorseModeOption.enableHorseMode;
         }
         return;
     }


### PR DESCRIPTION
- #1100 をリバートしなかった理由は、「公式が🏇なら強制的にSHR🏇反映」のコードは残した方が良いと思ったからです。
- (　・ω・) { 公式又馬やるやろ )