### PR TITLE
死亡時役職を確認できる設定が正常に動いていない問題を修正 ( 設定方法の変更によるバグ修正 )

### DIFF
--- a/SuperNewRoles/Mode/PlusMode/PlusGameOptions.cs
+++ b/SuperNewRoles/Mode/PlusMode/PlusGameOptions.cs
@@ -9,7 +9,7 @@ class PlusGameOptions
 {
     public static CustomOption PlusGameOptionSetting;
 
-    public static CustomOption CanGhostSeeRole;
+    public static CustomOption CanNotGhostSeeRole;
     public static CustomOption OnlyImpostorGhostSeeRole;
 
     public static CustomOption CanGhostSeeVote;
@@ -39,8 +39,8 @@ class PlusGameOptions
     {
         PlusGameOptionSetting = Create(508, true, CustomOptionType.Generic, Cs(new Color(168f / 187f, 191f / 255f, 147f / 255f, 1f), "PlusGameOptionSetting"), false, null, isHeader: true);
 
-        CanGhostSeeRole = Create(1100, true, CustomOptionType.Generic, "CanGhostSeeRole", true, PlusGameOptionSetting, isHeader: true);
-        OnlyImpostorGhostSeeRole = Create(1101, true, CustomOptionType.Generic, "OnlyImpostorGhostSeeRole", false, CanGhostSeeRole);
+        CanNotGhostSeeRole = Create(1100, true, CustomOptionType.Generic, "CanNotGhostSeeRole", false, PlusGameOptionSetting, isHeader: true);
+        OnlyImpostorGhostSeeRole = Create(1101, true, CustomOptionType.Generic, "OnlyImpostorGhostSeeRole", false, CanNotGhostSeeRole);
 
         CanGhostSeeVote = Create(1144, true, CustomOptionType.Generic, "CanGhostSeeVote", true, PlusGameOptionSetting, isHeader: true);
 

--- a/SuperNewRoles/Modules/SetNames.cs
+++ b/SuperNewRoles/Modules/SetNames.cs
@@ -214,11 +214,9 @@ public class SetNamesClass
             if (!Mode.PlusMode.PlusGameOptions.PlusGameOptionSetting.GetBool()) return true;
             else
             {
-                if (Mode.PlusMode.PlusGameOptions.CanGhostSeeRole.GetBool()) // 「死亡者が全員の役職を確認できる」設定が有効で、
-                {
-                    if (!Mode.PlusMode.PlusGameOptions.OnlyImpostorGhostSeeRole.GetBool()) return true; // 「死亡したインポスターのみが役職を見れる設定」が無効であれば trueを返す。
-                    else return target.IsImpostor(); // 「死亡したインポスターのみが役職を見れる設定」が有効な場合, targetがインポスターならtrueを そうではない場合 falseを返す。                }
-                }
+                if (!Mode.PlusMode.PlusGameOptions.CanNotGhostSeeRole.GetBool()) return true; // 「死亡時に他プレイヤーの役職を表示しない」設定が無効な時
+                // この設定は、上記bool判定の子Optionである為、上記true時（親Option無効時）取得しない設定。
+                else if (Mode.PlusMode.PlusGameOptions.OnlyImpostorGhostSeeRole.GetBool()) return target.IsImpostor();
             }
         }
         return false; // 上記[役職が確認できる]条件を満たさなかった場合falseを返す。

--- a/SuperNewRoles/Modules/SetNames.cs
+++ b/SuperNewRoles/Modules/SetNames.cs
@@ -214,12 +214,16 @@ public class SetNamesClass
             if (!Mode.PlusMode.PlusGameOptions.PlusGameOptionSetting.GetBool()) return true;
             else
             {
-                if (Mode.PlusMode.PlusGameOptions.CanGhostSeeRole.GetBool()) return true;
-                else if (!Mode.PlusMode.PlusGameOptions.OnlyImpostorGhostSeeRole.GetBool() || target.IsImpostor()) return true;
+                if (Mode.PlusMode.PlusGameOptions.CanGhostSeeRole.GetBool()) // 「死亡者が全員の役職を確認できる」設定が有効で、
+                {
+                    if (!Mode.PlusMode.PlusGameOptions.OnlyImpostorGhostSeeRole.GetBool()) return true; // 「死亡したインポスターのみが役職を見れる設定」が無効であれば trueを返す。
+                    else return target.IsImpostor(); // 「死亡したインポスターのみが役職を見れる設定」が有効な場合, targetがインポスターならtrueを そうではない場合 falseを返す。                }
+                }
             }
         }
-        return false;
+        return false; // 上記[役職が確認できる]条件を満たさなかった場合falseを返す。
     }
+
     public static void SetPlayerNameColors(PlayerControl player)
     {
         var role = player.GetRole();

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -221,9 +221,9 @@ RestrictDevicesTimeOption,Time limit setting,時間制限の設定,,時間限制
 RestrictAdmin,Restrict Admin,アドミンの時間制限,管理地图使用时间限制,管理員地圖時間限制
 RestrictVital,Restrict Vital,バイタルの時間制限,生命监测装置使用时间限制,生命跡象檢測器時間限制
 RestrictCamera,Restrict Camera,カメラの時間制限,监控使用时间限制,監視器時間限制
-CanGhostSeeRole,After death，everyone's role can be confirmed.,死亡者が全員の役職を確認できる,死亡玩家能确认所有玩家的职业,死亡玩家能確認所有玩家的職業
+CanNotGhostSeeRole,When a player dies，the role of other players is not displayed.,死亡時に他プレイヤーの役職を表示しない
+OnlyImpostorGhostSeeRole,Impostors display the roles of other players.,インポスターは死亡時に他プレイヤーの役職を表示する
 CanGhostSeeVote,After death，everyone's voting address can be confirmed.,死亡者が全員の投票先を確認できる,死亡玩家能确认所有玩家的职业,死亡玩家能確認所有玩家的投票
-OnlyImpostorGhostSeeRole,,死亡しているインポスターのみが全員の役職を確認できる,只有死亡的内鬼阵营玩家可以确认所有玩家的职业,只有死亡的內鬼陣營玩家能確認所有玩家的職業
 AntiTaskOverWallSetting,Cannot tasks over the wall.,壁越しにタスクをできない,禁止隔墙做任务,禁止隔牆做任務
 ShuffleElectricalDoorsSetting,Shuffle electrical doors after meeting,会議後に電気室のドアをシャッフルする,飞艇地图配电室门的开关在会议后重新分配,AirShip地圖配電室門的開關會在會議結束後重新配置
 


### PR DESCRIPTION
# [修正点]
- 死亡時役職を確認できる設定が正常に動いていない問題を修正
  - [死亡者が全員の役職を確認できる]設定有効時、[内部設定 : 死亡しているインポスターのみが全員の役職を確認できる]設定が働いている状態だった。

# [変更点]
- [死亡者が全員の役職を確認できる]設定を[死亡時に他プレイヤーの役職を表示しない] 設定に変更。
  - (デフォルトを[ゲーム オプション]無効時のデフォルトである「死亡者が全員の役職を確認できる」状態と置く)
  - 設定オンの意味が、デフォルト状態をオフにする設定ではなく、
  デフォルト状態に戻す設定になっていて理解しにくかった問題をこの変更により修正した。
    - そもそもこのバグこの設定のややこしさで生まれた物でした...()
    設定の並び替え、設定の依存先(親Option)の変更時に、設定の意図を読み取れずバグを発生させていました。
