### PR TITLE
バニラバグのペットによる死亡位置透けバグに対応&生死の状態に関わらず死亡時の処理を動かしていた問題を修正

### DIFF
--- a/SuperNewRoles/Buttons/Buttons.cs
+++ b/SuperNewRoles/Buttons/Buttons.cs
@@ -439,6 +439,7 @@ static class HudManagerStartPatch
                 ModHelpers.CheckMurderAttemptAndKill(PlayerControl.LocalPlayer, target);
                 PavlovsdogKillButton.MaxTimer = RoleClass.Pavlovsdogs.IsOwnerDead ? CustomOptionHolder.PavlovsdogRunAwayKillCoolTime.GetFloat() : CustomOptionHolder.PavlovsdogKillCoolTime.GetFloat();
                 PavlovsdogKillButton.Timer = PavlovsdogKillButton.MaxTimer;
+                if (target.IsRole(RoleId.Fox) && RoleClass.Fox.Killer.ContainsKey(PlayerControl.LocalPlayer.PlayerId)) return;
                 RoleClass.Pavlovsdogs.DeathTime = CustomOptionHolder.PavlovsdogRunAwayDeathTime.GetFloat();
             },
             (bool isAlive, RoleId role) => { return isAlive && role == RoleId.Pavlovsdogs; },

--- a/SuperNewRoles/Modules/DeadPlayer.cs
+++ b/SuperNewRoles/Modules/DeadPlayer.cs
@@ -6,6 +6,7 @@ namespace SuperNewRoles.Modules;
 public class DeadPlayer
 {
     public static List<DeadPlayer> deadPlayers = new();
+    public static Dictionary<byte, (DateTime, PlayerControl)> ActualDeathTime;
     public PlayerControl player;
     public byte playerId;
     public DateTime timeOfDeath;
@@ -21,5 +22,11 @@ public class DeadPlayer
         this.deathReason = deathReason;
         this.killerIfExisting = killerIfExisting;
         if (killerIfExisting != null) killerIfExistingId = killerIfExisting.PlayerId;
+    }
+
+    internal static void ClearAndReloads()
+    {
+        deadPlayers = new();
+        ActualDeathTime = new();
     }
 }

--- a/SuperNewRoles/Patches/EndGamePatch.cs
+++ b/SuperNewRoles/Patches/EndGamePatch.cs
@@ -526,9 +526,6 @@ public static class OnGameEndPatch
                             : gameOverReason == GameOverReason.ImpostorBySabotage && !p.Role.IsImpostor
                                 ? FinalStatus.Sabotage
                                 : FinalStatus.Alive;
-                // FIXME:守護天使の能力でのガード時、キルが起きた(MurderPlayerが通った)判定になる。このコードは根本的な修正ではないうえに、問題をマスキングしている。
-                // 妖狐やFastMakerのMK等、守護が発動した場合、死亡していなくとも[死因:キル]が記載される為、生きている場合は生存で上書きする。
-                if (!p.IsDead) finalStatus = FinalStatus.Alive;
 
                 string namesuffix = "";
                 if (p.Object.IsLovers())

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1072,7 +1072,7 @@ public static class MurderPlayerPatch
         DeadPlayer.deadPlayers.Add(deadPlayer);
         FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.Kill;
 
-        DyingMessenger.ActualDeathTime[target.PlayerId] = (DateTime.Now, __instance); // [ ]MEMO : DyingMessenger.csからDeadPlayer.csに移動
+        DeadPlayer.ActualDeathTime[target.PlayerId] = (DateTime.Now, __instance);
 
         if (IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())
         {
@@ -1333,14 +1333,14 @@ class ReportDeadBodyPatch
                     __instance.SetRoleRPC(target.Object.GetRole());
                 }
             }
-            if (__instance.IsRole(RoleId.DyingMessenger) && target != null && DyingMessenger.ActualDeathTime.ContainsKey(target.PlayerId))
+            if (__instance.IsRole(RoleId.DyingMessenger) && target != null && DeadPlayer.ActualDeathTime.ContainsKey(target.PlayerId))
             {
-                bool isGetRole = (float)(DyingMessenger.ActualDeathTime[target.PlayerId].Item1 + new TimeSpan(0, 0, 0, DyingMessenger.DyingMessengerGetRoleTime.GetInt()) - DateTime.Now).TotalSeconds >= 0;
-                bool isGetLightAndDarker = (float)(DyingMessenger.ActualDeathTime[target.PlayerId].Item1 + new TimeSpan(0, 0, 0, DyingMessenger.DyingMessengerGetLightAndDarkerTime.GetInt()) - DateTime.Now).TotalSeconds >= 0;
+                bool isGetRole = (float)(DeadPlayer.ActualDeathTime[target.PlayerId].Item1 + new TimeSpan(0, 0, 0, DyingMessenger.DyingMessengerGetRoleTime.GetInt()) - DateTime.Now).TotalSeconds >= 0;
+                bool isGetLightAndDarker = (float)(DeadPlayer.ActualDeathTime[target.PlayerId].Item1 + new TimeSpan(0, 0, 0, DyingMessenger.DyingMessengerGetLightAndDarkerTime.GetInt()) - DateTime.Now).TotalSeconds >= 0;
                 string firstPerson = IsSucsessChance(9) ? ModTranslation.GetString("DyingMessengerFirstPerson1") : ModTranslation.GetString("DyingMessengerFirstPerson2");
                 if (isGetRole)
                 {
-                    string text = string.Format(ModTranslation.GetString("DyingMessengerGetRoleText"), firstPerson, ModTranslation.GetString($"{DyingMessenger.ActualDeathTime[target.PlayerId].Item2.GetRole()}Name"));
+                    string text = string.Format(ModTranslation.GetString("DyingMessengerGetRoleText"), firstPerson, ModTranslation.GetString($"{DeadPlayer.ActualDeathTime[target.PlayerId].Item2.GetRole()}Name"));
                     new LateTask(() =>
                     {
                         MessageWriter writer = RPCHelper.StartRPC(CustomRPC.Chat, __instance);
@@ -1352,7 +1352,7 @@ class ReportDeadBodyPatch
                 if (isGetLightAndDarker)
                 {
                     string text = string.Format(ModTranslation.GetString("DyingMessengerGetLightAndDarkerText"), firstPerson,
-                        CustomColors.lighterColors.Contains(DyingMessenger.ActualDeathTime[target.PlayerId].Item2.Data.DefaultOutfit.ColorId) ? ModTranslation.GetString("LightColor") : ModTranslation.GetString("DarkerColor"));
+                        CustomColors.lighterColors.Contains(DeadPlayer.ActualDeathTime[target.PlayerId].Item2.Data.DefaultOutfit.ColorId) ? ModTranslation.GetString("LightColor") : ModTranslation.GetString("DarkerColor"));
                     new LateTask(() =>
                     {
                         MessageWriter writer = RPCHelper.StartRPC(CustomRPC.Chat, __instance);

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1000,6 +1000,12 @@ public static class MurderPlayerPatch
         // SuperNewRolesPlugin.Logger.LogInfo("MurderPlayer発生！元:" + __instance.GetDefaultName() + "、ターゲット:" + target.GetDefaultName());
         // Collect dead player info
         Logger.Info("追加");
+        Logger.Info($"prefix : {target.IsDead()}");
+        if (target.IsDead())
+        {
+            target.RpcSetPet("peet_EmptyPet");
+            Logger.Info($"{target.name}が死亡した為, Petを外しました。");
+        }
         DeadPlayer deadPlayer = new(target, target.PlayerId, DateTime.UtcNow, DeathReason.Kill, __instance);
         DeadPlayer.deadPlayers.Add(deadPlayer);
         FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.Kill;

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1032,8 +1032,6 @@ public static class MurderPlayerPatch
 
         if (ModeHandler.IsMode(ModeId.Default))
         {
-            Levelinger.MurderPlayer(__instance, target); // [ ]MEMO:要仕様調整
-
             Minimalist.MurderPatch.Postfix(__instance);
 
             Vampire.OnMurderPlayer(__instance, target); // ヴァンパイアと眷属のキルクール同期の為 対象の死亡状態にかかわらず呼び出す
@@ -1094,6 +1092,8 @@ public static class MurderPlayerPatch
         }
         else if (ModeHandler.IsMode(ModeId.Default))
         {
+            Levelinger.MurderPlayer(__instance, target);
+
             if (RoleClass.Camouflager.IsCamouflage)
             {
                 PlayerOutfit outfit = new()

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -1016,7 +1016,11 @@ public static class MurderPlayerPatch
             }
         }
 
-        SerialKiller.MurderPlayer(__instance, target); // [ ]MEMO:要仕様確認
+        // FIXME:狐キル時にはキルクールリセットが発生しないようにして, この処理は死体が発生した時の処理にしたい。
+        SerialKiller.MurderPlayer(__instance, target);
+        if (target.IsRole(RoleId.Fox) && !RoleClass.Fox.Killer.ContainsKey(__instance.PlayerId))
+            RoleClass.Fox.Killer.Add(__instance.PlayerId, true);
+
 
         if (IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())
         {

--- a/SuperNewRoles/Patches/PlayerControlPatch.cs
+++ b/SuperNewRoles/Patches/PlayerControlPatch.cs
@@ -935,7 +935,6 @@ public static class MurderPlayerPatch
         }
         EvilGambler.MurderPlayerPrefix(__instance, target);
         Doppelganger.KillCoolSetting.SHRMurderPlayer(__instance, target);
-        DyingMessenger.ActualDeathTime[target.PlayerId] = (DateTime.Now, __instance);
         if (ModeHandler.IsMode(ModeId.Default))
         {
             target.resetChange();
@@ -997,20 +996,11 @@ public static class MurderPlayerPatch
     }
     public static void Postfix(PlayerControl __instance, [HarmonyArgument(0)] PlayerControl target)
     {
+        // |:===== targetが生存している場合にも発生させる処理 =====:|
         // SuperNewRolesPlugin.Logger.LogInfo("MurderPlayer発生！元:" + __instance.GetDefaultName() + "、ターゲット:" + target.GetDefaultName());
         // Collect dead player info
-        Logger.Info("追加");
-        Logger.Info($"prefix : {target.IsDead()}");
-        if (target.IsDead())
-        {
-            target.RpcSetPet("peet_EmptyPet");
-            Logger.Info($"{target.name}が死亡した為, Petを外しました。");
-        }
-        DeadPlayer deadPlayer = new(target, target.PlayerId, DateTime.UtcNow, DeathReason.Kill, __instance);
-        DeadPlayer.deadPlayers.Add(deadPlayer);
-        FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.Kill;
-        __instance.OnKill(target);
-        target.OnDeath(__instance);
+
+        __instance.OnKill(target); // 使われるようになった時に要仕様調整
 
         if (CachedPlayer.LocalPlayer.PlayerId == __instance.PlayerId)
         {
@@ -1026,14 +1016,73 @@ public static class MurderPlayerPatch
             }
         }
 
-        SerialKiller.MurderPlayer(__instance, target);
-        Seer.WrapUpPatch.MurderPlayerPatch.Postfix(target);
+        SerialKiller.MurderPlayer(__instance, target); // [ ]MEMO:要仕様確認
+
         if (IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())
         {
             new CustomMessage("MurderPlayerが発生しました", 5f);
             Logger.Info("MurderPlayerが発生しました", "DebugMode");
         }
-        Roles.Crewmate.KnightProtected_Patch.MurderPlayerPatch.Postfix(target);
+
+        KnightProtected_Patch.MurderPlayerPatch.Postfix(target);
+
+        if (ModeHandler.IsMode(ModeId.Default))
+        {
+            Levelinger.MurderPlayer(__instance, target); // [ ]MEMO:要仕様調整
+
+            Minimalist.MurderPatch.Postfix(__instance);
+
+            Vampire.OnMurderPlayer(__instance, target); // ヴァンパイアと眷属のキルクール同期の為 対象の死亡状態にかかわらず呼び出す
+
+            if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
+            {
+                if (Squid.Abilitys.IsKillGuard)
+                {
+                    PlayerControl.LocalPlayer.SetKillTimerUnchecked(Squid.SquidNotKillTime.GetFloat(), Squid.SquidNotKillTime.GetFloat());
+                    Squid.SetKillTimer(Squid.SquidNotKillTime.GetFloat());
+                    Squid.Abilitys.IsKillGuard = false;
+                }
+
+                if (__instance.IsImpostor())
+                    PlayerControl.LocalPlayer.SetKillTimerUnchecked(RoleHelpers.GetCoolTime(__instance), RoleHelpers.GetCoolTime(__instance));
+
+                if (PlayerControl.LocalPlayer.IsRole(RoleId.Slugger)) // キルクリセット処理
+                {
+                    if (CustomOptionHolder.SluggerIsKillCoolSync.GetBool())
+                    {
+                        HudManagerStartPatch.SluggerButton.MaxTimer = CustomOptionHolder.SluggerCoolTime.GetFloat();
+                        HudManagerStartPatch.SluggerButton.Timer = HudManagerStartPatch.SluggerButton.MaxTimer;
+                    }
+                }
+
+                EvilGambler.MurderPlayerPostfix(__instance); // キルクリセット処理
+
+                Doppelganger.KillCoolSetting.MurderPlayer(__instance, target); // キルクリセット処理
+            }
+        }
+
+        // |:===== 以下targetが生存している場合には発生させない処理 =====:|
+        if (target.IsAlive()) return;
+
+        target.RpcSetPet("peet_EmptyPet");
+        Logger.Info($"{target.name}が死亡した為, Petを外しました。");
+
+        Logger.Info("死亡者リストに追加");
+        DeadPlayer deadPlayer = new(target, target.PlayerId, DateTime.UtcNow, DeathReason.Kill, __instance);
+        DeadPlayer.deadPlayers.Add(deadPlayer);
+        FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.Kill;
+
+        DyingMessenger.ActualDeathTime[target.PlayerId] = (DateTime.Now, __instance); // [ ]MEMO : DyingMessenger.csからDeadPlayer.csに移動
+
+        if (IsDebugMode() && CustomOptionHolder.IsMurderPlayerAnnounce.GetBool())
+        {
+            new CustomMessage("\n死者が発生しました", 5f);
+            Logger.Info("死者が発生しました", "DebugMode");
+        }
+
+        target.OnDeath(__instance);
+
+        Seer.WrapUpPatch.MurderPlayerPatch.Postfix(target);
 
         if (ModeHandler.IsMode(ModeId.SuperHostRoles))
         {
@@ -1062,26 +1111,7 @@ public static class MurderPlayerPatch
                     }
                 }
             }
-            if (target.IsRole(RoleId.Speeder))
-            {
-                if (RoleClass.Speeder.IsSpeedDown) Speeder.SpeedDownEnd();
-            }
-            else if (target.IsRole(RoleId.Clergyman))
-            {
-                RPCProcedure.RPCClergymanLightOut(false);
-            }
-            if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && PlayerControl.LocalPlayer.IsRole(RoleId.Finder))
-            {
-                RoleClass.Finder.KillCount++;
-            }
-            if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && PlayerControl.LocalPlayer.IsRole(RoleId.Slugger))
-            {
-                if (CustomOptionHolder.SluggerIsKillCoolSync.GetBool())
-                {
-                    HudManagerStartPatch.SluggerButton.MaxTimer = CustomOptionHolder.SluggerCoolTime.GetFloat();
-                    HudManagerStartPatch.SluggerButton.Timer = HudManagerStartPatch.SluggerButton.MaxTimer;
-                }
-            }
+
             if (target.IsRole(RoleId.NiceMechanic, RoleId.EvilMechanic) && target.PlayerId == PlayerControl.LocalPlayer.PlayerId)
             {
                 if (NiceMechanic.TargetVent.ContainsKey(target.PlayerId) || NiceMechanic.TargetVent[target.PlayerId] is not null)
@@ -1090,6 +1120,19 @@ public static class MurderPlayerPatch
                     NiceMechanic.RpcSetVentStatusMechanic(PlayerControl.LocalPlayer, NiceMechanic.TargetVent[target.PlayerId], false, new(truepos.x, truepos.y, truepos.z + 0.0025f));
                 }
             }
+
+            if (target.IsRole(RoleId.Speeder))
+            {
+                if (RoleClass.Speeder.IsSpeedDown) Speeder.SpeedDownEnd();
+            }
+            else if (target.IsRole(RoleId.Clergyman))
+            {
+                RPCProcedure.RPCClergymanLightOut(false);
+            }
+
+            if (PlayerControl.LocalPlayer.IsRole(RoleId.Finder))
+                RoleClass.Finder.KillCount++;
+
             if (__instance.IsRole(RoleId.OverKiller))
             {
                 FinalStatusPatch.FinalStatusData.FinalStatuses[target.PlayerId] = FinalStatus.OverKillerOverKill;
@@ -1105,6 +1148,7 @@ public static class MurderPlayerPatch
                     deadBody.transform.position = position;
                 }
             }
+
             if (target.IsRole(RoleId.Jumbo))
             {
                 DeadBody[] array = UnityEngine.Object.FindObjectsOfType<DeadBody>();
@@ -1117,7 +1161,7 @@ public static class MurderPlayerPatch
                     }
                 }
             }
-            if (PlayerControl.LocalPlayer.IsRole(RoleId.Painter) && RoleClass.Painter.CurrentTarget != null && RoleClass.Painter.CurrentTarget.PlayerId == target.PlayerId) Roles.Crewmate.Painter.Handle(Roles.Crewmate.Painter.ActionType.Death);
+
             if (target.IsRole(RoleId.Assassin))
             {
                 target.Revive();
@@ -1135,44 +1179,28 @@ public static class MurderPlayerPatch
                 RoleClass.Assassin.TriggerPlayer = target;
                 return;
             }
+
+            if (PlayerControl.LocalPlayer.IsRole(RoleId.Painter) &&
+                RoleClass.Painter.CurrentTarget != null &&
+                RoleClass.Painter.CurrentTarget.PlayerId == target.PlayerId)
+                Painter.Handle(Painter.ActionType.Death);
+
             if (PlayerControl.LocalPlayer.IsRole(RoleId.Psychometrist))
+                Psychometrist.MurderPlayer(__instance, target);
+
+            if (target.IsRole(RoleId.Hitman))
+                Hitman.Death();
+
+            if (target.IsRole(RoleId.OrientalShaman) && OrientalShaman.OrientalShamanCausative.ContainsKey(target.PlayerId))
             {
-                Roles.Crewmate.Psychometrist.MurderPlayer(__instance, target);
-            }
-            if (target.IsDead())
-            {
-                if (target.IsRole(RoleId.Hitman))
+                PlayerControl causativePlayer = PlayerById(OrientalShaman.OrientalShamanCausative[target.PlayerId]);
+                if (causativePlayer.IsAlive())
                 {
-                    Roles.Neutral.Hitman.Death();
-                }
-                else if (target.IsRole(RoleId.OrientalShaman) && OrientalShaman.OrientalShamanCausative.ContainsKey(target.PlayerId))
-                {
-                    PlayerControl causativePlayer = PlayerById(OrientalShaman.OrientalShamanCausative[target.PlayerId]);
-                    if (causativePlayer.IsAlive())
-                    {
-                        RPCProcedure.RPCMurderPlayer(causativePlayer.PlayerId, causativePlayer.PlayerId, 0);
-                        causativePlayer.RpcSetFinalStatus(FinalStatus.WorshiperSelfDeath);
-                    }
+                    RPCProcedure.RPCMurderPlayer(causativePlayer.PlayerId, causativePlayer.PlayerId, 0);
+                    causativePlayer.RpcSetFinalStatus(FinalStatus.WorshiperSelfDeath);
                 }
             }
-            Levelinger.MurderPlayer(__instance, target);
-            if (RoleClass.Lovers.SameDie && target.IsLovers())
-            {
-                if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
-                {
-                    PlayerControl SideLoverPlayer = target.GetOneSideLovers();
-                    if (SideLoverPlayer.IsAlive())
-                    {
-                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.RPCMurderPlayer, SendOption.Reliable, -1);
-                        writer.Write(SideLoverPlayer.PlayerId);
-                        writer.Write(SideLoverPlayer.PlayerId);
-                        writer.Write(byte.MaxValue);
-                        AmongUsClient.Instance.FinishRpcImmediately(writer);
-                        RPCProcedure.RPCMurderPlayer(SideLoverPlayer.PlayerId, SideLoverPlayer.PlayerId, byte.MaxValue);
-                        SideLoverPlayer.RpcSetFinalStatus(FinalStatus.LoversBomb);
-                    }
-                }
-            }
+
             if (target.IsQuarreled())
             {
                 if (AmongUsClient.Instance.AmHost)
@@ -1190,23 +1218,6 @@ public static class MurderPlayerPatch
                         GameManager.Instance.RpcEndGame((GameOverReason)CustomGameOverReason.QuarreledWin, false);
                     }
                 }
-            }
-            Minimalist.MurderPatch.Postfix(__instance);
-        }
-        Vampire.OnMurderPlayer(__instance, target);
-        if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId && ModeHandler.IsMode(ModeId.Default))
-        {
-            EvilGambler.MurderPlayerPostfix(__instance);
-            Doppelganger.KillCoolSetting.MurderPlayer(__instance, target);
-            if (__instance.IsImpostor())
-            {
-                PlayerControl.LocalPlayer.SetKillTimerUnchecked(RoleHelpers.GetCoolTime(__instance), RoleHelpers.GetCoolTime(__instance));
-            }
-            if (Squid.Abilitys.IsKillGuard)
-            {
-                PlayerControl.LocalPlayer.SetKillTimerUnchecked(Squid.SquidNotKillTime.GetFloat(), Squid.SquidNotKillTime.GetFloat());
-                Squid.SetKillTimer(Squid.SquidNotKillTime.GetFloat());
-                Squid.Abilitys.IsKillGuard = false;
             }
         }
     }

--- a/SuperNewRoles/Roles/CrewMate/DyingMessenger.cs
+++ b/SuperNewRoles/Roles/CrewMate/DyingMessenger.cs
@@ -21,10 +21,8 @@ public class DyingMessenger
 
     public static List<PlayerControl> DyingMessengerPlayer;
     public static Color32 color = new(191, 197, 202, byte.MaxValue);
-    public static Dictionary<byte, (DateTime, PlayerControl)> ActualDeathTime;
     public static void ClearAndReload()
     {
         DyingMessengerPlayer = new();
-        ActualDeathTime = new();
     }
 }

--- a/SuperNewRoles/Roles/Impostor/SerialKiller.cs
+++ b/SuperNewRoles/Roles/Impostor/SerialKiller.cs
@@ -78,6 +78,7 @@ public static class SerialKiller
     {
         if (__instance.IsRole(RoleId.SerialKiller))
         {
+            if (target.IsRole(RoleId.Fox) && RoleClass.Fox.Killer.ContainsKey(__instance.PlayerId)) return;
             if (__instance.PlayerId == CachedPlayer.LocalPlayer.PlayerId)
             {
                 RoleClass.SerialKiller.SuicideTime = RoleClass.SerialKiller.SuicideDefaultTime;

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -37,7 +37,7 @@ public static class RoleClass
         BlockPlayers = new();
         IsMeeting = false;
         RandomSpawn.IsFirstSpawn = true;
-        DeadPlayer.deadPlayers = new();
+        DeadPlayer.ClearAndReloads();
         AllRoleSetClass.Assigned = false;
         LateTask.Tasks = new();
         LateTask.AddTasks = new();

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -1575,6 +1575,7 @@ public static class RoleClass
         public static List<PlayerControl> FoxPlayer;
         public static Color32 color = FoxPurple;
         public static Dictionary<int, int> KillGuard;
+        public static Dictionary<byte, bool> Killer;
         public static bool IsUseVent;
         public static bool UseReport;
         public static bool IsImpostorLight;
@@ -1582,6 +1583,7 @@ public static class RoleClass
         {
             FoxPlayer = new();
             KillGuard = new();
+            Killer = new();
             IsUseVent = CustomOptionHolder.FoxIsUseVent.GetBool();
             UseReport = CustomOptionHolder.FoxReport.GetBool();
             IsImpostorLight = CustomOptionHolder.FoxIsImpostorLight.GetBool();


### PR DESCRIPTION
- 死亡(IsDead()==true)時にペットを外す事で死体位置にペットが残らないようにした

- 生存していても死因がキルになる問題を根本的に修正した

- 死亡していなくても死亡者リスト及び死亡推定時刻辞書に追加していた問題を修正

- シーアのshowflashや霊魂が死亡しなくても表示される事があった問題を修正

- ペインターとサイコメトラーの死者に関する情報を保存しないように修正