### PR TITLE
サーバに対し[ver2023.3.28]と偽装する機能作成

### DIFF
--- a/SuperNewRoles/Main.cs
+++ b/SuperNewRoles/Main.cs
@@ -117,6 +117,17 @@ public partial class SuperNewRolesPlugin : BasePlugin
         foreach (string resourceName in resourceNames)
             if (resourceName.EndsWith(".png"))
                 ModHelpers.LoadSpriteFromResources(resourceName, 115f);
+        Constants.CompatVersions = new int[1] { Constants.GetBroadcastVersion() };
+    }
+
+    [HarmonyPatch(typeof(Constants), nameof(Constants.GetBroadcastVersion))]
+    public static class GetBroadcastVersionAwakePatch
+    {
+        public static bool Prefix(ref int __result)
+        {
+            __result = 50577350;
+            return false;
+        }
     }
 
     public static bool IsApril()

--- a/SuperNewRoles/Patches/GameStartPatch.cs
+++ b/SuperNewRoles/Patches/GameStartPatch.cs
@@ -8,38 +8,10 @@ class GameStartPatch
     [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.MakePublic))]
     class MakePublicPatch
     {
-        /*public static bool Prefix(GameStartManager __instance)
+        public static bool Prefix(GameStartManager __instance)
         {
-            bool NameIncludeMod = LegacySaveManager.PlayerName.ToLower().Contains("mod");
-            bool NameIncludeSNR = LegacySaveManager.PlayerName.ToUpper().Contains("SNR");
-            bool NameIncludeSHR = LegacySaveManager.PlayerName.ToUpper().Contains("SHR");
-            if (AmongUsClient.Instance.AmHost)
-            {
-                if (NameIncludeMod && !NameIncludeSNR && !NameIncludeSHR)
-                {
-                    SuperNewRolesPlugin.Logger.LogWarning("\"mod\"が名前に含まれている状態では公開部屋にすることはできません。");
-                    __instance.MakePublicButton.color = Palette.DisabledClear;
-                    __instance.privatePublicText.color = Palette.DisabledClear;
-                    PlayerControl.LocalPlayer.RpcSendChat(string.Format("Modが名前に含まれている状態では公開部屋にすることはできません。"));
-                    return false;
-                }
-                else if ((ModeHandler.IsMode(ModeId.SuperHostRoles, false) && NameIncludeSNR && !NameIncludeSHR) || (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && NameIncludeMod && !NameIncludeSHR))
-                {
-                    SuperNewRolesPlugin.Logger.LogWarning("SHRモードで\"SNR\"が名前に含まれている状態では公開部屋にすることはできません。");
-                    PlayerControl.LocalPlayer.RpcSendChat(string.Format("SHRモードでSNRが名前に含まれている状態では公開部屋にすることはできません。"));
-                    return false;
-                }
-                else if (!NameIncludeSNR && !NameIncludeSHR)
-                {
-                    SuperNewRolesPlugin.Logger.LogWarning("Mod関連のワードが名前にないので公開部屋にできません");
-                    __instance.MakePublicButton.color = Palette.DisabledClear;
-                    __instance.privatePublicText.color = Palette.DisabledClear;
-                    PlayerControl.LocalPlayer.RpcSendChat(string.Format("Mod関連のワードが名前に入っていないと公開部屋にすることはできません。特殊モードをご利用の場合は名前に「SHR」を入れてください。"));
-                    return false;
-                }
-            }
-            return true;
-        }*/
+            return false;
+        }
     }
     [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
     public static class LobbyCountDownTimer

--- a/SuperNewRoles/Patches/GameStartPatch.cs
+++ b/SuperNewRoles/Patches/GameStartPatch.cs
@@ -10,6 +10,18 @@ class GameStartPatch
     {
         public static bool Prefix(GameStartManager __instance)
         {
+            if (!AmongUsClient.Instance.AmHost) return true;
+
+            var HostVersion = ShareGameVersion.GameStartManagerUpdatePatch.VersionPlayers[AmongUsClient.Instance.HostId].version;
+            var error = (Mode.ModeHandler.IsMode(Mode.ModeId.Default) || Mode.ModeHandler.IsMode(Mode.ModeId.Werewolf))
+                ? string.Format(ModTranslation.GetString("PublicRoomErrorClientMode"), HostVersion)
+                : string.Format(ModTranslation.GetString("PublicRoomErrorHostMode"), HostVersion);
+
+            Logger.Error(error, "MakePublicPatch");
+            __instance.MakePublicButton.color = Palette.DisabledClear;
+            __instance.privatePublicText.color = Palette.DisabledClear;
+            PlayerControl.LocalPlayer.RpcSendChat(error);
+
             return false;
         }
     }

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1422,6 +1422,8 @@ Processing,Processing...,処理中...,处理中...,處理中...
 SuccessfulExperiment,Successful Experiment,実験成功,测试成功,測試成功
 SNRIntroduction,introduction status,導入状況,导入情况,導入狀況
 NoFriendCode,No possession.,未所持,未持有,不具有
+PublicRoomErrorHostMode,The current v{0} cannot be made public.\nIf you want to make the room public in Host mode，\nPlease use [ AmongUs body: ver2023.3.28 + SNR: v1.7.2.0 ].,現在使用している v{0} では公開部屋にする事ができません。\nHostモードで公開部屋にしたい場合は\n[ AmongUs本体:ver2023.3.28 + SNR:v1.7.2.0 ] を使用して下さい。
+PublicRoomErrorClientMode,The current v{0} cannot be made public.\nIf you want to make the room public in Client mode，\nPlease use [ AmongUs body: ver2023.6.27 + SNR: v1.8.1.2 ].,現在使用している v{0} では公開部屋にする事ができません。\nClientモードで公開部屋にしたい場合は\n[ AmongUs本体:ver2023.6.27 + SNR:v1.8.1.2 ] を使用して下さい。
 
 # Agartha
 Agartha_WareHouse,WareHouse,倉庫,仓库,倉庫


### PR DESCRIPTION
- 代償として全てのモードにおいて公開部屋変更不可となっている。
  - 公開部屋にした場合, 使用可能なバージョンをチャットに示し警告するようにしている。
    - HostModeは 2023.3.28 + 1.7.2.0を促している
    - ClientModeは 2023.6.27 + 1.8.1.2を促している

- vanillaサーバテスト済み
  - 非導入者ファストメーカーが導入者クルーメイトをMKできた。