### PR TITLE
[新機能] : マッチメイキングタグ

### DIFF
--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1008,10 +1008,11 @@ public class CustomOptionHolder
 
         if (ConfigRoles.DebugMode.Value)
         {
-            IsDebugMode = Create(100800, true, CustomOptionType.Generic, "<color=#828282>デバッグモード</color>", false, null, isHeader: true);
-            DebugModeFastStart = Create(100801, true, CustomOptionType.Generic, "<color=#828282>即開始</color>", false, IsDebugMode);
-            CanUseChatWhenTaskPhase = Create(100802, true, CustomOptionType.Generic, "<color=#828282>タスクフェイズ中にチャットを使える</color>", false, IsDebugMode);
-            IsMurderPlayerAnnounce = Create(100803, true, CustomOptionType.Generic, "<color=#828282>MurderPlayer発生時に通知を行う</color>", false, IsDebugMode);
+            Color debugColor = (Color)RoleClass.Debugger.color;
+            IsDebugMode = Create(100800, true, CustomOptionType.Generic, Cs(debugColor, "デバッグモード"), false, null, isHeader: true);
+            DebugModeFastStart = Create(100801, true, CustomOptionType.Generic, Cs(debugColor, "即開始"), false, IsDebugMode);
+            CanUseChatWhenTaskPhase = Create(100802, true, CustomOptionType.Generic, Cs(debugColor, "タスクフェイズ中にチャットを使える"), false, IsDebugMode);
+            IsMurderPlayerAnnounce = Create(100803, true, CustomOptionType.Generic, Cs(debugColor, "MurderPlayer発生時に通知を行う"), false, IsDebugMode);
         }
 
         DisconnectNotPCOption = Create(100900, true, CustomOptionType.Generic, Cs(new Color(238f / 187f, 204f / 255f, 203f / 255f, 1f), "DisconnectNotPC"), true, null, isHeader: true);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -1973,6 +1973,8 @@ public class CustomOptionHolder
 
         /* |: ========================= Roles Settings ========================== :| */
 
+        MatchTagOption.LoadOption(); // マッチタグの設定
+
         Logger.Info("---------- CustomOption Id Info start ----------", "CustomOptionId Info");
 
         Logger.Info("---------- SettingRoleId Info----------", "SettingRoleId Info");
@@ -1981,6 +1983,7 @@ public class CustomOptionHolder
         Logger.Info("SettingRoleIdのMax:" + GetRoleSettingid(NeutralIdMax), "Neutral");
         Logger.Info("SettingRoleIdのMax:" + GetRoleSettingid(CrewmateIdMax), "Crewmate");
         Logger.Info("SettingRoleIdのMax:" + GetRoleSettingid(ModifierIdMax), "Modifier");
+        Logger.Info("SettingRoleIdのMax:" + GetRoleSettingid(MatchingTagIdMax), "MatchingTag");
 
         Logger.Info("---------- SettingId Info----------", "SettingId Info");
         Logger.Info("CustomOptionのIdのMax:" + GenericIdMax, "Generic");
@@ -1988,6 +1991,7 @@ public class CustomOptionHolder
         Logger.Info("CustomOptionのIdのMax:" + NeutralIdMax, "Neutral");
         Logger.Info("CustomOptionのIdのMax:" + CrewmateIdMax, "Crewmate");
         Logger.Info("CustomOptionのIdのMax:" + ModifierIdMax, "Modifier");
+        Logger.Info("CustomOptionのIdのMax:" + MatchingTagIdMax, "MatchingTag");
         Logger.Info("設定数:" + options.Count);
 
         Logger.Info("---------- CustomOption Id Info End ----------", "CustomOptionId Info");

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -148,6 +148,10 @@ public class CustomOption
                 if (ModifierIdMax < Id) ModifierIdMax = Id;
                 if (duplication) Logger.Info(duplicationString, $"{SettingPattern.ModifierId}");
                 break;
+            case SettingPattern.MatchingTagId:
+                if (MatchingTagIdMax < Id) MatchingTagIdMax = Id;
+                if (duplication) Logger.Info(duplicationString, $"{SettingPattern.MatchingTagId}");
+                break;
         }
         options.Add(this);
     }
@@ -157,6 +161,7 @@ public class CustomOption
     public static int NeutralIdMax = 0;
     public static int CrewmateIdMax = 0;
     public static int ModifierIdMax = 0;
+    public static int MatchingTagIdMax = 0;
 
     private SettingPattern GetSettingPattern(int id)
     {
@@ -166,6 +171,7 @@ public class CustomOption
         if (id is >= 300000 and < 400000) return SettingPattern.NeutralId;
         if (id is >= 400000 and < 500000) return SettingPattern.CrewmateId;
         if (id is >= 500000 and < 600000) return SettingPattern.ModifierId;
+        if (id is >= 600000 and < 700000) return SettingPattern.MatchingTagId;
 
         return SettingPattern.ErrorId;
     }
@@ -178,6 +184,7 @@ public class CustomOption
         NeutralId = 300000,
         CrewmateId = 400000,
         ModifierId = 500000,
+        MatchingTagId = 600000,
     }
     public static CustomOption Create(int id, bool IsSHROn, CustomOptionType type, string name, string[] selections, CustomOption parent = null, bool isHeader = false, bool isHidden = false, string format = "")
     {
@@ -208,6 +215,11 @@ public class CustomOption
                 _ => CustomOptionType.Generic
             };
         return new CustomRoleOption(id, IsSHROn, type, $"{roleId}Name", IntroData.GetIntroData(roleId).color, max, isHidden);
+    }
+
+    public static CustomOption CreateMatchMakeTag(int id, bool IsSHROn, string name, bool defaultValue, CustomOption parent = null, bool isHeader = false, bool isHidden = false, string format = "", CustomOptionType type = CustomOptionType.MatchTag)
+    {
+        return new CustomOption(id, IsSHROn, type, name, new string[] { "optionOff", "optionOn" }, defaultValue ? "optionOn" : "optionOff", parent, isHeader, isHidden, format);
     }
 
     // Static behaviour

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -1186,7 +1186,7 @@ class GameOptionsDataPatch
                 }
 
                 entry = new StringBuilder();
-                if (!GameOptionsMenuUpdatePatch.IsHidden(option))
+                if (!(GameOptionsMenuUpdatePatch.IsHidden(option) || option.type == CustomOptionType.MatchTag))
                 {
                     entry.AppendLine(OptionToString(option));
                 }

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -600,7 +600,7 @@ class GameOptionsMenuStartPatch
 
         var matchTagTab = UnityEngine.Object.Instantiate(roleTab, crewmateTab.transform);
         var matchTagTabHighlight = matchTagTab.transform.FindChild("Hat Button").FindChild("Tab Background").GetComponent<SpriteRenderer>();
-        matchTagTab.transform.FindChild("Hat Button").FindChild("Icon").GetComponent<SpriteRenderer>().sprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.Setting_Crewmate.png", 100f);
+        matchTagTab.transform.FindChild("Hat Button").FindChild("Icon").GetComponent<SpriteRenderer>().sprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.TabIcon.png", 100f);
         matchTagTab.name = "matchTagTab";
 
         var RegulationTab = UnityEngine.Object.Instantiate(roleTab, matchTagTab.transform);

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -64,16 +64,8 @@ public class CustomOption
                 }
                 if (AmongUsClient.Instance != null && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined && AmongUsClient.Instance.IsGamePublic)
                 {
-                    if (id is (>= 100000 and < 600000) or 0)
-                    {
-                        MatchMaker.UpdateOption();
-                        Logger.Info($"設定id : {id} が変更された為, ゲーム & 役職の設定を送信しました。","UpdateOption");
-                    }
-                    else if (id is >= 600000 and < 700000)
-                    {
-                        MatchMaker.UpdateTags();
-                        Logger.Info($"設定id : {id} が変更された為, タグ情報を送信しました。","UpdateTags");
-                    }
+                    if (id is (>= 100000 and < 600000) or 0) MatchMaker.UpdateOption();
+                    else if (id is >= 600000 and < 700000) MatchMaker.UpdateTags();
                     else Logger.Error($"設定idが規定範囲外でした : {id}", "MatchMakerUpdate");
                 }
             }

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -64,7 +64,8 @@ public class CustomOption
                 }
                 if (AmongUsClient.Instance != null && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined && AmongUsClient.Instance.IsGamePublic)
                 {
-                    Modules.MatchMaker.UpdateOption();
+                    MatchMaker.UpdateOption();
+                    MatchMaker.UpdateTags();
                 }
             }
             else

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -23,6 +23,7 @@ public enum CustomOptionType
     Impostor,
     Neutral,
     Crewmate,
+    MatchTag,
     Empty // 使用されない
 }
 
@@ -692,9 +693,10 @@ class GameOptionsMenuStartPatch
         List<OptionBehaviour> impostorOptions = new();
         List<OptionBehaviour> neutralOptions = new();
         List<OptionBehaviour> crewmateOptions = new();
+        List<OptionBehaviour> matchTagOptions = new();
 
         List<Transform> menus = new() { snrMenu.transform, impostorMenu.transform, neutralMenu.transform, crewmateMenu.transform, matchTagMenu.transform, RegulationMenu.transform };
-        List<List<OptionBehaviour>> optionBehaviours = new() { snrOptions, impostorOptions, neutralOptions, crewmateOptions };
+        List<List<OptionBehaviour>> optionBehaviours = new() { snrOptions, impostorOptions, neutralOptions, crewmateOptions, matchTagOptions };
 
         for (int i = 0; i < CustomOption.options.Count; i++)
         {
@@ -712,7 +714,8 @@ class GameOptionsMenuStartPatch
             }
             option.optionBehaviour.gameObject.SetActive(true);
         }
-        Logger.Info("通過やでええええええええええええええええ");
+        Logger.Info("SNROption - matchTagOption通過");
+
         foreach (var Regulation in CustomRegulation.RegulationData.Regulations)
         {
             if (Regulation.optionBehaviour == null)
@@ -727,6 +730,7 @@ class GameOptionsMenuStartPatch
             }
             Regulation.optionBehaviour.gameObject.SetActive(true);
         }
+        Logger.Info("RegulationOption通過");
 
         snrMenu.Children = snrOptions.ToArray();
         snrSettings.gameObject.SetActive(false);
@@ -918,6 +922,7 @@ static class GameOptionsMenuUpdatePatch
             "ImpostorSetting" => CustomOptionType.Impostor,
             "NeutralSetting" => CustomOptionType.Neutral,
             "CrewmateSetting" => CustomOptionType.Crewmate,
+            "matchTagSetting" => CustomOptionType.MatchTag,
             _ => CustomOptionType.Crewmate,
         };
     }

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -516,6 +516,11 @@ class GameOptionsMenuStartPatch
             GameObject.Find("CrewmateSettings").transform.FindChild("GameGroup").FindChild("Text").GetComponent<TMPro.TextMeshPro>().SetText(ModTranslation.GetString("SettingCrewmate"));
             return;
         }
+        if (GameObject.Find("matchTagSettings") != null)
+        {
+            GameObject.Find("matchTagSettings").transform.FindChild("GameGroup").FindChild("Text").GetComponent<TMPro.TextMeshPro>().SetText(ModTranslation.GetString("SettingMatchTag"));
+            return;
+        }
         if (GameObject.Find("RegulationSettings") != null)
         {
             GameObject.Find("RegulationSettings").transform.FindChild("GameGroup").FindChild("Text").GetComponent<TMPro.TextMeshPro>().SetText(ModTranslation.GetString("SettingRegulation"));
@@ -548,6 +553,11 @@ class GameOptionsMenuStartPatch
         crewmateSettings.name = "CrewmateSettings";
         crewmateSettings.transform.FindChild("GameGroup").FindChild("SliderInner").name = "CrewmateSetting";
 
+        var matchTagSettings = UnityEngine.Object.Instantiate(gameSettings, gameSettings.transform.parent);
+        var matchTagMenu = matchTagSettings.transform.FindChild("GameGroup").FindChild("SliderInner").GetComponent<GameOptionsMenu>();
+        matchTagSettings.name = "matchTagSettings";
+        matchTagSettings.transform.FindChild("GameGroup").FindChild("SliderInner").name = "matchTagSetting";
+
         var RegulationSettings = UnityEngine.Object.Instantiate(gameSettings, gameSettings.transform.parent);
         var RegulationMenu = RegulationSettings.transform.FindChild("GameGroup").FindChild("SliderInner").GetComponent<GameOptionsMenu>();
         RegulationSettings.name = "RegulationSettings";
@@ -575,7 +585,12 @@ class GameOptionsMenuStartPatch
         crewmateTab.transform.FindChild("Hat Button").FindChild("Icon").GetComponent<SpriteRenderer>().sprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.Setting_Crewmate.png", 100f);
         crewmateTab.name = "CrewmateTab";
 
-        var RegulationTab = UnityEngine.Object.Instantiate(roleTab, neutralTab.transform);
+        var matchTagTab = UnityEngine.Object.Instantiate(roleTab, crewmateTab.transform);
+        var matchTagTabHighlight = matchTagTab.transform.FindChild("Hat Button").FindChild("Tab Background").GetComponent<SpriteRenderer>();
+        matchTagTab.transform.FindChild("Hat Button").FindChild("Icon").GetComponent<SpriteRenderer>().sprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.Setting_Crewmate.png", 100f);
+        matchTagTab.name = "matchTagTab";
+
+        var RegulationTab = UnityEngine.Object.Instantiate(roleTab, matchTagTab.transform);
         var RegulationTabHighlight = RegulationTab.transform.FindChild("Hat Button").FindChild("Tab Background").GetComponent<SpriteRenderer>();
         RegulationTab.transform.FindChild("Hat Button").FindChild("Icon").GetComponent<SpriteRenderer>().sprite = ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.Setting_Crewmate.png", 100f);
         RegulationTab.name = "RegulationTab";
@@ -585,11 +600,12 @@ class GameOptionsMenuStartPatch
         roleTab.transform.position += Vector3.left * 3f;
         snrTab.transform.position += Vector3.left * 2f;
         impostorTab.transform.localPosition = Vector3.right * 1f;
-        neutralTab.transform.localPosition = Vector3.right * 1f;
+        neutralTab.transform.localPosition = Vector3.right * 0.95f;
         crewmateTab.transform.localPosition = Vector3.right * 0.95f;
-        RegulationTab.transform.localPosition = Vector3.right * 1.85f;
+        matchTagTab.transform.localPosition = Vector3.right * 1.05f;
+        RegulationTab.transform.localPosition = Vector3.right * 0.90f;
 
-        var tabs = new GameObject[] { gameTab, roleTab, snrTab, impostorTab, neutralTab, crewmateTab, RegulationTab };
+        var tabs = new GameObject[] { gameTab, roleTab, snrTab, impostorTab, neutralTab, crewmateTab, matchTagTab, RegulationTab };
         for (int i = 0; i < tabs.Length; i++)
         {
             var button = tabs[i].GetComponentInChildren<PassiveButton>();
@@ -604,6 +620,7 @@ class GameOptionsMenuStartPatch
                 impostorSettings.gameObject.SetActive(false);
                 neutralSettings.gameObject.SetActive(false);
                 crewmateSettings.gameObject.SetActive(false);
+                matchTagSettings.gameObject.SetActive(false);
                 RegulationSettings.gameObject.SetActive(false);
                 gameSettingMenu.GameSettingsHightlight.enabled = false;
                 gameSettingMenu.RolesSettingsHightlight.enabled = false;
@@ -611,6 +628,7 @@ class GameOptionsMenuStartPatch
                 impostorTabHighlight.enabled = false;
                 neutralTabHighlight.enabled = false;
                 crewmateTabHighlight.enabled = false;
+                matchTagTabHighlight.enabled = false;
                 RegulationTabHighlight.enabled = false;
                 if (copiedIndex == 0)
                 {
@@ -647,10 +665,14 @@ class GameOptionsMenuStartPatch
                 }
                 else if (copiedIndex == 6)
                 {
+                    matchTagSettings.gameObject.SetActive(true);
+                    matchTagTabHighlight.enabled = true;
+                }
+                else if (copiedIndex == 7)
+                {
                     RegulationSettings.gameObject.SetActive(true);
                     RegulationTabHighlight.enabled = true;
                 }
-
             }));
         }
 
@@ -662,6 +684,8 @@ class GameOptionsMenuStartPatch
             UnityEngine.Object.Destroy(option.gameObject);
         foreach (OptionBehaviour option in crewmateMenu.GetComponentsInChildren<OptionBehaviour>())
             UnityEngine.Object.Destroy(option.gameObject);
+        foreach (OptionBehaviour option in matchTagMenu.GetComponentsInChildren<OptionBehaviour>())
+            UnityEngine.Object.Destroy(option.gameObject);
         foreach (OptionBehaviour option in RegulationMenu.GetComponentsInChildren<OptionBehaviour>())
             UnityEngine.Object.Destroy(option.gameObject);
         List<OptionBehaviour> snrOptions = new();
@@ -669,7 +693,7 @@ class GameOptionsMenuStartPatch
         List<OptionBehaviour> neutralOptions = new();
         List<OptionBehaviour> crewmateOptions = new();
 
-        List<Transform> menus = new() { snrMenu.transform, impostorMenu.transform, neutralMenu.transform, crewmateMenu.transform, RegulationMenu.transform };
+        List<Transform> menus = new() { snrMenu.transform, impostorMenu.transform, neutralMenu.transform, crewmateMenu.transform, matchTagMenu.transform, RegulationMenu.transform };
         List<List<OptionBehaviour>> optionBehaviours = new() { snrOptions, impostorOptions, neutralOptions, crewmateOptions };
 
         for (int i = 0; i < CustomOption.options.Count; i++)
@@ -715,6 +739,8 @@ class GameOptionsMenuStartPatch
 
         crewmateMenu.Children = crewmateOptions.ToArray();
         crewmateSettings.gameObject.SetActive(false);
+
+        matchTagSettings.gameObject.SetActive(false);
 
         RegulationSettings.gameObject.SetActive(false);
 

--- a/SuperNewRoles/Modules/CustomOptionModel.cs
+++ b/SuperNewRoles/Modules/CustomOptionModel.cs
@@ -64,8 +64,17 @@ public class CustomOption
                 }
                 if (AmongUsClient.Instance != null && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Joined && AmongUsClient.Instance.IsGamePublic)
                 {
-                    MatchMaker.UpdateOption();
-                    MatchMaker.UpdateTags();
+                    if (id is (>= 100000 and < 600000) or 0)
+                    {
+                        MatchMaker.UpdateOption();
+                        Logger.Info($"設定id : {id} が変更された為, ゲーム & 役職の設定を送信しました。","UpdateOption");
+                    }
+                    else if (id is >= 600000 and < 700000)
+                    {
+                        MatchMaker.UpdateTags();
+                        Logger.Info($"設定id : {id} が変更された為, タグ情報を送信しました。","UpdateTags");
+                    }
+                    else Logger.Error($"設定idが規定範囲外でした : {id}", "MatchMakerUpdate");
                 }
             }
             else

--- a/SuperNewRoles/Modules/CustomOverlay.cs
+++ b/SuperNewRoles/Modules/CustomOverlay.cs
@@ -194,6 +194,9 @@ public class CustomOverlays
                 Regulation(out leftText, out centerText, out rightText);
                 infoOverlayRight.transform.localPosition = infoOverlayLeft.transform.localPosition + new Vector3(3.75f, 0.0f, 0.0f);
                 break;
+            case CustomOverlayPattern.MatchTag:
+                MatchTag(out leftText, out centerText, out rightText);
+                break;
         }
 
         infoOverlayLeft.text = leftText;
@@ -275,6 +278,7 @@ public class CustomOverlays
             if (Input.GetKeyDown(KeyCode.Escape) && overlayShown) HideInfoOverlay(); // overlayを閉じる
             else if (Input.GetKeyDown(KeyCode.F3)) YoggleInfoOverlay(CustomOverlayPattern.PlayerDataInfo); // 参加プレイヤーの情報を表示
             else if (Input.GetKeyDown(KeyCode.G)) YoggleInfoOverlay(CustomOverlayPattern.ActivateRoles); // 「現在配役されている役職」を表示
+            else if (Input.GetKeyDown(KeyCode.T)) YoggleInfoOverlay(CustomOverlayPattern.MatchTag); // 「現在設定されているタグ」を表示
             else if (Input.GetKeyDown(KeyCode.Tab) && overlayShown) YoggleInfoOverlay(nowPattern, true); // 全てのoverlayの文章の更新 & GとIはページ送り
 
             if (AmongUsClient.Instance.GameState != InnerNet.InnerNetClient.GameStates.Started) return;
@@ -293,6 +297,7 @@ public class CustomOverlays
         PlayerDataInfo, // F3キー : 参加プレイヤーの情報(プレイヤー名,カラー,導入状況,プラットフォーム,フレンドコード)
         MyRole, // Hキー : 自分の役職の説明と設定の情報
         Regulation, // Iキー : バニラとSNRのゲーム設定の情報
+        MatchTag, // Tキー : マッチメイキングタグの情報
     }
 
     /// <summary>
@@ -756,5 +761,45 @@ public class CustomOverlays
             right = GameOptionsDataPatch.ResultData();
 
         SuperNewRolesPlugin.optionsPage = firstPage; // 現在のページを左の列に表示しているページに戻す
+    }
+
+    // マッチメイキングタグの設定を表示する
+    private static void MatchTag(out string left, out string center, out string right)
+    {
+        left = center = right = null;
+
+        Dictionary<int, string> EnableTags = new();
+        int index = 0;
+
+        foreach (CustomOption option in CustomOption.options)
+        {
+            if (option.GetSelection() == 0) continue;
+            if (option.type != CustomOptionType.MatchTag) continue;
+            if (option.IsHidden()) continue;
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles, false) && !option.isSHROn) continue;
+
+            string name = option.name;
+            EnableTags[index] = name;
+            index++;
+        }
+
+        const string size = "<size=150%>";
+        StringBuilder leftBuilder = new(size + ModTranslation.GetString("EnableTagsMessage") + "\n\n");
+        StringBuilder centerBuilder = new(size + "\n\n"), rightBuilder = new(size + "\n\n");
+
+        foreach (KeyValuePair<int, string> kvp in EnableTags)
+        {
+            const int line = 17;
+            if (kvp.Key < line)
+                leftBuilder.AppendLine(kvp.Value);
+            else if (kvp.Key < line * 2)
+                centerBuilder.AppendLine(kvp.Value);
+            else if (kvp.Key < line * 3)
+                rightBuilder.AppendLine(kvp.Value);
+        }
+
+        left = leftBuilder.ToString();
+        center = centerBuilder.ToString();
+        right = rightBuilder.ToString();
     }
 }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -1,11 +1,9 @@
 using System.Collections.Generic;
-using System;
-using HarmonyLib;
-using UnityEngine;
-using SuperNewRoles.Mode;
+using System.Linq;
 using AmongUs.GameOptions;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
-using System.Linq;
+using SuperNewRoles.Mode;
+using UnityEngine;
 using static SuperNewRoles.Modules.CustomOption;
 using static SuperNewRoles.Modules.CustomOptionHolder;
 
@@ -16,9 +14,11 @@ public static class MatchMaker
     public static string BaseURL = "https://supermatchmaker.vercel.app/";
     public static Dictionary<string, string> CreateBaseData()
     {
-        var data = new Dictionary<string, string>();
-        data["friendcode"] = PlayerControl.LocalPlayer.Data.FriendCode;
-        data["roomid"] = InnerNet.GameCode.IntToGameName(AmongUsClient.Instance.GameId);
+        var data = new Dictionary<string, string>
+        {
+            ["friendcode"] = PlayerControl.LocalPlayer.Data.FriendCode,
+            ["roomid"] = InnerNet.GameCode.IntToGameName(AmongUsClient.Instance.GameId)
+        };
         return data;
     }
     public static void EndInviting()
@@ -51,7 +51,7 @@ public static class MatchMaker
         {
             if (opt.GetSelection() == 0) continue;
             if (opt.IsHidden()) continue;
-            CustomOption countopt = CustomOption.options.FirstOrDefault(x => x.id == (opt.id + 1));
+            CustomOption countopt = options.FirstOrDefault(x => x.id == (opt.id + 1));
             for (int i = 0; i < (countopt.GetSelection() + 1); i++)
             {
                 ActivateRoles.Add(opt.RoleId.ToString());
@@ -59,10 +59,10 @@ public static class MatchMaker
         }
         string ActiveOptions = "";
         List<string> ActivateOptions = new();
-        foreach (CustomOption option in CustomOption.options)
+        foreach (CustomOption option in options)
         {
             bool enabled = true;
-            if (AmongUsClient.Instance?.AmHost == false && CustomOptionHolder.hideSettings.GetBool())
+            if (AmongUsClient.Instance?.AmHost == false && hideSettings.GetBool())
             {
                 enabled = false;
             }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -208,10 +208,10 @@ public static class MatchTagOption
     {
         // 村レベル : 600000 ~
         Color villageLvColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
-        BeginnerTag = CreateMatchMakeTag(600000, true, Cs(villageLvColor, "BeginnerTag"), false, null, isHeader: true); // 初心者
-        IntermediateTag = CreateMatchMakeTag(600001, true, Cs(villageLvColor, "IntermediateTag"), false, null); // 中級者
-        AdvancedTag = CreateMatchMakeTag(600002, true, Cs(villageLvColor, "AdvancedTag"), false, null); // 上級者
-        CompetenceIsNotRequiredTag = CreateMatchMakeTag(600003, true, Cs(villageLvColor, "CompetenceIsNotRequiredTag"), false, null); // 実力不問
+        BeginnerTag = CreateMatchMakeTag(600000, true, Cs(new Color(134f / 255f, 214f / 255f, 31f / 255f, 1), "BeginnerTag"), false, null, isHeader: true); // 初心者
+        IntermediateTag = CreateMatchMakeTag(600001, true, Cs(new Color(12f / 255f, 184f / 255f, 232f / 255f, 1), "IntermediateTag"), false, null); // 中級者
+        AdvancedTag = CreateMatchMakeTag(600002, true, Cs(new Color(167f / 255f, 139f / 255f, 92f / 255f, 1), "AdvancedTag"), false, null); // 上級者
+        CompetenceIsNotRequiredTag = CreateMatchMakeTag(600003, true, Cs(new Color(105f / 255f, 179f / 255f, 119f / 255f, 1), "CompetenceIsNotRequiredTag"), false, null); // 実力不問
 
         // プレイスタンス : 600100 ~
         Color playingStanceColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using AmongUs.GameOptions;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using SuperNewRoles.Mode;
@@ -107,12 +108,19 @@ public static class MatchMaker
 
             if (enabled)
             {
-                ActiveTags.Add($"{option.id}");
-                Logger.Info($"{option.id}" + "ぷぇ");
+                // 先にカラータグを外す
+                string tagName = option.name;
+                string pattern = @"<color=#\w+>|</color>";
+
+                Regex colorRegex = new(pattern);
+                tagName = colorRegex.Replace(tagName, "");
+
+                string tagKey = ModTranslation.GetTranslateKey(tagName);
+
+                ActiveTags.Add($"{tagKey}");
             }
         }
         data["updatetags"] = string.Join(',', ActiveTags);
-
     }
     public static void CreateRoom()
     {

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -62,6 +62,7 @@ public static class MatchMaker
         foreach (CustomOption option in options)
         {
             bool enabled = true;
+            if (option.type == CustomOptionType.MatchTag) continue;
             if (AmongUsClient.Instance?.AmHost == false && hideSettings.GetBool())
             {
                 enabled = false;
@@ -88,6 +89,31 @@ public static class MatchMaker
         data["mode"] = GameOptionsManager.Instance.currentGameMode == GameModes.HideNSeek ? "HNS" : ModeHandler.GetMode(false).ToString();
         AmongUsClient.Instance.StartCoroutine(Analytics.Post(BaseURL + "api/update_state", data.GetString()).WrapToIl2Cpp());
     }
+    public static void UpdateTags()
+    {
+        var data = CreateBaseData();
+        data["type"] = "updatetags";
+        List<string> ActiveTags = new();
+        foreach (CustomOption option in options)
+        {
+            if (option.GetSelection() == 0) continue;
+            if (option.IsHidden()) continue;
+            if (option.type != CustomOptionType.MatchTag) continue;
+
+            bool enabled = true;
+
+            if (AmongUsClient.Instance?.AmHost == false && hideSettings.GetBool())
+                enabled = false;
+
+            if (enabled)
+            {
+                ActiveTags.Add($"{option.id}");
+                Logger.Info($"{option.id}" + "ぷぇ");
+            }
+        }
+        data["updatetags"] = string.Join(',', ActiveTags);
+
+    }
     public static void CreateRoom()
     {
         var data = CreateBaseData();
@@ -97,6 +123,7 @@ public static class MatchMaker
         {
             if (opt.GetSelection() == 0) continue;
             if (opt.IsHidden()) continue;
+            if (opt.type == CustomOptionType.MatchTag) continue;
             ActivateRoles.Add(opt.RoleId.ToString());
         }
         string ActiveOptions = "";
@@ -283,9 +310,13 @@ public static class MatchTagOption
         }
 
         // SHRでは表示しない設定を内部的にもオフにする
-        if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+        try
         {
-            FeatureCanNotUseAdminTag.selection = 0;
+            if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+            {
+                FeatureCanNotUseAdminTag.selection = 0;
+            }
         }
+        catch { }
     }
 }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -184,7 +184,6 @@ public static class MatchTagOption
     public static CustomOption FullVCOnlyTag; // 聞き専不可
 
     // レギュレーション : 600500 ~
-    public static CustomOption TakadaVillageRegulationTag; // 高田村レギュ
     public static CustomOption SheriffAndMadRegulationTag; // シェリマ
     public static CustomOption NeutralKillerRegulationTag; // 第三キル人外入り
     public static CustomOption VillageForOutsidersRegulationTag; // 人外村
@@ -247,7 +246,6 @@ public static class MatchTagOption
 
         // レギュレーション : 600500 ~
         Color RegulationColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
-        TakadaVillageRegulationTag = CreateMatchMakeTag(600500, false, Cs(RegulationColor, "TakadaVillageRegulationTag"), false, null, isHeader: true); // 高田村レギュ
         SheriffAndMadRegulationTag = CreateMatchMakeTag(600501, true, Cs(RegulationColor, "SheriffAndMadRegulationTag"), false, null); // シェリマ
         NeutralKillerRegulationTag = CreateMatchMakeTag(600502, true, Cs(RegulationColor, "NeutralKillerRegulationTag"), false, null); // 第三キル人外入り
         ManyRolesRegulationTag = CreateMatchMakeTag(600503, true, Cs(RegulationColor, "ManyRolesRegulationTag"), false, null); // 多役
@@ -287,7 +285,6 @@ public static class MatchTagOption
         // SHRでは表示しない設定を内部的にもオフにする
         if (ModeHandler.IsMode(ModeId.SuperHostRoles))
         {
-            TakadaVillageRegulationTag.selection = 0;
             FeatureCanNotUseAdminTag.selection = 0;
         }
     }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -265,7 +265,7 @@ public static class MatchTagOption
         DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(DebugColor, "バグ修正"), false, null, isHidden: notDebugMode);
         DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(DebugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
 
-        if (notDebugMode)
+        if (!notDebugMode)
         {
             DebugNewRolesTag.selection = 0;
             DebugNewFeaturesTag.selection = 0;

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -196,7 +196,11 @@ public static class MatchTagOption
     public static CustomOption AmusementRegulationTag; // お遊びレギュ
     public static CustomOption RegulationAdjustedTag; // レギュ調整中
 
-    // デバック : 600600 ~
+    // 使用機能 : 600600 ~
+    public static CustomOption FeatureAdminLimitTag;
+    public static CustomOption FeatureCanNotUseAdminTag;
+
+    // デバック : 600700 ~
     public static CustomOption DebugNewRolesTag; // 新役職
     public static CustomOption DebugNewFeaturesTag; // 新機能
     public static CustomOption DebugAddFeaturesTag; // 機能追加
@@ -254,21 +258,21 @@ public static class MatchTagOption
         TryingOutRolesRegulationTag = CreateMatchMakeTag(600508, true, Cs(RegulationColor, "TryingOutRolesRegulationTag"), false, null); // 役職お試し中(・ω・　)
         AmusementRegulationTag = CreateMatchMakeTag(600509, true, Cs(RegulationColor, "AmusementRegulationTag"), false, null); // お遊びレギュ
         RegulationAdjustedTag = CreateMatchMakeTag(600510, true, Cs(RegulationColor, "RegulationAdjustedTag"), false, null); // レギュ調整中
-        // SHRでは表示しない設定を内部的にもオフにする
-        if(ModeHandler.IsMode(ModeId.SuperHostRoles))
-        {
-            TakadaVillageRegulationTag.selection = 0;
-        }
+
+        // 使用機能 : 600600 ~
+        Color useFeatureColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        FeatureAdminLimitTag = CreateMatchMakeTag(600600, false, Cs(useFeatureColor, "FeatureAdminLimitTag"), false, null, isHeader: true); // アドミン使用制限
+        FeatureCanNotUseAdminTag = CreateMatchMakeTag(600601, true, Cs(useFeatureColor, "FeatureCanNotUseAdminTag"), false, null, isHeader: true); // アドミン禁止
 
         // デバッグ : 600600 ~
         Color debugColor = (Color)Roles.RoleClass.Debugger.color;
         bool notDebugMode = !ConfigRoles.DebugMode.Value;
-        DebugNewRolesTag = CreateMatchMakeTag(600600, true, Cs(debugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
-        DebugNewFeaturesTag = CreateMatchMakeTag(600601, true, Cs(debugColor, "新機能"), false, null, isHidden: notDebugMode);
-        DebugAddFeaturesTag = CreateMatchMakeTag(600602, true, Cs(debugColor, "機能追加"), false, null, isHidden: notDebugMode);
-        DebugChangeTag = CreateMatchMakeTag(600603, true, Cs(debugColor, "仕様変更"), false, null, isHidden: notDebugMode);
-        DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(debugColor, "バグ修正"), false, null, isHidden: notDebugMode);
-        DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(debugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
+        DebugNewRolesTag = CreateMatchMakeTag(600700, true, Cs(debugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
+        DebugNewFeaturesTag = CreateMatchMakeTag(600701, true, Cs(debugColor, "新機能"), false, null, isHidden: notDebugMode);
+        DebugAddFeaturesTag = CreateMatchMakeTag(600702, true, Cs(debugColor, "機能追加"), false, null, isHidden: notDebugMode);
+        DebugChangeTag = CreateMatchMakeTag(600703, true, Cs(debugColor, "仕様変更"), false, null, isHidden: notDebugMode);
+        DebugBugFixTag = CreateMatchMakeTag(600704, true, Cs(debugColor, "バグ修正"), false, null, isHidden: notDebugMode);
+        DebugOthersTag = CreateMatchMakeTag(600705, true, Cs(debugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
 
         if (notDebugMode)
         {
@@ -278,6 +282,13 @@ public static class MatchTagOption
             DebugChangeTag.selection = 0;
             DebugBugFixTag.selection = 0;
             DebugOthersTag.selection = 0;
+        }
+
+        // SHRでは表示しない設定を内部的にもオフにする
+        if (ModeHandler.IsMode(ModeId.SuperHostRoles))
+        {
+            TakadaVillageRegulationTag.selection = 0;
+            FeatureCanNotUseAdminTag.selection = 0;
         }
     }
 }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -243,7 +243,7 @@ public static class MatchTagOption
 
         // レギュレーション : 600500 ~
         Color RegulationColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
-        TakadaVillageRegulationTag = CreateMatchMakeTag(600500, true, Cs(RegulationColor, "TakadaVillageRegulationTag"), false, null, isHeader: true); // 高田村レギュ
+        TakadaVillageRegulationTag = CreateMatchMakeTag(600500, false, Cs(RegulationColor, "TakadaVillageRegulationTag"), false, null, isHeader: true); // 高田村レギュ
         SheriffAndMadRegulationTag = CreateMatchMakeTag(600501, true, Cs(RegulationColor, "SheriffAndMadRegulationTag"), false, null); // シェリマ
         NeutralKillerRegulationTag = CreateMatchMakeTag(600502, true, Cs(RegulationColor, "NeutralKillerRegulationTag"), false, null); // 第三キル人外入り
         ManyRolesRegulationTag = CreateMatchMakeTag(600503, true, Cs(RegulationColor, "ManyRolesRegulationTag"), false, null); // 多役
@@ -254,6 +254,11 @@ public static class MatchTagOption
         TryingOutRolesRegulationTag = CreateMatchMakeTag(600508, true, Cs(RegulationColor, "TryingOutRolesRegulationTag"), false, null); // 役職お試し中(・ω・　)
         AmusementRegulationTag = CreateMatchMakeTag(600509, true, Cs(RegulationColor, "AmusementRegulationTag"), false, null); // お遊びレギュ
         RegulationAdjustedTag = CreateMatchMakeTag(600510, true, Cs(RegulationColor, "RegulationAdjustedTag"), false, null); // レギュ調整中
+        // SHRでは表示しない設定を内部的にもオフにする
+        if(ModeHandler.IsMode(ModeId.SuperHostRoles))
+        {
+            TakadaVillageRegulationTag.selection = 0;
+        }
 
         // デバッグ : 600600 ~
         Color debugColor = (Color)Roles.RoleClass.Debugger.color;

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -118,6 +118,7 @@ public static class MatchMaker
                 string tagKey = ModTranslation.GetTranslateKey(tagName);
 
                 ActiveTags.Add($"{tagKey}");
+                Logger.Info($"タグ情報 : {tagName}({option.id}) を送信します。" ,"UpdateTags");
             }
         }
         data["updatetags"] = string.Join(',', ActiveTags);

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -301,12 +301,12 @@ public static class MatchTagOption
         // デバッグ : 600600 ~
         Color debugColor = (Color)Roles.RoleClass.Debugger.color;
         bool notDebugMode = !ConfigRoles.DebugMode.Value;
-        DebugNewRolesTag = CreateMatchMakeTag(600700, true, Cs(debugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
-        DebugNewFeaturesTag = CreateMatchMakeTag(600701, true, Cs(debugColor, "新機能"), false, null, isHidden: notDebugMode);
-        DebugAddFeaturesTag = CreateMatchMakeTag(600702, true, Cs(debugColor, "機能追加"), false, null, isHidden: notDebugMode);
-        DebugChangeTag = CreateMatchMakeTag(600703, true, Cs(debugColor, "仕様変更"), false, null, isHidden: notDebugMode);
-        DebugBugFixTag = CreateMatchMakeTag(600704, true, Cs(debugColor, "バグ修正"), false, null, isHidden: notDebugMode);
-        DebugOthersTag = CreateMatchMakeTag(600705, true, Cs(debugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
+        DebugNewRolesTag = CreateMatchMakeTag(600700, true, Cs(debugColor, "DebugNewRolesTag"), false, null, isHeader: true, isHidden: notDebugMode);
+        DebugNewFeaturesTag = CreateMatchMakeTag(600701, true, Cs(debugColor, "DebugNewFeaturesTag"), false, null, isHidden: notDebugMode);
+        DebugAddFeaturesTag = CreateMatchMakeTag(600702, true, Cs(debugColor, "DebugAddFeaturesTag"), false, null, isHidden: notDebugMode);
+        DebugChangeTag = CreateMatchMakeTag(600703, true, Cs(debugColor, "DebugChangeTag"), false, null, isHidden: notDebugMode);
+        DebugBugFixTag = CreateMatchMakeTag(600704, true, Cs(debugColor, "DebugBugFixTag"), false, null, isHidden: notDebugMode);
+        DebugOthersTag = CreateMatchMakeTag(600705, true, Cs(debugColor, "DebugOthersTag"), false, null, isHidden: notDebugMode);
 
         if (notDebugMode)
         {

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -6,6 +6,8 @@ using SuperNewRoles.Mode;
 using AmongUs.GameOptions;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using System.Linq;
+using static SuperNewRoles.Modules.CustomOption;
+using static SuperNewRoles.Modules.CustomOptionHolder;
 
 namespace SuperNewRoles.Modules;
 
@@ -145,5 +147,132 @@ public static class MatchMaker
         }
         data["Server"] = server;
         AmongUsClient.Instance.StartCoroutine(Analytics.Post(BaseURL + "api/create_room", data.GetString()).WrapToIl2Cpp());
+    }
+}
+
+public static class MatchTagOption
+{
+    // 村レベル : 600000 ~
+    public static CustomOption BeginnerTag; // 初心者
+    public static CustomOption IntermediateTag; // 中級
+    public static CustomOption AdvancedTag; // 上級者
+    public static CustomOption CompetenceIsNotRequiredTag; // 実力不問
+
+    // プレイスタンス : 600100 ~
+    public static CustomOption SeriousTag; // ガチ勢
+    public static CustomOption EnjoyTag;  // エンジョイ勢
+
+    // プレイスタイル : 600200 ~
+    public static CustomOption SeriousnessTag; // 真剣プレイ
+    public static CustomOption WelcomeBeginnerTag; // 初心者歓迎
+
+    // 状態 600300
+    public static CustomOption NowRecordingTag; // 撮影中
+    public static CustomOption NowBeingDeliveredTag; // 配信中
+    public static CustomOption OKForRecordingTag; // 撮影OK
+    public static CustomOption OKForBeingDeliveredTag; // 配信OK
+    public static CustomOption NoRecordingTag; // 撮影NG
+    public static CustomOption NoBeingDeliveredTag; // 配信NG
+
+
+    // 会議方法 : 600400 ~
+    public static CustomOption FreeChatTag; // フリーチャット
+    public static CustomOption QuickChatTag; // クイックチャット
+    public static CustomOption VoiceChatTag; // VC
+    public static CustomOption BetterCrewLinkTag; // 近アモ
+    public static CustomOption CanListenOnlyTag; // 聞き専可
+    public static CustomOption FullVCOnlyTag; // 聞き専不可
+
+    // レギュレーション : 600500 ~
+    public static CustomOption TakadaVillageRegulationTag; // 高田村レギュ
+    public static CustomOption SheriffAndMadRegulationTag; // シェリマ
+    public static CustomOption NeutralKillerRegulationTag; // 第三キル人外入り
+    public static CustomOption VillageForOutsidersRegulationTag; // 人外村
+    public static CustomOption ManyRolesRegulationTag; // 多役
+    public static CustomOption WerewolfMoonlightRegulationTag; // 月下
+    public static CustomOption DarkPotRegulationTag; // 闇鍋
+    public static CustomOption OthersRegulationTag; // その他レギュ
+    public static CustomOption TryingOutRolesRegulationTag; // 役職お試し中(・ω・　)
+    public static CustomOption AmusementRegulationTag; // お遊びレギュ
+    public static CustomOption RegulationAdjustedTag; // レギュ調整中
+
+    // デバック : 600600 ~
+    public static CustomOption DebugNewRolesTag; // 新役職
+    public static CustomOption DebugNewFeaturesTag; // 新機能
+    public static CustomOption DebugAddFeaturesTag; // 機能追加
+    public static CustomOption DebugChangeTag; // 仕様変更
+    public static CustomOption DebugBugFixTag; // バグ修正
+    public static CustomOption DebugOthersTag; // その他(デバック)
+
+    public static void LoadOption()
+    {
+        // 村レベル : 600000 ~
+        Color villageLvColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        BeginnerTag = CreateMatchMakeTag(600000, true, Cs(villageLvColor, "BeginnerTag"), false, null, isHeader: true); // 初心者
+        IntermediateTag = CreateMatchMakeTag(600001, true, Cs(villageLvColor, "IntermediateTag"), false, null); // 中級者
+        AdvancedTag = CreateMatchMakeTag(600002, true, Cs(villageLvColor, "AdvancedTag"), false, null); // 上級者
+        CompetenceIsNotRequiredTag = CreateMatchMakeTag(600003, true, Cs(villageLvColor, "CompetenceIsNotRequiredTag"), false, null); // 実力不問
+
+        // プレイスタンス : 600100 ~
+        Color playingStanceColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        SeriousTag = CreateMatchMakeTag(600100, true, Cs(playingStanceColor, "SeriousTag"), false, null, isHeader: true); // ガチ勢
+        EnjoyTag = CreateMatchMakeTag(600101, true, Cs(playingStanceColor, "EnjoyTag"), false, null);  // エンジョイ勢
+
+        // プレイスタイル : 600200 ~
+        Color playingStyleColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        SeriousnessTag = CreateMatchMakeTag(600200, true, Cs(playingStyleColor, "SeriousnessTag"), false, null, isHeader: true); // 真剣プレイ
+        WelcomeBeginnerTag = CreateMatchMakeTag(600201, true, Cs(playingStyleColor, "WelcomeBeginnerTag"), false, null); // 初心者歓迎
+
+        // 状態 600300
+        Color conditionColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        NowRecordingTag = CreateMatchMakeTag(600300, true, Cs(conditionColor, "NowRecordingTag"), false, null, isHeader: true); // 撮影中
+        NowBeingDeliveredTag = CreateMatchMakeTag(600301, true, Cs(conditionColor, "NowBeingDeliveredTag"), false, null); // 配信中
+        OKForRecordingTag = CreateMatchMakeTag(600302, true, Cs(conditionColor, "OKForRecordingTag"), false, null); // 撮影OK
+        OKForBeingDeliveredTag = CreateMatchMakeTag(600303, true, Cs(conditionColor, "OKForBeingDeliveredTag"), false, null); // 配信OK
+        NoRecordingTag = CreateMatchMakeTag(600304, true, Cs(conditionColor, "NoRecordingTag"), false, null); // 撮影NG
+        NoBeingDeliveredTag = CreateMatchMakeTag(600305, true, Cs(conditionColor, "NoBeingDeliveredTag"), false, null); // 配信NG
+
+        // 会議方法 : 600400 ~
+        Color meetingSystemColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        FreeChatTag = CreateMatchMakeTag(600400, true, Cs(meetingSystemColor, "FreeChatTag"), false, null, isHeader: true); // フリーチャット
+        QuickChatTag = CreateMatchMakeTag(600401, true, Cs(meetingSystemColor, "QuickChatTag"), false, null); // クイックチャット
+        VoiceChatTag = CreateMatchMakeTag(600402, true, Cs(meetingSystemColor, "VoiceChatTag"), false, null); // VC
+        BetterCrewLinkTag = CreateMatchMakeTag(600403, true, Cs(meetingSystemColor, "BetterCrewLinkTag"), false, null); // 近アモ
+        CanListenOnlyTag = CreateMatchMakeTag(600404, true, Cs(meetingSystemColor, "CanListenOnlyTag"), false, null); // 聞き専可
+        FullVCOnlyTag = CreateMatchMakeTag(600405, true, Cs(meetingSystemColor, "FullVCOnlyTag"), false, null); // 聞き専不可
+
+        // レギュレーション : 600500 ~
+        Color RegulationColor = new(255f / 255f, 255f / 255f, 255f / 255f, 1);
+        TakadaVillageRegulationTag = CreateMatchMakeTag(600500, true, Cs(RegulationColor, "TakadaVillageRegulationTag"), false, null, isHeader: true); // 高田村レギュ
+        SheriffAndMadRegulationTag = CreateMatchMakeTag(600501, true, Cs(RegulationColor, "SheriffAndMadRegulationTag"), false, null); // シェリマ
+        NeutralKillerRegulationTag = CreateMatchMakeTag(600502, true, Cs(RegulationColor, "NeutralKillerRegulationTag"), false, null); // 第三キル人外入り
+        ManyRolesRegulationTag = CreateMatchMakeTag(600503, true, Cs(RegulationColor, "ManyRolesRegulationTag"), false, null); // 多役
+        WerewolfMoonlightRegulationTag = CreateMatchMakeTag(600504, true, Cs(RegulationColor, "WerewolfMoonlightRegulationTag"), false, null); // 月下
+        VillageForOutsidersRegulationTag = CreateMatchMakeTag(600505, true, Cs(RegulationColor, "VillageForOutsidersRegulationTag"), false, null); // 人外村
+        DarkPotRegulationTag = CreateMatchMakeTag(600506, true, Cs(RegulationColor, "DarkPotRegulationTag"), false, null); // 闇鍋
+        OthersRegulationTag = CreateMatchMakeTag(600507, true, Cs(RegulationColor, "OthersRegulationTag"), false, null); // その他
+        TryingOutRolesRegulationTag = CreateMatchMakeTag(600508, true, Cs(RegulationColor, "TryingOutRolesRegulationTag"), false, null); // 役職お試し中(・ω・　)
+        AmusementRegulationTag = CreateMatchMakeTag(600509, true, Cs(RegulationColor, "AmusementRegulationTag"), false, null); // お遊びレギュ
+        RegulationAdjustedTag = CreateMatchMakeTag(600510, true, Cs(RegulationColor, "RegulationAdjustedTag"), false, null); // レギュ調整中
+
+        // デバッグ : 600600 ~
+        Color DebugColor = new(82f / 255f, 82f / 255f, 82f / 255f, 1);
+        bool notDebugMode = !ConfigRoles.DebugMode.Value;
+        DebugNewRolesTag = CreateMatchMakeTag(600600, true, Cs(DebugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
+        DebugNewFeaturesTag = CreateMatchMakeTag(600601, true, Cs(DebugColor, "新機能"), false, null, isHidden: notDebugMode);
+        DebugAddFeaturesTag = CreateMatchMakeTag(600602, true, Cs(DebugColor, "機能追加"), false, null, isHidden: notDebugMode);
+        DebugChangeTag = CreateMatchMakeTag(600603, true, Cs(DebugColor, "仕様変更"), false, null, isHidden: notDebugMode);
+        DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(DebugColor, "バグ修正"), false, null, isHidden: notDebugMode);
+        DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(DebugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
+
+        if (notDebugMode)
+        {
+            DebugNewRolesTag.selection = 0;
+            DebugNewFeaturesTag.selection = 0;
+            DebugAddFeaturesTag.selection = 0;
+            DebugChangeTag.selection = 0;
+            DebugBugFixTag.selection = 0;
+            DebugOthersTag.selection = 0;
+        }
     }
 }

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -265,7 +265,7 @@ public static class MatchTagOption
         DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(DebugColor, "バグ修正"), false, null, isHidden: notDebugMode);
         DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(DebugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
 
-        if (!notDebugMode)
+        if (notDebugMode)
         {
             DebugNewRolesTag.selection = 0;
             DebugNewFeaturesTag.selection = 0;

--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -256,14 +256,14 @@ public static class MatchTagOption
         RegulationAdjustedTag = CreateMatchMakeTag(600510, true, Cs(RegulationColor, "RegulationAdjustedTag"), false, null); // レギュ調整中
 
         // デバッグ : 600600 ~
-        Color DebugColor = new(82f / 255f, 82f / 255f, 82f / 255f, 1);
+        Color debugColor = (Color)Roles.RoleClass.Debugger.color;
         bool notDebugMode = !ConfigRoles.DebugMode.Value;
-        DebugNewRolesTag = CreateMatchMakeTag(600600, true, Cs(DebugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
-        DebugNewFeaturesTag = CreateMatchMakeTag(600601, true, Cs(DebugColor, "新機能"), false, null, isHidden: notDebugMode);
-        DebugAddFeaturesTag = CreateMatchMakeTag(600602, true, Cs(DebugColor, "機能追加"), false, null, isHidden: notDebugMode);
-        DebugChangeTag = CreateMatchMakeTag(600603, true, Cs(DebugColor, "仕様変更"), false, null, isHidden: notDebugMode);
-        DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(DebugColor, "バグ修正"), false, null, isHidden: notDebugMode);
-        DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(DebugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
+        DebugNewRolesTag = CreateMatchMakeTag(600600, true, Cs(debugColor, "新役職"), false, null, isHeader: true, isHidden: notDebugMode);
+        DebugNewFeaturesTag = CreateMatchMakeTag(600601, true, Cs(debugColor, "新機能"), false, null, isHidden: notDebugMode);
+        DebugAddFeaturesTag = CreateMatchMakeTag(600602, true, Cs(debugColor, "機能追加"), false, null, isHidden: notDebugMode);
+        DebugChangeTag = CreateMatchMakeTag(600603, true, Cs(debugColor, "仕様変更"), false, null, isHidden: notDebugMode);
+        DebugBugFixTag = CreateMatchMakeTag(600604, true, Cs(debugColor, "バグ修正"), false, null, isHidden: notDebugMode);
+        DebugOthersTag = CreateMatchMakeTag(600605, true, Cs(debugColor, "その他(デバッグ)"), false, null, isHidden: notDebugMode);
 
         if (notDebugMode)
         {

--- a/SuperNewRoles/Modules/ModTranslation.cs
+++ b/SuperNewRoles/Modules/ModTranslation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using System.Reflection;
 using AmongUs.Data;
@@ -41,6 +42,38 @@ public static class ModTranslation
             SupportedLangs.TChinese => dictionary[key][4],// 繁体中国語
             _ => dictionary[key][1] // それ以外は英語
         };
+    }
+
+    /// <summary>
+    /// 翻訳語の文章から翻訳キーを取得する。
+    /// CustomOptionで追加しているカラータグは先に外してください。
+    /// </summary>
+    /// <param name="value">keyを取得したい翻訳後の文</param>
+    /// <returns>keyが存在 => key / keyが存在しない => 引数をそのまま返す </returns>
+    internal static string GetTranslateKey(string value)
+    {
+        SupportedLangs langId = TranslationController.InstanceExists ? TranslationController.Instance.currentLanguage.languageID : DataManager.Settings.Language.CurrentLanguage;
+
+        int index = langId switch
+        {
+            SupportedLangs.English => 1,
+            SupportedLangs.Japanese => 2,
+            SupportedLangs.SChinese => 3,
+            SupportedLangs.TChinese => 4,
+            _ => 1,
+        };
+
+        string key = dictionary.FirstOrDefault(x => x.Value[index].Equals(value)).Key;
+        if (key != null)
+        {
+            Logger.Info($"{key}", "ModTranslation");
+            return key;
+        }
+        else
+        {
+            Logger.Info($"key not found:{value}", "ModTranslation");
+            return value;
+        }
     }
 
     public static void LoadCsv()

--- a/SuperNewRoles/Patches/GameStartPatch.cs
+++ b/SuperNewRoles/Patches/GameStartPatch.cs
@@ -25,7 +25,10 @@ class GameStartPatch
         {
             lastPublic = AmongUsClient.Instance.IsGamePublic;
             if (lastPublic && AmongUsClient.Instance.AmHost)
+            {
                 Modules.MatchMaker.CreateRoom();
+                Modules.MatchMaker.UpdateTags();
+            }
             lastTimer = 0;
         }
     }
@@ -62,6 +65,7 @@ class GameStartPatch
                 if (AmongUsClient.Instance.IsGamePublic)
                 {
                     Modules.MatchMaker.CreateRoom();
+                    Modules.MatchMaker.UpdateTags();
                 }
                 else
                 {

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1378,7 +1378,7 @@ IsNotUsingBlood,Make the blood expression black.,血液表現を黒にする,和
 IsLightAndDarker,Show light and darker,明暗を表示する,显示颜色深浅,顯示顏色深淺
 
 #SettingMatchTag
-SettingMatchTag,<color=#a9ceec>Match making Tag</color> Settings,<color=#00ffff>マッチメイキング タグ</color>の設定
+SettingMatchTag,<color=#a9ceec>Match making Tag</color> Settings,<color=#93b69c>マッチメイキング タグ</color>の設定
 
 BeginnerTag,Beginner,初心者
 IntermediateTag,Intermediate,中級者

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1445,6 +1445,7 @@ Team,Team,陣営,阵营,陣營
 TeamRoleType,Role,役職,,職業
 MessageSettings,Settings,設定,设置,設定
 NowRolesMessage,Activate Roles,現在入っている役職,当前激活的职业,當前啟用的職業
+EnableTagsMessage,,現在設定されているマッチメイキングタグ,
 NotAssign,This is the mode in which no roles are assigned.,役職が選出されないモードに設定されています。,目前还没有激活任何职业。,目前還沒有啟用任何職業
 MyRoleErrorSHRMode,This command is not available in SHR mode.,SHRモードではこのコマンドは使用できません。,,在SHR模式中無法使用此指令。
 TeamMessage,【Team:{0}】,【{0}陣営】,【{0}阵营】,【{0}陣營】

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1405,7 +1405,6 @@ BetterCrewLinkTag,Use BetterCrewLink,近アモ
 CanListenOnlyTag,Listen only OK,聞き専可
 FullVCOnlyTag,Always use voice chat,聞き専不可
 
-TakadaVillageRegulationTag,Takada Village Regulation,高田村レギュ
 SheriffAndMadRegulationTag,Regulation with Sheriff and Madrole,シェリマ
 NeutralKillerRegulationTag,Regulation with neutral killer,第三キル人外入り
 VillageForOutsidersRegulationTag,Regulation for outsiders  village,人外村

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1377,6 +1377,46 @@ PteranodonButtonName,Juump!!,ジャーンプ！,飞跃,起飛！
 IsNotUsingBlood,Make the blood expression black.,血液表現を黒にする,和谐血液显示,血液黑色表示
 IsLightAndDarker,Show light and darker,明暗を表示する,显示颜色深浅,顯示顏色深淺
 
+#SettingMatchTag
+SettingMatchTag,<color=#a9ceec>Match making Tag</color> Settings,<color=#00ffff>マッチメイキング タグ</color>の設定
+
+BeginnerTag,Beginner,初心者
+IntermediateTag,Intermediate,中級者
+AdvancedTag,Advanced,上級者
+CompetenceIsNotRequiredTag,Competence is not required.,実力不問
+
+SeriousTag,Serious Players,ガチ勢
+EnjoyTag,Enjoyers,エンジョイ勢
+
+SeriousnessTag,Seriousness Play,真剣プレイ
+WelcomeBeginnerTag,,初心者歓迎
+
+NowRecordingTag,Now Recording,撮影中
+NowBeingDeliveredTag,Now Being Delivered,配信中
+OKForRecordingTag,OK for Recording,撮影OK
+OKForBeingDeliveredTag,OK for Recording,配信OK
+NoRecordingTag,No Recording,撮影NG
+NoBeingDeliveredTag,No Recording,配信NG
+
+FreeChatTag,FreeChat,フリーチャット
+QuickChatTag,QuickChat,クイックチャット
+VoiceChatTag,VoiceChat,VC
+BetterCrewLinkTag,Use BetterCrewLink,近アモ
+CanListenOnlyTag,Listen only OK,聞き専可
+FullVCOnlyTag,Always use voice chat,聞き専不可
+
+TakadaVillageRegulationTag,Takada Village Regulation,高田村レギュ
+SheriffAndMadRegulationTag,Regulation with Sheriff and Madrole,シェリマ
+NeutralKillerRegulationTag,Regulation with neutral killer,第三キル人外入り
+VillageForOutsidersRegulationTag,Regulation for outsiders  village,人外村
+ManyRolesRegulationTag,Regulation with many roles,多役
+WerewolfMoonlightRegulationTag,Werewolf Moonlight Regulation,月下
+DarkPotRegulationTag,Dark pot,闇鍋
+OthersRegulationTag,Others regulation,その他レギュ
+TryingOutRolesRegulationTag,Trying out a roles.,役職お試し中
+AmusementRegulationTag,Amusement regulation,お遊びレギュ
+RegulationAdjustedTag,Adjusted,レギュ調整中
+
 # Other
 WelcomeMessage1,Welcome to SuperNewRoles!,SuperNewRolesへようこそ！,欢迎游玩Super New Roles（超新职业）！,歡迎遊玩Super New Roles（超新執業）！
 WelcomeMessage2,You can play a variety of modes and different hard on any model with SuperNewRoles!,SuperNewRolesを使用することで、様々なモードや様々な役職をどの機種でも遊べます！,您可以在超新职业体验各种不同的模式和职业！,您可以在超新職業體驗各種不同的模式和職業！

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1398,8 +1398,8 @@ OKForBeingDeliveredTag,OK for Recording,配信OK
 NoRecordingTag,No Recording,撮影NG
 NoBeingDeliveredTag,No Recording,配信NG
 
-FreeChatTag,FreeChat,フリーチャット
-QuickChatTag,QuickChat,クイックチャット
+FreeChatTag,FreeChat Only,フリーチャットのみ
+QuickChatTag,QuickChat Only,クイックチャットのみ
 VoiceChatTag,VoiceChat,VC
 BetterCrewLinkTag,Use BetterCrewLink,近アモ
 CanListenOnlyTag,Listen only OK,聞き専可

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1419,6 +1419,13 @@ RegulationAdjustedTag,Adjusted,レギュ調整中
 FeatureAdminLimitTag,Admin Use Restrictions,アドミン使用制限
 FeatureCanNotUseAdminTag,Admin use prohibited,アドミン禁止
 
+DebugNewRolesTag,New Roles,新役職
+DebugNewFeaturesTag,New Features,新機能
+DebugAddFeaturesTag,Add Features,機能追加
+DebugChangeTag,Change,仕様変更
+DebugBugFixTag,Fix Bug,バグ修正
+DebugOthersTag,Others,その他(デバッグ)
+
 # Other
 WelcomeMessage1,Welcome to SuperNewRoles!,SuperNewRolesへようこそ！,欢迎游玩Super New Roles（超新职业）！,歡迎遊玩Super New Roles（超新執業）！
 WelcomeMessage2,You can play a variety of modes and different hard on any model with SuperNewRoles!,SuperNewRolesを使用することで、様々なモードや様々な役職をどの機種でも遊べます！,您可以在超新职业体验各种不同的模式和职业！,您可以在超新職業體驗各種不同的模式和職業！

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -1417,6 +1417,9 @@ TryingOutRolesRegulationTag,Trying out a roles.,役職お試し中
 AmusementRegulationTag,Amusement regulation,お遊びレギュ
 RegulationAdjustedTag,Adjusted,レギュ調整中
 
+FeatureAdminLimitTag,Admin Use Restrictions,アドミン使用制限
+FeatureCanNotUseAdminTag,Admin use prohibited,アドミン禁止
+
 # Other
 WelcomeMessage1,Welcome to SuperNewRoles!,SuperNewRolesへようこそ！,欢迎游玩Super New Roles（超新职业）！,歡迎遊玩Super New Roles（超新執業）！
 WelcomeMessage2,You can play a variety of modes and different hard on any model with SuperNewRoles!,SuperNewRolesを使用することで、様々なモードや様々な役職をどの機種でも遊べます！,您可以在超新职业体验各种不同的模式和职业！,您可以在超新職業體驗各種不同的模式和職業！

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -245,7 +245,7 @@ public static class RoleClass
     public static class Debugger
     {
         public static bool AmDebugger;
-        public static Color32 color = new(130, 130, 130, byte.MaxValue);
+        public static Color32 color = new(149, 148, 154, byte.MaxValue);
         public static Sprite GetButtonSprite() => ModHelpers.LoadSpriteFromResources("SuperNewRoles.Resources.GhostMechanicRepairButton.png", 115f);
 
         public static void ClearAndReload()


### PR DESCRIPTION
# 説明
- 名前ランダム化前で部屋主の名前でレギュレーション機能を設定していた物の代価機能。
  - 部屋主の名前を表示させると, サーバの荒らしができてしまう為, タグとして設定するように。
- CustomOptionとして実装した。
  - 設定画面が見づらかった為, レギュレーションには表示しないようにしている。
   -  チャットコマンド及びカスタムオーバーレイ(T)で確認できるようにした。
  - 情報送信はCustomOptionとしてでは無く, タグとして分離させ別枠で送信している。
- 翻訳辞書のvalueからkeyを取得するメソッドを作成。
  - これにより, タグの翻訳前の文章取得を実装した。
- ゲーム&配役設定が変更されたらそれのみが, タグが更新されたらタグのみが送信されるようにした。
  - 変更された設定のidにより判別している
    - 変更されたidが ``id == 0 ``又は, ``100000 <= id < 600000``の時は設定のみを送信。
      - <details><summary>log画像</summary><div><img src="https://github.com/ykundesu/SuperNewRoles/assets/104145991/98cfe975-51e4-48dd-959d-0ae0ec08450b"></div></details>
    - 変更されたidが``600000 <= id < 600000``の時はタグのみを送信。
      - <details><summary>log画像</summary><div><img src="https://github.com/ykundesu/SuperNewRoles/assets/104145991/284e678a-4389-4452-bb15-ff5c43be2824"></div></details>