### PR TITLE
タグの情報を送信していなかった問題を修正&部屋作成と設定更新時で動くメソッドを分けた

### DIFF
--- a/SuperNewRoles/Modules/MatchMaker.cs
+++ b/SuperNewRoles/Modules/MatchMaker.cs
@@ -90,10 +90,14 @@ public static class MatchMaker
         data["mode"] = GameOptionsManager.Instance.currentGameMode == GameModes.HideNSeek ? "HNS" : ModeHandler.GetMode(false).ToString();
         AmongUsClient.Instance.StartCoroutine(Analytics.Post(BaseURL + "api/update_state", data.GetString()).WrapToIl2Cpp());
     }
-    public static void UpdateTags()
+    internal static void UpdateTags()
     {
         var data = CreateBaseData();
-        data["type"] = "updatetags";
+        data["updatetags"] = GetTagData();
+        AmongUsClient.Instance.StartCoroutine(Analytics.Post(BaseURL + "api/update_state", data.GetString()).WrapToIl2Cpp());
+    }
+    private static string GetTagData()
+    {
         List<string> ActiveTags = new();
         foreach (CustomOption option in options)
         {
@@ -118,10 +122,11 @@ public static class MatchMaker
                 string tagKey = ModTranslation.GetTranslateKey(tagName);
 
                 ActiveTags.Add($"{tagKey}");
-                Logger.Info($"タグ情報 : {tagName}({option.id}) を送信します。" ,"UpdateTags");
+                Logger.Info($"タグ情報 : {tagName}({option.id}) を送信します。");
             }
         }
-        data["updatetags"] = string.Join(',', ActiveTags);
+        string tagData = string.Join(',', ActiveTags);
+        return tagData;
     }
     public static void CreateRoom()
     {
@@ -167,6 +172,7 @@ public static class MatchMaker
         data["NowPlayer"] = GameData.Instance.PlayerCount.ToString();
         data["MaxPlayer"] = GameOptionsManager.Instance.CurrentGameOptions.MaxPlayers.ToString();
         data["Version"] = SuperNewRolesPlugin.VersionString;
+        data["updatetags"] = GetTagData();
         string server = "NoneServer";
         StringNames n = FastDestroyableSingleton<ServerManager>.Instance.CurrentRegion.TranslateName;
         switch (n)

--- a/SuperNewRoles/Patches/GameStartPatch.cs
+++ b/SuperNewRoles/Patches/GameStartPatch.cs
@@ -27,7 +27,6 @@ class GameStartPatch
             if (lastPublic && AmongUsClient.Instance.AmHost)
             {
                 Modules.MatchMaker.CreateRoom();
-                Modules.MatchMaker.UpdateTags();
             }
             lastTimer = 0;
         }
@@ -65,7 +64,6 @@ class GameStartPatch
                 if (AmongUsClient.Instance.IsGamePublic)
                 {
                     Modules.MatchMaker.CreateRoom();
-                    Modules.MatchMaker.UpdateTags();
                 }
                 else
                 {


### PR DESCRIPTION
- RoomCreateの時に同時送信するようにし, Updateの時はもともとのメソッドを使用している。
- タグの情報を取得するメソッドをUpdateTagから分離し,RoomCreate時で流用できるようにした。