### PR TITLE
翻訳システムのパフォーマンスを改善

### DIFF
--- a/SuperNewRoles/Modules/ModTranslation.cs
+++ b/SuperNewRoles/Modules/ModTranslation.cs
@@ -10,37 +10,40 @@ public static class ModTranslation
 {
     // 一番左と一行全部
     private static Dictionary<string, string[]> dictionary = new();
-    private static readonly List<string> outputtedStr = new();
+    private static readonly HashSet<string> outputtedStr = new();
     public static string GetString(string key)
     {
         // アモアス側の言語読み込みが完了しているか ? 今の言語 : 最後の言語
-        SupportedLangs langId = TranslationController.InstanceExists ? TranslationController.Instance.currentLanguage.languageID : DataManager.Settings.Language.CurrentLanguage;
+        SupportedLangs langId = DestroyableSingleton<TranslationController>.InstanceExists ? FastDestroyableSingleton<TranslationController>.Instance.currentLanguage.languageID : DataManager.Settings.Language.CurrentLanguage;
 
-        if (!dictionary.ContainsKey(key)) return key; // keyが辞書にないならkeyのまま返す
+        if (!dictionary.TryGetValue(key, out string[] values)) return key; // keyが辞書にないならkeyのまま返す
 
-        if (dictionary[key].Length < 4 || dictionary[key][3] == "")
-        { //簡体中国語がない場合英語で返す
-            if (!outputtedStr.Contains(key))
-                Logger.Info($"SChinese not found:{key}", "ModTranslation");
-            outputtedStr.Add(key);
-            if (langId == SupportedLangs.SChinese) return dictionary[key][1];
-        }
+        if (langId is SupportedLangs.SChinese or SupportedLangs.TChinese)
+        {
+            if (langId == SupportedLangs.SChinese && (values.Length < 4 || values[3] == ""))
+            { //簡体中国語がない場合英語で返す
+                if (!outputtedStr.Contains(key))
+                    Logger.Info($"SChinese not found:{key}", "ModTranslation");
+                outputtedStr.Add(key);
+                return values[1];
+            }
 
-        if (dictionary[key].Length < 5 || dictionary[key][4] == "")
-        { //繁体中国語がない場合英語で返す
-            if (!outputtedStr.Contains(key))
-                Logger.Info($"TChinese not found:{key}", "ModTranslation");
-            outputtedStr.Add(key);
-            if (langId == SupportedLangs.TChinese) return dictionary[key][1];
+            if (langId == SupportedLangs.TChinese && (values.Length < 5 || values[4] == ""))
+            { //繁体中国語がない場合英語で返す
+                if (!outputtedStr.Contains(key))
+                    Logger.Info($"TChinese not found:{key}", "ModTranslation");
+                outputtedStr.Add(key);
+                return values[1];
+            }
         }
 
         return langId switch
         {
-            SupportedLangs.English => dictionary[key][1], // 英語
-            SupportedLangs.Japanese => dictionary[key][2],// 日本語
-            SupportedLangs.SChinese => dictionary[key][3],// 簡体中国語
-            SupportedLangs.TChinese => dictionary[key][4],// 繁体中国語
-            _ => dictionary[key][1] // それ以外は英語
+            SupportedLangs.English => values[1], // 英語
+            SupportedLangs.Japanese => values[2],// 日本語
+            SupportedLangs.SChinese => values[3],// 簡体中国語
+            SupportedLangs.TChinese => values[4],// 繁体中国語
+            _ => values[1] // それ以外は英語
         };
     }
 


### PR DESCRIPTION
・outputtedStrをListからHashsetにして高速化
・そもそも中国語じゃない場合不必要な処理を実行しないように変更
・TranslationControllerでDestroyableSingletonもしくはFastDestroyableSingletonを使用するように変更
・TryGetValueを使用して、毎回のデータへのアクセスをなくした