### PR TITLE
ゲッサー項目追加

### DIFF
--- a/SuperNewRoles/Roles/Attribute/Guesser.cs
+++ b/SuperNewRoles/Roles/Attribute/Guesser.cs
@@ -188,7 +188,8 @@ class Guesser
         if (CustomOptionHolder.RevolutionistAndDictatorOption.GetSelection() is not 0) { CreateRole(IntroData.DictatorIntro); CreateRole(IntroData.RevolutionistIntro); }
         if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() is not 0) { CreateRole(IntroData.AssassinIntro); CreateRole(IntroData.MarlinIntro); }
         if (CustomOptionHolder.ChiefOption.GetSelection() is not 0) { CreateRole(IntroData.SheriffIntro);}
-        if (CustomOptionHolder.MadMakerOption.GetSelection() is not 0 || CustomOptionHolder.FastMakerOption.GetSelection() is not 0)
+        if (CustomOptionHolder.MadMakerOption.GetSelection() is not 0 || CustomOptionHolder.FastMakerOption.GetSelection() is not 0 ||
+            (CustomOptionHolder.LevelingerOption.GetSelection() is not 0 && Levelinger.LevelingerCanUse("SidekickName")))
             { CreateRole(IntroData.MadmateIntro);}
         if (CustomOptionHolder.SideKillerOption.GetSelection() is not 0) { CreateRole(IntroData.MadKillerIntro);}
         if (CustomOptionHolder.VampireOption.GetSelection() is not 0) { CreateRole(IntroData.DependentsIntro);}

--- a/SuperNewRoles/Roles/Attribute/Guesser.cs
+++ b/SuperNewRoles/Roles/Attribute/Guesser.cs
@@ -187,6 +187,12 @@ class Guesser
         if (CustomOptionHolder.PavlovsownerOption.GetSelection() is not 0) CreateRole(IntroData.PavlovsdogsIntro);
         if (CustomOptionHolder.RevolutionistAndDictatorOption.GetSelection() is not 0) { CreateRole(IntroData.DictatorIntro); CreateRole(IntroData.RevolutionistIntro); }
         if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() is not 0) { CreateRole(IntroData.AssassinIntro); CreateRole(IntroData.MarlinIntro); }
+        if (CustomOptionHolder.ChiefOption.GetSelection() is not 0) { CreateRole(IntroData.SheriffIntro);}
+        if (CustomOptionHolder.MadMakerOption.GetSelection() is not 0 || CustomOptionHolder.FastMakerOption.GetSelection() is not 0)
+            { CreateRole(IntroData.MadmateIntro);}
+        if (CustomOptionHolder.SideKillerOption.GetSelection() is not 0) { CreateRole(IntroData.MadKillerIntro);}
+        if (CustomOptionHolder.VampireOption.GetSelection() is not 0) { CreateRole(IntroData.DependentsIntro);}
+        if (OrientalShaman.OrientalShamanOption.GetSelection() is not 0) { CreateRole(IntroData.ShermansServantIntro);}
         void CreateRole(IntroData roleInfo)
         {
             if (40 <= i[(int)roleInfo.Team]) i[(int)roleInfo.Team] = 0;

--- a/SuperNewRoles/Roles/Attribute/Guesser.cs
+++ b/SuperNewRoles/Roles/Attribute/Guesser.cs
@@ -189,7 +189,9 @@ class Guesser
         if (CustomOptionHolder.AssassinAndMarlinOption.GetSelection() is not 0) { CreateRole(IntroData.AssassinIntro); CreateRole(IntroData.MarlinIntro); }
         if (CustomOptionHolder.ChiefOption.GetSelection() is not 0) { CreateRole(IntroData.SheriffIntro);}
         if (CustomOptionHolder.MadMakerOption.GetSelection() is not 0 || CustomOptionHolder.FastMakerOption.GetSelection() is not 0 ||
-            (CustomOptionHolder.LevelingerOption.GetSelection() is not 0 && Levelinger.LevelingerCanUse("SidekickName")))
+            (CustomOptionHolder.LevelingerOption.GetSelection() is not 0 && Levelinger.LevelingerCanUse("SidekickName")) ||
+            (CustomOptionHolder.EvilSeerOption.GetSelection() is not 0 && CustomOptionHolder.EvilSeerMadmateSetting.GetBool()) ||
+            (CustomOptionHolder.EvilHackerOption.GetSelection() is not 0 && CustomOptionHolder.EvilHackerMadmateSetting.GetBool()))
             { CreateRole(IntroData.MadmateIntro);}
         if (CustomOptionHolder.SideKillerOption.GetSelection() is not 0) { CreateRole(IntroData.MadKillerIntro);}
         if (CustomOptionHolder.VampireOption.GetSelection() is not 0) { CreateRole(IntroData.DependentsIntro);}

--- a/SuperNewRoles/Roles/Impostor/Levelinger.cs
+++ b/SuperNewRoles/Roles/Impostor/Levelinger.cs
@@ -1,4 +1,13 @@
 using SuperNewRoles.Helpers;
+using System.Collections.Generic;
+using SuperNewRoles.Patches;
+using SuperNewRoles.Roles;
+using SuperNewRoles.Roles.Crewmate;
+using SuperNewRoles.Roles.Impostor;
+using SuperNewRoles.Roles.Neutral;
+using SuperNewRoles.Roles.RoleBases;
+using UnityEngine;
+using static SuperNewRoles.Modules.CustomOption;
 
 namespace SuperNewRoles.Roles;
 
@@ -35,5 +44,16 @@ public static class Levelinger
                 RoleClass.Levelinger.ThisXP -= RoleClass.Levelinger.ReviveUseXP;
             }
         }
+    }
+    public static bool LevelingerCanUse(string data)
+    {
+        List<string> leveData = new() { "optionOff", "LevelingerSettingKeep", "PursuerName", "TeleporterName", "SidekickName", "SpeedBoosterName", "MovingName" };
+        if (!leveData.Contains(data)) return false;
+        if(CustomOptionHolder.LevelingerLevelOneGetPower.GetString() == ModTranslation.GetString(data) ||
+           CustomOptionHolder.LevelingerLevelTwoGetPower.GetString() == ModTranslation.GetString(data) ||
+           CustomOptionHolder.LevelingerLevelThreeGetPower.GetString() == ModTranslation.GetString(data) ||
+           CustomOptionHolder.LevelingerLevelFourGetPower.GetString() == ModTranslation.GetString(data) ||
+           CustomOptionHolder.LevelingerLevelFiveGetPower.GetString() == ModTranslation.GetString(data)) return true;
+        return false;
     }
 }


### PR DESCRIPTION
左の役職が配役されているときに、右の役職の項目を追加
-----------------------------------------------------------------
村長→シェリフ

マッドメーカー→マッドメイト
ファストメーカー→マッドメイト
レベリンガー(マッド作成可能)→マッドメイト
イビルハッカー→マッドメイト
イビルシーア→マッドメイト

サイドキラー→マッドキラー

ヴァンパイア→眷属

陰陽師→式神