### PR TITLE
EvilSeerの[死の点滅]に死者の色情報が分かる機能を追加 & カスタムメッセージの文字色を変更可能にした

### DIFF
--- a/SuperNewRoles/Modules/CustomMsg.cs
+++ b/SuperNewRoles/Modules/CustomMsg.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using static SuperNewRoles.Modules.CustomOptionHolder;
 
 namespace SuperNewRoles.Modules;
 
@@ -9,7 +10,16 @@ public class CustomMessage
     public readonly TMPro.TMP_Text text;
     private static readonly List<CustomMessage> customMessages = new();
 
-    public CustomMessage(string message, float duration)
+    /// <summary>
+    /// タスクフェイズ中画面下部にメッセージを表示する。
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="duration">メッセージを表示する時間</param>
+    /// <param name="useCustomColor">メッセージの色を変更するか</param>
+    /// <param name="firstColor">最初に表示するMessageの色</param>
+    /// <param name="secondColor"></param>
+    /// <returns></returns>
+    public CustomMessage(string message, float duration, bool useCustomColor = false, Color firstColor = new(), Color secondColor = default)
     {
         RoomTracker roomTracker = FastDestroyableSingleton<HudManager>.Instance?.roomTracker;
         if (roomTracker != null)
@@ -33,9 +43,25 @@ public class CustomMessage
                     return;
                 }
                 bool even = ((int)(p * duration / 0.25f)) % 2 == 0; // Bool flips every 0.25 seconds
-                string prefix = even ? "<color=#FCBA03FF>" : "<color=#FF0000FF>";
-                text.text = prefix + message + "</color>";
-                if (text != null) text.color = even ? Color.yellow : Color.red;
+                if (useCustomColor)
+                {
+                    firstColor = firstColor == default ? Color.yellow : firstColor;
+                    secondColor = secondColor == default ? firstColor : secondColor;
+
+                    text.text = even
+                        ? ModHelpers.Cs(firstColor, message)
+                        : ModHelpers.Cs(secondColor, message);
+
+                    if (text != null)
+                        text.color = even ? firstColor : secondColor;
+                }
+                else
+                {
+                    string prefix = even ? "<color=#FCBA03FF>" : "<color=#FF0000FF>";
+                    text.text = prefix + message + "</color>";
+                    if (text != null)
+                        text.color = even ? Color.yellow : Color.red;
+                }
                 if (p == 1f && text != null && text.gameObject != null)
                 {
                     UnityEngine.Object.Destroy(text.gameObject);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -525,6 +525,7 @@ public class CustomOptionHolder
     public static CustomOption EvilSeerPlayerCount;
     public static CustomOption EvilSeerMode;
     public static CustomOption EvilSeerIsFlashBodyColor;
+    public static CustomOption EvilSeerIsReportingBodyColorName;
     public static CustomOption EvilSeerFlashColorMode;
     public static CustomOption EvilSeerLimitSoulDuration;
     public static CustomOption EvilSeerSoulDuration;
@@ -1154,7 +1155,8 @@ public class CustomOptionHolder
         EvilSeerLimitSoulDuration = Create(201903, false, CustomOptionType.Impostor, "SeerLimitSoulDuration", false, EvilSeerOption);
         EvilSeerSoulDuration = Create(201904, false, CustomOptionType.Impostor, "SeerSoulDuration", 15f, 0f, 120f, 5f, EvilSeerLimitSoulDuration, format: "unitCouples");
         EvilSeerIsFlashBodyColor = Create(201906, false, CustomOptionType.Impostor, "EvilSeerIsFlashColor", true, EvilSeerOption);
-        EvilSeerFlashColorMode = Create(201907, false, CustomOptionType.Impostor, "EvilSeerFlashColorMode", new string[] { "SeerColorModeclear", "SeerColorModeLightAndDark" }, EvilSeerIsFlashBodyColor);
+        EvilSeerIsReportingBodyColorName = Create(201907, false, CustomOptionType.Impostor, "EvilSeerIsReportingBodyColorName", true, EvilSeerIsFlashBodyColor);
+        EvilSeerFlashColorMode = Create(201908, false, CustomOptionType.Impostor, "EvilSeerFlashColorMode", new string[] { "EvilSeerColorModeclear", "EvilSeerColorModeLightAndDark" }, EvilSeerIsFlashBodyColor);
         EvilSeerMadmateSetting = Create(201905, false, CustomOptionType.Impostor, "CreateMadmateSetting", false, EvilSeerOption);
 
         EvilButtonerOption = SetupCustomRoleOption(202000, true, RoleId.EvilButtoner);

--- a/SuperNewRoles/Modules/CustomOptionHolder.cs
+++ b/SuperNewRoles/Modules/CustomOptionHolder.cs
@@ -524,9 +524,8 @@ public class CustomOptionHolder
     public static CustomRoleOption EvilSeerOption;
     public static CustomOption EvilSeerPlayerCount;
     public static CustomOption EvilSeerMode;
-    public static CustomOption EvilSeerModeBoth;
-    public static CustomOption EvilSeerModeFlash;
-    public static CustomOption EvilSeerModeSouls;
+    public static CustomOption EvilSeerIsFlashBodyColor;
+    public static CustomOption EvilSeerFlashColorMode;
     public static CustomOption EvilSeerLimitSoulDuration;
     public static CustomOption EvilSeerSoulDuration;
     public static CustomOption EvilSeerMadmateSetting;
@@ -1154,6 +1153,8 @@ public class CustomOptionHolder
         EvilSeerMode = Create(201902, false, CustomOptionType.Impostor, "SeerMode", new string[] { "SeerModeBoth", "SeerModeFlash", "SeerModeSouls" }, EvilSeerOption);
         EvilSeerLimitSoulDuration = Create(201903, false, CustomOptionType.Impostor, "SeerLimitSoulDuration", false, EvilSeerOption);
         EvilSeerSoulDuration = Create(201904, false, CustomOptionType.Impostor, "SeerSoulDuration", 15f, 0f, 120f, 5f, EvilSeerLimitSoulDuration, format: "unitCouples");
+        EvilSeerIsFlashBodyColor = Create(201906, false, CustomOptionType.Impostor, "EvilSeerIsFlashColor", true, EvilSeerOption);
+        EvilSeerFlashColorMode = Create(201907, false, CustomOptionType.Impostor, "EvilSeerFlashColorMode", new string[] { "SeerColorModeclear", "SeerColorModeLightAndDark" }, EvilSeerIsFlashBodyColor);
         EvilSeerMadmateSetting = Create(201905, false, CustomOptionType.Impostor, "CreateMadmateSetting", false, EvilSeerOption);
 
         EvilButtonerOption = SetupCustomRoleOption(202000, true, RoleId.EvilButtoner);

--- a/SuperNewRoles/Modules/CustomOverlay.cs
+++ b/SuperNewRoles/Modules/CustomOverlay.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using AmongUs.Data;
 using HarmonyLib;
-using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using SuperNewRoles.Mode;
 using UnityEngine;
 namespace SuperNewRoles.Patches;
@@ -659,18 +658,13 @@ public class CustomOverlays
         // プレイヤー名とクルーカラーを■で表記
         data += $"<size=150%>{p.PlayerId + 1}. {p.name}{ModHelpers.Cs(Palette.PlayerColors[p.Data.DefaultOutfit.ColorId], "■")}</size>\n";
         // クルーカラーとカラー名を表記
-        data += $"<pos=10%>{ModHelpers.Cs(Palette.PlayerColors[p.Data.DefaultOutfit.ColorId], "■")} : {GetColorTranslation(Palette.ColorNames[p.Data.DefaultOutfit.ColorId])}\n";
+        data += $"<pos=10%>{ModHelpers.Cs(Palette.PlayerColors[p.Data.DefaultOutfit.ColorId], "■")} : {OutfitManager.GetColorTranslation(Palette.ColorNames[p.Data.DefaultOutfit.ColorId])}\n";
         data += $"<size=90%><pos=10%>{ModTranslation.GetString("SNRIntroduction")} : {(p.IsMod() ? "〇" : "×")}\n"; // Mod導入状態
         data += $"<pos=10%>FriendCode : {friendCode}\n"; // フレンドコード
         data += $"<pos=10%>Platform : {p.GetClient()?.PlatformData?.Platform}</size>\n"; // プラットフォーム
 
         return data;
     }
-
-    // クルーカラーの翻訳を取得する。
-    // 参考=>https://github.com/tugaru1975/TownOfPlus/blob/main/Helpers.cs
-    private static string GetColorTranslation(StringNames name) =>
-        DestroyableSingleton<TranslationController>.Instance.GetString(name, new Il2CppReferenceArray<Il2CppSystem.Object>(0));
 
     // 自分の役職の説明をoverlayに表示する (Hキーの動作)
     private static void MyRole(out string left, out string center, out string right)

--- a/SuperNewRoles/Modules/OutfitManager.cs
+++ b/SuperNewRoles/Modules/OutfitManager.cs
@@ -1,4 +1,5 @@
 namespace SuperNewRoles.Modules;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 
 public static class OutfitManager
 {
@@ -24,4 +25,9 @@ public static class OutfitManager
         changeToPlayer(pc, pc);
         pc.CurrentOutfitType = PlayerOutfitType.Default;
     }
-}
+
+
+    // クルーカラーの翻訳を取得する。
+    // 参考=>https://github.com/tugaru1975/TownOfPlus/blob/main/Helpers.cs
+    internal static string GetColorTranslation(StringNames name) =>
+        DestroyableSingleton<TranslationController>.Instance.GetString(name, new Il2CppReferenceArray<Il2CppSystem.Object>(0));}

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -876,11 +876,11 @@ MadSeerTitle1,Feel the success of your husband,ご主人の活躍を感じ取ろ
 EvilSeerName,EvilSeer,イビルシーア,邪恶的灵媒,邪惡的先知
 EvilSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n相方の行動を把握しサポートに回りましょう。,邪恶的灵媒属于内鬼阵营，可以获知死亡时间与死亡场所，来获取与死亡有关的情报。\n邪恶的灵媒需要利用手中的情报帮助同伙。,邪惡的先知屬於內鬼陣營，可以獲知死亡時間與死亡場所，來獲取與死亡有關的情報。\n邪惡的先知需要利用手中的情報幫助同伴。
 EvilSeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡,你能感知死亡
-EvilSeerIsFlashColor,,死の点滅の色をクルーのボディカラー依存にするか
-EvilSeerIsReportingBodyColorName,,ボディカラーの情報を文字でも表示するか
-EvilSeerFlashColorMode,,死者ボディカラーの表示方法
-EvilSeerColorModeclear,,色の詳細がわかる
-EvilSeerColorModeLightAndDark,,明暗のみがわかる
+EvilSeerIsFlashColor,Make the color of the death flash dependent on the crew's body color?,死の点滅の色をクルーのボディカラー依存にするか
+EvilSeerIsReportingBodyColorName,Do you want to display body color information in text as well?,ボディカラーの情報を文字でも表示するか
+EvilSeerFlashColorMode,How to display dead body color,死者ボディカラーの表示方法
+EvilSeerColorModeclear,You can see the color details.,色の詳細がわかる
+EvilSeerColorModeLightAndDark,Only light and dark are known.,明暗のみがわかる
 EvilSeerClearColorDeadText,The crew of {0} color has died.,{0}のクルーの気配が弱まりました。
 EvilSeerLightPlayerDeadText,A brightly colored crew died.,<color=#89c3eb>明るい色</color>のクルーの気配が弱まりました。
 EvilSeerDarkPlayerDeadText,A dark colored crew member died.,<color=#74325c>暗い色</color>のクルーの気配が弱まりました。

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -876,11 +876,11 @@ MadSeerTitle1,Feel the success of your husband,ご主人の活躍を感じ取ろ
 EvilSeerName,EvilSeer,イビルシーア,邪恶的灵媒,邪惡的先知
 EvilSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n相方の行動を把握しサポートに回りましょう。,邪恶的灵媒属于内鬼阵营，可以获知死亡时间与死亡场所，来获取与死亡有关的情报。\n邪恶的灵媒需要利用手中的情报帮助同伙。,邪惡的先知屬於內鬼陣營，可以獲知死亡時間與死亡場所，來獲取與死亡有關的情報。\n邪惡的先知需要利用手中的情報幫助同伴。
 EvilSeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡,你能感知死亡
-EvilSeerIsFlashColor,,死の点滅の色をクルーのボディカラー依存にするか。
-EvilSeerIsReportingBodyColorName,,ボディカラーの情報を文字でも表示するか。
+EvilSeerIsFlashColor,,死の点滅の色をクルーのボディカラー依存にするか
+EvilSeerIsReportingBodyColorName,,ボディカラーの情報を文字でも表示するか
 EvilSeerFlashColorMode,,死者ボディカラーの表示方法
-EvilSeerColorModeclear,,色の詳細がわかる。
-EvilSeerColorModeLightAndDark,,明暗のみがわかる。
+EvilSeerColorModeclear,,色の詳細がわかる
+EvilSeerColorModeLightAndDark,,明暗のみがわかる
 EvilSeerClearColorDeadText,The crew of {0} color has died.,{0}のクルーの気配が弱まりました。
 EvilSeerLightPlayerDeadText,A brightly colored crew died.,<color=#89c3eb>明るい色</color>のクルーの気配が弱まりました。
 EvilSeerDarkPlayerDeadText,A dark colored crew member died.,<color=#74325c>暗い色</color>のクルーの気配が弱まりました。

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -876,6 +876,14 @@ MadSeerTitle1,Feel the success of your husband,ご主人の活躍を感じ取ろ
 EvilSeerName,EvilSeer,イビルシーア,邪恶的灵媒,邪惡的先知
 EvilSeerDescription,,死亡時刻や死亡場所を把握する事が可能な、死者に関わる情報を司る役職です。\n相方の行動を把握しサポートに回りましょう。,邪恶的灵媒属于内鬼阵营，可以获知死亡时间与死亡场所，来获取与死亡有关的情报。\n邪恶的灵媒需要利用手中的情报帮助同伙。,邪惡的先知屬於內鬼陣營，可以獲知死亡時間與死亡場所，來獲取與死亡有關的情報。\n邪惡的先知需要利用手中的情報幫助同伴。
 EvilSeerTitle1,You will see players die,船員の気配を感じ取ろう,你能感知死亡,你能感知死亡
+EvilSeerIsFlashColor,,死の点滅の色をクルーのボディカラー依存にするか。
+EvilSeerIsReportingBodyColorName,,ボディカラーの情報を文字でも表示するか。
+EvilSeerFlashColorMode,,死者ボディカラーの表示方法
+EvilSeerColorModeclear,,色の詳細がわかる。
+EvilSeerColorModeLightAndDark,,明暗のみがわかる。
+EvilSeerClearColorDeadText,The crew of {0} color has died.,{0}のクルーの気配が弱まりました。
+EvilSeerLightPlayerDeadText,A brightly colored crew died.,明るい色のクルーの気配が弱まりました。
+EvilSeerDarkPlayerDeadText,A dark colored crew member died.,暗い色のクルーの気配が弱まりました。
 RemoteSheriffName,Remote Sheriff,リモートシェリフ,超能警长,超能警長
 RemoteSheriffTitle1,Let's do a Remote Sheriff kill!,遠隔でシェリフキルをしよう,远距离进行执法,遠距離進行執法擊殺
 RemoteSheriffIsKillTeleportSetting,Kill Teleport,キルテレポート,击杀时传送到被击杀者所在位置,擊殺時傳送到被擊殺者所在位置

--- a/SuperNewRoles/Resources/Translate.csv
+++ b/SuperNewRoles/Resources/Translate.csv
@@ -882,8 +882,8 @@ EvilSeerFlashColorMode,,死者ボディカラーの表示方法
 EvilSeerColorModeclear,,色の詳細がわかる。
 EvilSeerColorModeLightAndDark,,明暗のみがわかる。
 EvilSeerClearColorDeadText,The crew of {0} color has died.,{0}のクルーの気配が弱まりました。
-EvilSeerLightPlayerDeadText,A brightly colored crew died.,明るい色のクルーの気配が弱まりました。
-EvilSeerDarkPlayerDeadText,A dark colored crew member died.,暗い色のクルーの気配が弱まりました。
+EvilSeerLightPlayerDeadText,A brightly colored crew died.,<color=#89c3eb>明るい色</color>のクルーの気配が弱まりました。
+EvilSeerDarkPlayerDeadText,A dark colored crew member died.,<color=#74325c>暗い色</color>のクルーの気配が弱まりました。
 RemoteSheriffName,Remote Sheriff,リモートシェリフ,超能警长,超能警長
 RemoteSheriffTitle1,Let's do a Remote Sheriff kill!,遠隔でシェリフキルをしよう,远距离进行执法,遠距離進行執法擊殺
 RemoteSheriffIsKillTeleportSetting,Kill Teleport,キルテレポート,击杀时传送到被击杀者所在位置,擊殺時傳送到被擊殺者所在位置

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -177,7 +177,7 @@ class Seer
 
                                     flashColor = isLight
                                         ? new(137f / 255f, 195f / 255f, 235f / 255f)    // 明
-                                        : new(86f / 255f, 84f / 255f, 162f / 255f);     // 暗
+                                        : new(116f / 255f, 50f / 255f, 92f / 255f);     // 暗
 
                                     showtext = isLight
                                         ? ModTranslation.GetString("EvilSeerLightPlayerDeadText")

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -148,6 +148,7 @@ class Seer
                 if (role is RoleId.Seer or RoleId.MadSeer or RoleId.EvilSeer or RoleId.SeerFriends or RoleId.JackalSeer or RoleId.SidekickSeer)
                 {
                     bool ModeFlag = false;
+                    Color flashColor = new(42f / 255f, 187f / 255f, 245f / 255f); // 基本の発光カラー
                     switch (role)
                     {
                         case RoleId.Seer:
@@ -161,6 +162,20 @@ class Seer
                         case RoleId.EvilSeer:
                             if (RoleClass.EvilSeer.deadBodyPositions != null) RoleClass.EvilSeer.deadBodyPositions.Add(target.transform.position);
                             ModeFlag = RoleClass.EvilSeer.mode <= 1;
+                            if (RoleClass.EvilSeer.IsFlashBodyColor)
+                            {
+                                if (RoleClass.EvilSeer.FlashColorMode == 0) // 彩光が最高
+                                {
+                                    flashColor = Palette.PlayerColors[target.Data.DefaultOutfit.ColorId];
+                                }
+                                else if (RoleClass.EvilSeer.FlashColorMode == 1) // 明暗
+                                {
+                                    flashColor =
+                                        CustomCosmetics.CustomColors.lighterColors.Contains(target.Data.DefaultOutfit.ColorId)
+                                            ? new(137f / 255f, 195f / 255f, 235f / 255f)    // 明
+                                            : new(86f / 255f, 84f / 255f, 162f / 255f);     // 暗
+                                }
+                            }
                             break;
                         case RoleId.SeerFriends:
                             if (RoleClass.SeerFriends.deadBodyPositions != null) RoleClass.SeerFriends.deadBodyPositions.Add(target.transform.position);
@@ -173,9 +188,7 @@ class Seer
                             break;
                     }
                     if (PlayerControl.LocalPlayer.IsAlive() && CachedPlayer.LocalPlayer.PlayerId != target.PlayerId && ModeFlag)
-                    {
-                        ShowFlash(new Color(42f / 255f, 187f / 255f, 245f / 255f));
-                    }
+                        ShowFlash(flashColor);
                 }
             }
             public static void ShowFlash_SHR(PlayerControl target)

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -168,7 +168,7 @@ class Seer
                                 if (RoleClass.EvilSeer.FlashColorMode == 0) // 彩光が最高
                                 {
                                     flashColor = Palette.PlayerColors[target.Data.DefaultOutfit.ColorId];
-                                    var crewColorText = $"[ {OutfitManager.GetColorTranslation(Palette.ColorNames[target.Data.DefaultOutfit.ColorId])} : {ModHelpers.Cs(flashColor, "■")} ]";
+                                    var crewColorText = $"[ <color=#89c3eb>{OutfitManager.GetColorTranslation(Palette.ColorNames[target.Data.DefaultOutfit.ColorId])}</color> : {ModHelpers.Cs(flashColor, "■")} ]";
                                     showtext = string.Format(ModTranslation.GetString("EvilSeerClearColorDeadText"), crewColorText);
                                 }
                                 else if (RoleClass.EvilSeer.FlashColorMode == 1) // 明暗

--- a/SuperNewRoles/Roles/CrewMate/Seer.cs
+++ b/SuperNewRoles/Roles/CrewMate/Seer.cs
@@ -162,19 +162,29 @@ class Seer
                         case RoleId.EvilSeer:
                             if (RoleClass.EvilSeer.deadBodyPositions != null) RoleClass.EvilSeer.deadBodyPositions.Add(target.transform.position);
                             ModeFlag = RoleClass.EvilSeer.mode <= 1;
-                            if (RoleClass.EvilSeer.IsFlashBodyColor)
+                            if (RoleClass.EvilSeer.IsFlashBodyColor) // SHRModeの場合このif文は読まれない
                             {
+                                string showtext = "";
                                 if (RoleClass.EvilSeer.FlashColorMode == 0) // 彩光が最高
                                 {
                                     flashColor = Palette.PlayerColors[target.Data.DefaultOutfit.ColorId];
+                                    var crewColorText = $"[ {OutfitManager.GetColorTranslation(Palette.ColorNames[target.Data.DefaultOutfit.ColorId])} : {ModHelpers.Cs(flashColor, "■")} ]";
+                                    showtext = string.Format(ModTranslation.GetString("EvilSeerClearColorDeadText"), crewColorText);
                                 }
                                 else if (RoleClass.EvilSeer.FlashColorMode == 1) // 明暗
                                 {
-                                    flashColor =
-                                        CustomCosmetics.CustomColors.lighterColors.Contains(target.Data.DefaultOutfit.ColorId)
-                                            ? new(137f / 255f, 195f / 255f, 235f / 255f)    // 明
-                                            : new(86f / 255f, 84f / 255f, 162f / 255f);     // 暗
+                                    var isLight = CustomCosmetics.CustomColors.lighterColors.Contains(target.Data.DefaultOutfit.ColorId);
+
+                                    flashColor = isLight
+                                        ? new(137f / 255f, 195f / 255f, 235f / 255f)    // 明
+                                        : new(86f / 255f, 84f / 255f, 162f / 255f);     // 暗
+
+                                    showtext = isLight
+                                        ? ModTranslation.GetString("EvilSeerLightPlayerDeadText")
+                                        : ModTranslation.GetString("EvilSeerDarkPlayerDeadText");
                                 }
+                                if (CustomOptionHolder.EvilSeerIsReportingBodyColorName.GetBool() && ModeFlag)
+                                    new CustomMessage(showtext, 5, true, RoleClass.Seer.color, new(42f / 255f, 187f / 255f, 245f / 255f));
                             }
                             break;
                         case RoleId.SeerFriends:
@@ -187,8 +197,7 @@ class Seer
                             ModeFlag = RoleClass.JackalSeer.mode <= 1;
                             break;
                     }
-                    if (PlayerControl.LocalPlayer.IsAlive() && CachedPlayer.LocalPlayer.PlayerId != target.PlayerId && ModeFlag)
-                        ShowFlash(flashColor);
+                    if (ModeFlag) ShowFlash(flashColor);
                 }
             }
             public static void ShowFlash_SHR(PlayerControl target)

--- a/SuperNewRoles/Roles/Role/RoleClass.cs
+++ b/SuperNewRoles/Roles/Role/RoleClass.cs
@@ -1670,6 +1670,8 @@ public static class RoleClass
         public static float soulDuration;
         public static bool limitSoulDuration;
         public static int mode;
+        public static bool IsFlashBodyColor;
+        public static int FlashColorMode;
         public static bool IsCreateMadmate;
         public static void ClearAndReload()
         {
@@ -1678,6 +1680,8 @@ public static class RoleClass
             limitSoulDuration = CustomOptionHolder.EvilSeerLimitSoulDuration.GetBool();
             soulDuration = CustomOptionHolder.EvilSeerSoulDuration.GetFloat();
             mode = Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) ? 1 : CustomOptionHolder.EvilSeerMode.GetSelection();
+            IsFlashBodyColor = !Mode.ModeHandler.IsMode(Mode.ModeId.SuperHostRoles) && CustomOptionHolder.EvilSeerIsFlashBodyColor.GetBool();
+            FlashColorMode = CustomOptionHolder.EvilSeerFlashColorMode.GetSelection();
             IsCreateMadmate = CustomOptionHolder.EvilSeerMadmateSetting.GetBool();
         }
     }


### PR DESCRIPTION
# [概要]
- EvilSeerの[死の点滅]に死者の色情報が分かる機能を追加した。
- カスタムメッセージ(部屋名表示を利用した通知機能)の文字色を変更できるようにした。

# [詳細]
## EvilSeerの[死の点滅]に死者の色情報が分かる機能を追加
### 動作例
- 色の詳細がわかる
![色の詳細がわかる](https://github.com/ykundesu/SuperNewRoles/assets/104145991/e55b2798-61da-42a8-b14f-aac5c11e4e50)

- 明暗のみがわかる
![明暗のみがわかる](https://github.com/ykundesu/SuperNewRoles/assets/104145991/ae20263a-d698-4072-9154-e0aaa838fb78)

### 追加設定説明
| 名前 | 詳細 | SHR対応 |
| :-- | :-- | :--: |
| 死の点滅の色をクルーのボディカラー依存にするか | 点滅の色をクルーのボディカラー依存にする事により, 死者の情報を確認できるようにするか。 | × |
| ボディカラーの情報を文字でも表示するか | 死の点滅が発動した時に, クルーのカラー情報を文字でも通知するか | × |
| 死者ボディカラーの表示方法 | 色の詳細がわかる =><br>文字表記が死者のカラー名, 点滅の色が死者のカラーになる。<br><br>明暗のみがわかる =><br>文字表記が死者が明るい色か暗い色かの表記のみ,<br>点滅の色は死者が明るい色なら[勿忘草色](https://www.colordic.org/colorsample/2085), 暗い色なら[暗紅色](https://www.colordic.org/colorsample/2036)になる。 | × |

# カスタムメッセージの文字色を変更可能に
- 引数でtrueを渡した時
  - firstColorに値を渡さなかった場合, 最初の文字色は黄色になる。
  - secondColorに値を渡さなかった場合, 2番目の文字色はfirstColorになる。
    - secondColorに値を渡さなかった場合, 文字の点滅を行わない。
    - secondColorのみに値を渡した場合, 文字は黄色と渡した色で点滅する。
  - 両方に値を渡した場合, 渡した色で点滅を行う。
  - [動作例](#動作例)
- 引数でfalseを渡した時, 又は引数を渡さなかった時
  - Defaultの赤と黄色の点滅での通知を行う。