### PR TITLE
同じBepInIncompatibilityが２つある問題を修正

### DIFF
--- a/SuperNewRoles/Modules/CustomRPC.cs
+++ b/SuperNewRoles/Modules/CustomRPC.cs
@@ -285,14 +285,14 @@ public static class CustomRPCManager
                             Logger.Warning($"Unknown RPC method ID: {id}");
                             return;
                         }
-                        
+
                         // プレイヤー接続状態をチェック
                         if (PlayerControl.LocalPlayer == null || PlayerControl.AllPlayerControls == null)
                         {
                             Logger.Warning("Player control not initialized, skipping RPC");
                             return;
                         }
-                        
+
                         // インスタンスメソッドならインスタンスを読み込む
                         object? instance = null;
                         if (InstanceMethodSet.Contains(method))
@@ -304,7 +304,7 @@ public static class CustomRPCManager
                                 return;
                             }
                         }
-                        
+
                         // パラメータを読み込み
                         var paramTypesRecv = ParamTypesByMethod[method];
                         var argsRecv = new object[paramTypesRecv.Length];
@@ -320,7 +320,7 @@ public static class CustomRPCManager
                                 return;
                             }
                         }
-                        
+
                         IsRpcReceived = true;
                         Logger.Info($"Invoking RPC: {method.Name}");
                         method.Invoke(instance, argsRecv);

--- a/SuperNewRoles/Patches/CoStartGame.cs
+++ b/SuperNewRoles/Patches/CoStartGame.cs
@@ -17,7 +17,7 @@ class AmongUsClientStartPatch
         try
         {
             Logger.Info("CoStartGame");
-
+            
             // プレイヤー接続状態を確認
             if (PlayerControl.LocalPlayer == null || PlayerControl.AllPlayerControls == null)
             {


### PR DESCRIPTION
### 概要

`SuperNewRolesPlugin` クラスにて、同じプラグインID (`com.emptybottle.townofhost`) の `[BepInIncompatibility]` 属性が2回指定されていたため、1つに整理しました。

### 動作確認

- 意図したとおり、非互換プラグインとの同時ロードが正しく防止されていることを確認済みです。
- 他の機能やプラグインには影響がないことを確認しました。