### PR TITLE
マッドキラーのバグの修正（推定）

### DIFF
--- a/SuperNewRoles/Roles/Madmates/MadKiller.cs
+++ b/SuperNewRoles/Roles/Madmates/MadKiller.cs
@@ -31,7 +31,7 @@ class MadKiller : RoleBase<MadKiller>
     public override AssignedTeamType AssignedTeam => AssignedTeamType.Impostor;
     public override WinnerTeamType WinnerTeam => WinnerTeamType.Impostor;
     public override TeamTag TeamTag => TeamTag.Madmate;
-    public override RoleTag[] RoleTags => new[] { RoleTag.SpecialKiller };
+    public override RoleTag[] RoleTags => [];
     public override RoleOptionMenuType OptionTeam => RoleOptionMenuType.Hidden;
     public override RoleId[] RelatedRoleIds => new[] { RoleId.SideKiller };
 }


### PR DESCRIPTION
マッドキラーで、正常に試合が終了しない原因とみられるものを修正いたしました。一応バグの概要をまとめておきます。
・昇格前のマッドキラーが第三キラーの判定となっている
※・昇格前のマッドキラーを忘却者が引き継いだ時のみ、たぶんインポスターとして人数に数えられている
・試合を終わらすためにはマッドキラーを吊るすなどして退場させなければいけない

※が起こる原因となるものはわかりませんでしたが、第三キラー判定となっているであろうRoleTagを修正いたしました。
（テストをしてくれる友達がいなかったため、正しく動作するかはテストしておりません。ご承知ください。）
