### PR TITLE
Fix mad killerbug

### DIFF
--- a/SuperNewRoles/Modules/ExPlayerControl.cs
+++ b/SuperNewRoles/Modules/ExPlayerControl.cs
@@ -227,7 +227,7 @@ public class ExPlayerControl
         if (ModifierRoleHistory.Count == 0 && oldModifier != ModifierRoleId.None)
             ModifierRoleHistory.Add(oldModifier);
         ModifierRoleHistory.Add(ModifierRole);
-        Logger.Info($"[Modifier] {PlayerId}:{Player?.name ?? "??"}{Role}) += {modifierRoleId}", "SNR.GameState");
+        Logger.Info($"[Modifier] {PlayerId}:{Player?.name ?? "??"}({Role}) += {modifierRoleId}", "SNR.GameState");
         if (CustomRoleManager.TryGetModifierById(modifierRoleId, out var modifier))
         {
             modifier.OnSetRole(Player);
@@ -251,7 +251,7 @@ public class ExPlayerControl
             SuperTrophyManager.DetachTrophy(GhostRole);
         var oldGhostRole = GhostRole;
         GhostRole = ghostRoleId;
-        Logger.Info($"[GhostRole] {PlayerId}:{Player?.name ?? "??"}{Role}): {oldGhostRole} -> {ghostRoleId}", "SNR.GameState");
+        Logger.Info($"[GhostRole] {PlayerId}:{Player?.name ?? "??"}({Role}): {oldGhostRole} -> {ghostRoleId}", "SNR.GameState");
         if (CustomRoleManager.TryGetGhostRoleById(ghostRoleId, out var role))
         {
             role.OnSetRole(Player);
@@ -616,7 +616,7 @@ public class ExPlayerControl
     }
     public bool IsKiller()
     {
-        // 🟢 修正③：昇進前のマッドキラーは IsKiller から除外
+        //昇進前のマッドキラーは IsKiller から除外
         if (IsImpostor() || IsPavlovsDog() || (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == true) || IsJackal() || Role == RoleId.Hitman)
             return true;
 
@@ -646,7 +646,7 @@ public class ExPlayerControl
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public bool IsImpostor()
     {
-        // 🟢 修正①：昇進前のマッドキラーは false を返す
+        //昇進前のマッドキラーはfalse
         if (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == false)
             return false;
 
@@ -655,13 +655,7 @@ public class ExPlayerControl
     public bool IsNeutral()
         => roleBase != null ? roleBase.AssignedTeam == AssignedTeamType.Neutral : false;
     public bool IsImpostorWinTeam()
-    {
-        // 🟢 修正②：昇進前のマッドキラーは false を返す
-        if (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == false)
-            return false;
-
-        return IsImpostor() || IsMadRoles() || Role == RoleId.MadKiller;
-    }
+        => IsImpostor() || IsMadRoles() || Role == RoleId.MadKiller;
     public bool IsPavlovsTeam()
         => Role is RoleId.PavlovsDog or RoleId.PavlovsOwner || GetAbility<SchrodingersCatAbility>()?.CurrentTeam is SchrodingersCatTeam.Pavlovs or SchrodingersCatTeam.PavlovFriends;
     public bool IsPavlovsDog()
@@ -1057,7 +1051,7 @@ public static class ExPlayerControlExtensions
 
     /// <summary>
     /// 親コンテキストを文字列シグネチャ化します。
-    /// Role/Modifier/Ghost はそれぞれ "R:""M:""G:" にIDを付与。
+    /// Role/Modifier/Ghost はそれぞれ "R:"/"M:"/"G:" にIDを付与。
     /// Ability 親は "A:" + 親アビリティID、プレイヤー直下は "P"、不明は "U"。
     /// </summary>
     /// <param name="parent">親コンテキスト</param>

--- a/SuperNewRoles/Modules/ExPlayerControl.cs
+++ b/SuperNewRoles/Modules/ExPlayerControl.cs
@@ -227,7 +227,7 @@ public class ExPlayerControl
         if (ModifierRoleHistory.Count == 0 && oldModifier != ModifierRoleId.None)
             ModifierRoleHistory.Add(oldModifier);
         ModifierRoleHistory.Add(ModifierRole);
-        Logger.Info($"[Modifier] {PlayerId}:{Player?.name ?? "??"}({Role}) += {modifierRoleId}", "SNR.GameState");
+        Logger.Info($"[Modifier] {PlayerId}:{Player?.name ?? "??"}{Role}) += {modifierRoleId}", "SNR.GameState");
         if (CustomRoleManager.TryGetModifierById(modifierRoleId, out var modifier))
         {
             modifier.OnSetRole(Player);
@@ -251,7 +251,7 @@ public class ExPlayerControl
             SuperTrophyManager.DetachTrophy(GhostRole);
         var oldGhostRole = GhostRole;
         GhostRole = ghostRoleId;
-        Logger.Info($"[GhostRole] {PlayerId}:{Player?.name ?? "??"}({Role}): {oldGhostRole} -> {ghostRoleId}", "SNR.GameState");
+        Logger.Info($"[GhostRole] {PlayerId}:{Player?.name ?? "??"}{Role}): {oldGhostRole} -> {ghostRoleId}", "SNR.GameState");
         if (CustomRoleManager.TryGetGhostRoleById(ghostRoleId, out var role))
         {
             role.OnSetRole(Player);
@@ -616,7 +616,8 @@ public class ExPlayerControl
     }
     public bool IsKiller()
     {
-        if (IsImpostor() || IsPavlovsDog() || Role == RoleId.MadKiller || IsJackal() || Role == RoleId.Hitman)
+        // 🟢 修正③：昇進前のマッドキラーは IsKiller から除外
+        if (IsImpostor() || IsPavlovsDog() || (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == true) || IsJackal() || Role == RoleId.Hitman)
             return true;
 
         var customKillButtons = GetAbilities<CustomKillButtonAbility>();
@@ -644,11 +645,23 @@ public class ExPlayerControl
         => IsCrewmate() || IsMadRoles() || IsFriendRoles();
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     public bool IsImpostor()
-        => Data.Role.IsImpostor || GetAbility<SchrodingersCatAbility>()?.CurrentTeam == SchrodingersCatTeam.Impostor;
+    {
+        // 🟢 修正①：昇進前のマッドキラーは false を返す
+        if (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == false)
+            return false;
+
+        return Data.Role.IsImpostor || GetAbility<SchrodingersCatAbility>()?.CurrentTeam == SchrodingersCatTeam.Impostor;
+    }
     public bool IsNeutral()
         => roleBase != null ? roleBase.AssignedTeam == AssignedTeamType.Neutral : false;
     public bool IsImpostorWinTeam()
-        => IsImpostor() || IsMadRoles() || Role == RoleId.MadKiller;
+    {
+        // 🟢 修正②：昇進前のマッドキラーは false を返す
+        if (Role == RoleId.MadKiller && GetAbility<MadKillerAbility>()?.IsAwakened == false)
+            return false;
+
+        return IsImpostor() || IsMadRoles() || Role == RoleId.MadKiller;
+    }
     public bool IsPavlovsTeam()
         => Role is RoleId.PavlovsDog or RoleId.PavlovsOwner || GetAbility<SchrodingersCatAbility>()?.CurrentTeam is SchrodingersCatTeam.Pavlovs or SchrodingersCatTeam.PavlovFriends;
     public bool IsPavlovsDog()
@@ -1044,7 +1057,7 @@ public static class ExPlayerControlExtensions
 
     /// <summary>
     /// 親コンテキストを文字列シグネチャ化します。
-    /// Role/Modifier/Ghost はそれぞれ "R:"/"M:"/"G:" にIDを付与。
+    /// Role/Modifier/Ghost はそれぞれ "R:""M:""G:" にIDを付与。
     /// Ability 親は "A:" + 親アビリティID、プレイヤー直下は "P"、不明は "U"。
     /// </summary>
     /// <param name="parent">親コンテキスト</param>

--- a/SuperNewRoles/Roles/Ability/MadKillerAbility.cs
+++ b/SuperNewRoles/Roles/Ability/MadKillerAbility.cs
@@ -83,9 +83,21 @@ public class MadKillerAbility : AbilityBase
     private void OnFixedUpdate()
     {
         if (_isAwakened || Player.IsDead()) return;
-        if (ownerAbility?.Player == null || ownerAbility.Player.IsDead())
+
+        //忘却者引き継ぎ時、親のデータが存在するかどうか
+        //存在する
+        if (ownerAbility?.Player != null)
         {
-            Awaken();
+            // 特定の親単体が死んでいる場合のみ覚醒する
+            if (ownerAbility.Player.IsDead())
+            {
+                Awaken();
+            }
+        }
+        //存在しない
+        else
+        {
+            return;
         }
     }
 


### PR DESCRIPTION
マッドキラーの昇格前に勝利できないバグと忘却者引き継ぎ後正しく動くように修正しました。テストプレイはあまりできていないのでバグがあるかもしれないです...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * マッドキラーの覚醒状態による役割判定の精度を改善しました。覚醒前後で正確にkillerおよびimpostorとして判定されるようになります。
  * マッドキラーの覚醒判定ロジックを最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperNewRoles/SuperNewRoles/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->