### PR TITLE
【バグ修正】カスタムコスメ読み込み後に画面が暗転する問題を修正

### DIFF
--- a/SuperNewRoles.Tests/CustomCosmeticsJsonNodeTests.cs
+++ b/SuperNewRoles.Tests/CustomCosmeticsJsonNodeTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using SuperNewRoles.CustomCosmetics;
+using SuperNewRoles.Modules;
+using Xunit;
+
+namespace SuperNewRoles.Tests;
+
+public class CustomCosmeticsJsonNodeTests
+{
+    [Fact]
+    public void Parse_ReadsMetadataWithoutNewtonsoftJson()
+    {
+        CustomCosmeticsJsonNode root = CustomCosmeticsJsonNode.Parse(
+            """
+            {
+              "package": { "name": "テスト", "parseversion": 2 },
+              "hats": [
+                { "name": "帽子A", "adaptive": true, "bounce": false },
+                // 外部コスメ定義との互換性のため、コメントと末尾カンマを許容する。
+                { "name": "帽子B", "adaptive": false },
+              ],
+            }
+            """);
+
+        root["package"]["name"].ToString().Should().Be("テスト");
+        ((int)root["package"]["parseversion"]).Should().Be(2);
+
+        CustomCosmeticsJsonNode firstHat = root["hats"].First;
+        firstHat["name"].ToString().Should().Be("帽子A");
+        ((bool)firstHat["adaptive"]).Should().BeTrue();
+        firstHat.Next["name"].ToString().Should().Be("帽子B");
+        firstHat.Next.Next.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_RejectsMalformedJson()
+    {
+        Action parse = () => CustomCosmeticsJsonNode.Parse("{ invalid json }");
+
+        parse.Should().Throw<JsonParseException>();
+    }
+
+    [Fact]
+    public void HatOptions_UseManagedJsonValues()
+    {
+        CustomCosmeticsJsonNode optionsJson = CustomCosmeticsJsonNode.Parse(
+            """{ "adaptive": true, "bounce": true, "behind": true, "hideBody": true }""");
+
+        var options = new CustomCosmeticsHatOptions(optionsJson);
+
+        options.front.Should().HaveFlag(HatOptionType.Adaptive);
+        options.front.Should().HaveFlag(HatOptionType.Bounce);
+        options.front.Should().HaveFlag(HatOptionType.Behind);
+        options.HideBody.Should().BeTrue();
+    }
+}

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsJsonNode.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsJsonNode.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using SuperNewRoles.Modules;
+
+namespace SuperNewRoles.CustomCosmetics;
+
+/// <summary>
+/// カスタムコスメティックのメタデータを既存の低依存 JsonParser で読み取るための JSON ノード。
+/// </summary>
+public sealed class CustomCosmeticsJsonNode
+{
+    private readonly object value;
+    private readonly List<object> parentArray;
+    private readonly int arrayIndex;
+
+    private CustomCosmeticsJsonNode(object value)
+    {
+        this.value = value;
+    }
+
+    private CustomCosmeticsJsonNode(object value, List<object> parentArray, int arrayIndex)
+    {
+        this.value = value;
+        this.parentArray = parentArray;
+        this.arrayIndex = arrayIndex;
+    }
+
+    public static CustomCosmeticsJsonNode Parse(string json)
+        => new(JsonParser.Parse(json, allowComments: true, allowTrailingCommas: true));
+
+    public CustomCosmeticsJsonNode this[string propertyName]
+    {
+        get
+        {
+            if (value is not Dictionary<string, object> properties
+                || !properties.TryGetValue(propertyName, out object property))
+                return null;
+
+            return property == null ? null : new CustomCosmeticsJsonNode(property);
+        }
+    }
+
+    public CustomCosmeticsJsonNode First
+    {
+        get
+        {
+            if (value is not List<object> array || array.Count == 0)
+                return null;
+
+            return new CustomCosmeticsJsonNode(array[0], array, 0);
+        }
+    }
+
+    public CustomCosmeticsJsonNode Next
+    {
+        get
+        {
+            int nextIndex = arrayIndex + 1;
+            if (parentArray == null || nextIndex >= parentArray.Count)
+                return null;
+
+            return new CustomCosmeticsJsonNode(parentArray[nextIndex], parentArray, nextIndex);
+        }
+    }
+
+    public bool TryGetBoolean(out bool value)
+    {
+        if (this.value is bool boolean)
+        {
+            value = boolean;
+            return true;
+        }
+
+        value = false;
+        return false;
+    }
+
+    public override string ToString()
+        => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+    public static explicit operator bool(CustomCosmeticsJsonNode node)
+    {
+        if (node != null && node.TryGetBoolean(out bool value))
+            return value;
+
+        throw new InvalidCastException("JSON value is not a boolean.");
+    }
+
+    public static explicit operator int(CustomCosmeticsJsonNode node)
+    {
+        if (node == null)
+            throw new InvalidCastException("JSON value is null.");
+        if (node.value is long longValue && longValue is >= int.MinValue and <= int.MaxValue)
+            return (int)longValue;
+        if (node.value is int intValue)
+            return intValue;
+        if (node.value is string stringValue
+            && int.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsedValue))
+            return parsedValue;
+
+        throw new InvalidCastException("JSON value is not a 32-bit integer.");
+    }
+}

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsLoader.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsLoader.cs
@@ -2,14 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using UnityEngine;
 using System.IO;
 using System.Net;
 using System.Security.Cryptography;
 using System.Linq;
 using HarmonyLib;
-using Newtonsoft.Json.Linq;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using SuperNewRoles.CustomCosmetics.CosmeticsPlayer;
 using SuperNewRoles.Modules;
@@ -342,8 +340,8 @@ public class CustomCosmeticsLoader
             {
                 string jsonContent = ft.content;
                 // JSONをパース
-                JObject json = JObject.Parse(jsonContent);
-                JToken assetBundlesToken = json["assetbundles"];
+                CustomCosmeticsJsonNode json = CustomCosmeticsJsonNode.Parse(jsonContent);
+                CustomCosmeticsJsonNode assetBundlesToken = json["assetbundles"];
                 if (assetBundlesToken != null)
                 {
 
@@ -377,7 +375,7 @@ public class CustomCosmeticsLoader
                 else
                     Logger.Error($"assetbundlesが見つかりません: {url}");
 
-                JToken hatsToken = json["hats"];
+                CustomCosmeticsJsonNode hatsToken = json["hats"];
                 if (hatsToken != null)
                 {
                     for (var hat = hatsToken.First; hat != null; hat = hat.Next)
@@ -467,7 +465,7 @@ public class CustomCosmeticsLoader
                     Logger.Error($"hatsが見つかりません: {url}");
 
                 // visorsとVisorsの両方のパターンがあるので
-                JToken visorsToken = json["visors"] ?? json["Visors"];
+                CustomCosmeticsJsonNode visorsToken = json["visors"] ?? json["Visors"];
                 if (visorsToken != null)
                 {
                     for (var visor = visorsToken.First; visor != null; visor = visor.Next)
@@ -523,7 +521,7 @@ public class CustomCosmeticsLoader
                     Logger.Error($"visorsが見つかりません: {url}");
 
                 // nameplatesとNamePlatesの両方のパターンがあるので
-                JToken namePlatesToken = json["nameplates"];
+                CustomCosmeticsJsonNode namePlatesToken = json["nameplates"];
                 if (namePlatesToken != null)
                 {
                     for (var namePlate = namePlatesToken.First; namePlate != null; namePlate = namePlate.Next)
@@ -730,8 +728,8 @@ public class CustomCosmeticsLoader
                 Logger.Error($"パッケージ: {package} の package.json が読み込めません(Hats)");
             }
             string packageJson = packageTextAsset.text;
-            JObject packageJsonObject = JObject.Parse(packageJson);
-            JToken packageInfo = packageJsonObject["package"];
+            CustomCosmeticsJsonNode packageJsonObject = CustomCosmeticsJsonNode.Parse(packageJson);
+            CustomCosmeticsJsonNode packageInfo = packageJsonObject["package"];
             if (packageInfo == null)
             {
                 Logger.Error($"パッケージ: {package} に package が見つかりません");
@@ -745,7 +743,7 @@ public class CustomCosmeticsLoader
             );
             loadedPackages.Add(cosmeticsPackage);
 
-            JToken hatsToken = packageJsonObject["hats"];
+            CustomCosmeticsJsonNode hatsToken = packageJsonObject["hats"];
             if (hatsToken != null)
             {
                 for (var hat = hatsToken.First; hat != null; hat = hat.Next)
@@ -779,8 +777,8 @@ public class CustomCosmeticsLoader
                 continue;
             }
             // バイザーの読み込み
-            JObject packageJsonObject = JObject.Parse(visorsTextAsset.text);
-            JToken packageInfo = packageJsonObject["package"];
+            CustomCosmeticsJsonNode packageJsonObject = CustomCosmeticsJsonNode.Parse(visorsTextAsset.text);
+            CustomCosmeticsJsonNode packageInfo = packageJsonObject["package"];
             if (packageInfo == null)
             {
                 Logger.Error($"パッケージ: {package} に package が見つかりません");
@@ -798,7 +796,7 @@ public class CustomCosmeticsLoader
                 loadedPackages.Add(cosmeticsPackage);
             }
 
-            JToken visorsToken = packageJsonObject["visors"];
+            CustomCosmeticsJsonNode visorsToken = packageJsonObject["visors"];
             if (visorsToken != null)
             {
                 for (var visor = visorsToken.First; visor != null; visor = visor.Next)
@@ -833,8 +831,8 @@ public class CustomCosmeticsLoader
                 Logger.Error($"パッケージ: {package} の package.json が読み込めません(NamePlates)");
                 continue;
             }
-            JObject packageJsonObject = JObject.Parse(namePlatesTextAsset.text);
-            JToken packageInfo = packageJsonObject["package"];
+            CustomCosmeticsJsonNode packageJsonObject = CustomCosmeticsJsonNode.Parse(namePlatesTextAsset.text);
+            CustomCosmeticsJsonNode packageInfo = packageJsonObject["package"];
             if (packageInfo == null)
             {
                 Logger.Error($"パッケージ: {package} に package が見つかりません");
@@ -852,7 +850,7 @@ public class CustomCosmeticsLoader
                 loadedPackages.Add(cosmeticsPackage);
             }
 
-            JToken namePlatesToken = packageJsonObject["nameplates"];
+            CustomCosmeticsJsonNode namePlatesToken = packageJsonObject["nameplates"];
             if (namePlatesToken != null)
             {
                 for (var namePlate = namePlatesToken.First; namePlate != null; namePlate = namePlate.Next)

--- a/SuperNewRoles/CustomCosmetics/CustomCosmeticsObject.cs
+++ b/SuperNewRoles/CustomCosmetics/CustomCosmeticsObject.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using SuperNewRoles.Modules;
 using UnityEngine;
 
@@ -417,7 +416,7 @@ public class CustomCosmeticsVisorOptions
     public bool flip { get; }
     public bool climb { get; set; }
     public bool isSNR { get; }
-    public CustomCosmeticsVisorOptions(JToken optionsJson)
+    public CustomCosmeticsVisorOptions(CustomCosmeticsJsonNode optionsJson)
     {
         adaptive = CustomCosmeticsHatOptions.GetBool(optionsJson["adaptive"]);
         flip = CustomCosmeticsHatOptions.GetBool(optionsJson["flip"]);
@@ -442,7 +441,7 @@ public class CustomCosmeticsHatOptions
     public bool blockVisors { get; }
     public bool HideBody { get; }
     /*
-        public CustomCosmeticsHatOptions(JToken optionsJson)
+        public CustomCosmeticsHatOptions(CustomCosmeticsJsonNode optionsJson)
         {
             front = GetOption(optionsJson, "front", true);
             front_left = GetOption(optionsJson, "front_left");
@@ -453,7 +452,7 @@ public class CustomCosmeticsHatOptions
             climb = GetOption(optionsJson, "climb");
             blockVisors = GetBool(optionsJson["block_visors"]);
         }*/
-    public CustomCosmeticsHatOptions(JToken optionsJson)
+    public CustomCosmeticsHatOptions(CustomCosmeticsJsonNode optionsJson)
     {
         bool adaptive = GetBool(optionsJson["adaptive"]);
         bool bounce = GetBool(optionsJson["bounce"]);
@@ -483,7 +482,7 @@ public class CustomCosmeticsHatOptions
     /// 指定されたプレフィックスに対してオプション値を取得します。
     /// useBaseFlagがtrueの場合、adaptiveがfalseならベースフラグの値を反映し、falseの場合は常にNoAdaptiveとなります。
     /// </summary>
-    private HatOptionType GetOption(JToken json, string keyPrefix, bool defaultOption = false, bool adaptive = false, bool bounce = false, bool behind = false)
+    private HatOptionType GetOption(CustomCosmeticsJsonNode json, string keyPrefix, bool defaultOption = false, bool adaptive = false, bool bounce = false, bool behind = false)
     {
         // ヘルパーローカル関数：トークンからbool値を安全に取得する
 
@@ -505,8 +504,8 @@ public class CustomCosmeticsHatOptions
 
         return option;
     }
-    public static bool GetBool(JToken token, bool defaultValue = false)
-        => token != null && token.Type == JTokenType.Boolean ? (bool)token : defaultValue;
+    public static bool GetBool(CustomCosmeticsJsonNode token, bool defaultValue = false)
+        => token != null && token.TryGetBoolean(out bool value) ? value : defaultValue;
 }
 [Flags]
 public enum HatOptionType

--- a/SuperNewRoles/Modules/JsonParser.cs
+++ b/SuperNewRoles/Modules/JsonParser.cs
@@ -8,17 +8,24 @@ namespace SuperNewRoles.Modules;
 public class JsonParser
 {
     private readonly string _json;
+    private readonly bool _allowComments;
+    private readonly bool _allowTrailingCommas;
     private int _pos;
 
-    private JsonParser(string json)
+    private JsonParser(string json, bool allowComments, bool allowTrailingCommas)
     {
         _json = json;
+        _allowComments = allowComments;
+        _allowTrailingCommas = allowTrailingCommas;
         _pos = 0;
     }
 
     public static object Parse(string json)
+        => Parse(json, allowComments: false, allowTrailingCommas: false);
+
+    public static object Parse(string json, bool allowComments, bool allowTrailingCommas)
     {
-        var parser = new JsonParser(json);
+        var parser = new JsonParser(json, allowComments, allowTrailingCommas);
         var result = parser.ParseValue();
         parser.SkipWhitespace();
         if (parser._pos != parser._json.Length)
@@ -176,8 +183,36 @@ public class JsonParser
 
     private void SkipWhitespace()
     {
-        while (_pos < _json.Length && char.IsWhiteSpace(_json[_pos]))
-            _pos++;
+        while (_pos < _json.Length)
+        {
+            if (char.IsWhiteSpace(_json[_pos]))
+            {
+                _pos++;
+                continue;
+            }
+
+            if (!_allowComments || _json[_pos] != '/' || _pos + 1 >= _json.Length)
+                return;
+
+            if (_json[_pos + 1] == '/')
+            {
+                _pos += 2;
+                while (_pos < _json.Length && _json[_pos] != '\r' && _json[_pos] != '\n')
+                    _pos++;
+                continue;
+            }
+
+            if (_json[_pos + 1] != '*')
+                return;
+
+            int commentStart = _pos;
+            _pos += 2;
+            while (_pos + 1 < _json.Length && (_json[_pos] != '*' || _json[_pos + 1] != '/'))
+                _pos++;
+            if (_pos + 1 >= _json.Length)
+                throw new JsonParseException("Unterminated block comment", commentStart);
+            _pos += 2;
+        }
     }
 
     private object ParseValue()
@@ -233,7 +268,12 @@ public class JsonParser
                 // Check for trailing comma before '}'
                 SkipWhitespace();
                 if (_pos < _json.Length && _json[_pos] == '}')
-                    throw new JsonParseException("Trailing comma is not allowed in object", _pos);
+                {
+                    if (!_allowTrailingCommas)
+                        throw new JsonParseException("Trailing comma is not allowed in object", _pos);
+                    _pos++;
+                    break;
+                }
                 continue;
             }
             if (nextChar == '}')
@@ -271,7 +311,12 @@ public class JsonParser
                 // Check for trailing comma before ']'
                 SkipWhitespace();
                 if (_pos < _json.Length && _json[_pos] == ']')
-                    throw new JsonParseException("Trailing comma is not allowed in array", _pos);
+                {
+                    if (!_allowTrailingCommas)
+                        throw new JsonParseException("Trailing comma is not allowed in array", _pos);
+                    _pos++;
+                    break;
+                }
                 continue;
             }
             if (nextChar == ']')


### PR DESCRIPTION
# 概要
- 一部環境でカスタムコスメ読み込み後に画面が暗転し、音声だけ再生される問題を修正しました。
- カスタムコスメのJSON解析経路から、`Collection is read-only` を発生させていたIL2CPP版Newtonsoft.JsonのJObject/JToken利用を除外しました。
- 既存の低依存JsonParserを利用するコスメ用JSONノードを追加し、外部コスメ定義で使われるコメントと末尾カンマをコスメ解析時のみ許可しました。
- System.Text.Jsonへの依存は追加していません。

# 検証
- 全テスト239件成功
- Releaseビルド成功（0エラー）
- 隔離した実ゲーム環境でカスタムコスメ読み込み完了後、メインメニューへ到達することを確認
- `Collection is read-only`、JsonParseException、FileNotFoundExceptionがログに出力されないことを確認
- Debug／Release DLLのアセンブリ参照にSystem.Text.Jsonが含まれないことを確認

# 関連Issue
- https://github.com/SuperNewRoles/SuperNewRolesReports/issues/1783